### PR TITLE
fix(build): make static build work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openshift/origin-release:golang-1.10 as builder
 
 RUN yum update -y && \
-    yum install -y make git sqlite && \
+    yum install -y make git sqlite glibc-static openssl-static zlib-static && \
     yum groupinstall -y "Development Tools" "Development Libraries"
 
 ENV GOPATH /go
@@ -21,7 +21,7 @@ RUN mkdir -p /go/src/github.com/grpc-ecosystem && \
     cd /go/src/github.com/grpc-ecosystem/grpc_health_probe && \
     go get -u github.com/golang/dep/cmd/dep && \
     dep ensure -vendor-only -v && \
-    go install -a -tags netgo -ldflags "-linkmode external   -extldflags -static"
+    CGO_ENABLED=0 go install -a -tags netgo -ldflags "-w"
 
 FROM openshift/origin-base
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ $(CMDS):
 
 build: clean $(CMDS)
 
-static: extra_flags=-ldflags '-w -extldflags "-static"' 
+static: extra_flags=-ldflags '-w -extldflags "-Wl,-Bstatic -ldl -lc -lpthread -lcrypto -lz -static"'
 static: build
 
 unit:

--- a/configmap-registry.Dockerfile
+++ b/configmap-registry.Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /go/src/$PROJECT
 
 COPY --from=builder /go/src/github.com/operator-framework/operator-registry/vendor/$ORG/grpc-health-probe .
 RUN dep ensure -vendor-only -v && \
-    go install -a -tags netgo -ldflags "-linkmode external -extldflags -static"
+    CGO_ENABLED=0 go install -a -tags netgo -ldflags "-w"
 
 
 FROM scratch

--- a/upstream.Dockerfile
+++ b/upstream.Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /go/src/$PROJECT
 
 COPY --from=builder /build/vendor/$ORG/grpc-health-probe .
 RUN dep ensure -vendor-only -v && \
-    go install -a -tags netgo -ldflags "-linkmode external -extldflags -static"
+    CGO_ENABLED=0 go install -a -tags netgo -ldflags "-w"
 
 FROM scratch
 COPY --from=builder /build/bundles.db /bundles.db


### PR DESCRIPTION
For the static build target, force only archive versions of the required
dependent libraries to be used (and make sure to install those
packages).

Also, do not statically build grpc-health-probe. Use of the build tag
netgo implies the intention of avoiding the cgo resolver (but really
isn't required anymore). However, the go install command has been
changed to mirror upstream's latest changes.

ART-448