### PR TITLE
pkg/sqlite: Add error checking and improve looping through rows

### DIFF
--- a/pkg/sqlite/directory.go
+++ b/pkg/sqlite/directory.go
@@ -161,6 +161,9 @@ func (d *DirectoryLoader) LoadBundle(dir string) (*registry.Bundle, error) {
 }
 
 func (d *DirectoryLoader) LoadPackagesWalkFunc(path string, f os.FileInfo, err error) error {
+	if err != nil {
+		return err
+	}
 	log := logrus.WithFields(logrus.Fields{"dir": d.directory, "file": f.Name(), "load": "package"})
 	if f == nil {
 		return fmt.Errorf("Not a valid file")


### PR DESCRIPTION
Ran into this problem while testing adding an operator locally, the for loop never exited because it reached the end of rows but there was no break in place, so it just kept looping.