### PR TITLE
update upstream configmap-registry image to use the builder image

### DIFF
--- a/configmap-registry.Dockerfile
+++ b/configmap-registry.Dockerfile
@@ -1,28 +1,7 @@
-FROM golang:1.10-alpine as builder
-
-RUN apk update && apk add sqlite build-base git mercurial
-WORKDIR /go/src/github.com/operator-framework/operator-registry
-
-COPY vendor vendor
-COPY cmd cmd
-COPY pkg pkg
-COPY Makefile Makefile
-RUN make static
-
-FROM golang:1.10-alpine as probe-builder
-
-RUN apk update && apk add build-base git
-ENV ORG github.com/grpc-ecosystem
-ENV PROJECT $ORG/grpc_health_probe
-WORKDIR /go/src/$PROJECT
-
-COPY --from=builder /go/src/github.com/operator-framework/operator-registry/vendor/$ORG/grpc-health-probe .
-COPY --from=builder /go/src/github.com/operator-framework/operator-registry/vendor .
-RUN CGO_ENABLED=0 go install -a -tags netgo -ldflags "-w"
-
+FROM quay.io/operator-framework/upstream-registry-builder:v1.1.0 as builder
 
 FROM scratch
-COPY --from=builder /go/src/github.com/operator-framework/operator-registry/bin/configmap-server /bin/configmap-server
-COPY --from=probe-builder /go/bin/grpc_health_probe /bin/grpc_health_probe
+COPY --from=builder /build/bin/configmap-server /bin/configmap-server
+COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/bin/configmap-server"]


### PR DESCRIPTION
This is to fix these errors: https://quay.io/repository/operator-framework/configmap-operator-registry/build/3a166a3c-64ae-48b6-9efb-170de68984f2