### PR TITLE
Remove OperatorSource dependency

### DIFF
--- a/pkg/appregistry/opsrc_specifier.go
+++ b/pkg/appregistry/opsrc_specifier.go
@@ -1,0 +1,106 @@
+package appregistry
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	marketplace "github.com/operator-framework/operator-marketplace/pkg/client/clientset/versioned"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// TODO: this entire file can be removed once marketplace operator transitions
+// to using the new flag 'registry'.
+
+func NewOperatorSourceCRSpecifier(kubeconfig string, logger *logrus.Entry) (OperatorSourceSpecifier, error) {
+	marketplaceClient, err := NewMarketplaceClient(kubeconfig, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	return &operatorSourceCRSpecifier{
+		marketplace: marketplaceClient,
+	}, nil
+}
+
+type operatorSourceCRSpecifier struct {
+	marketplace marketplace.Interface
+}
+
+func (p *operatorSourceCRSpecifier) Parse(specifiers []string) ([]*Source, error) {
+	sources := make([]*Source, 0)
+	allErrors := []error{}
+
+	for _, specifier := range specifiers {
+		source, err := p.ParseOne(specifier)
+		if err != nil {
+			allErrors = append(allErrors, err)
+			continue
+		}
+
+		sources = append(sources, source)
+	}
+
+	err := utilerrors.NewAggregate(allErrors)
+	return sources, err
+}
+
+func (p *operatorSourceCRSpecifier) ParseOne(specifier string) (*Source, error) {
+	key, err := split(specifier)
+	if err != nil {
+		return nil, err
+	}
+
+	opsrc, err := p.marketplace.MarketplaceV1alpha1().OperatorSources(key.Namespace).Get(key.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	source := &Source{
+		Endpoint:          opsrc.Spec.Endpoint,
+		RegistryNamespace: opsrc.Spec.RegistryNamespace,
+		Secret: types.NamespacedName{
+			Namespace: opsrc.GetNamespace(),
+			Name:      opsrc.Spec.AuthorizationToken.SecretName,
+		},
+	}
+
+	return source, nil
+}
+
+func split(sourceName string) (*types.NamespacedName, error) {
+	split := strings.Split(sourceName, "/")
+	if len(split) != 2 {
+		return nil, errors.New(fmt.Sprintf("OperatorSource name should be specified in this format {namespace}/{name}"))
+	}
+
+	return &types.NamespacedName{
+		Namespace: split[0],
+		Name:      split[1],
+	}, nil
+}
+
+func NewMarketplaceClient(kubeconfig string, logger *logrus.Entry) (clientset marketplace.Interface, err error) {
+	var config *rest.Config
+
+	if kubeconfig != "" {
+		logger.Infof("Loading kube client config from path %q", kubeconfig)
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	} else {
+		logger.Infof("Using in-cluster kube client config")
+		config, err = rest.InClusterConfig()
+	}
+
+	if err != nil {
+		err = fmt.Errorf("Cannot load config for REST client: %v", err)
+		return
+	}
+
+	clientset, err = marketplace.NewForConfig(config)
+	return
+}

--- a/pkg/appregistry/registry_specifier.go
+++ b/pkg/appregistry/registry_specifier.go
@@ -1,0 +1,77 @@
+package appregistry
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+type registrySpecifier struct {
+}
+
+func (p *registrySpecifier) Parse(specifiers []string) ([]*Source, error) {
+	sources := make([]*Source, 0)
+	allErrors := []error{}
+
+	for _, specifier := range specifiers {
+		source, err := p.ParseOne(specifier)
+		if err != nil {
+			allErrors = append(allErrors, err)
+			continue
+		}
+
+		sources = append(sources, source)
+	}
+
+	err := utilerrors.NewAggregate(allErrors)
+	return sources, err
+}
+
+// ParseOne constructs a Source objects from a given pipe delimited
+// representation of an operator source. The format is specified as shown below.
+
+// {base url with cnr prefix}|{quay registry namespace}|{secret namespace/secret name}
+//
+// Secret is optional.
+func (*registrySpecifier) ParseOne(specifier string) (*Source, error) {
+	splits := strings.Split(specifier, "|")
+
+	// If leading or trailing delimiter is specified, then handle it by removing
+	// the empty string from the slice.
+	values := make([]string, 0)
+	for _, value := range splits {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+
+		values = append(values, value)
+	}
+
+	if len(values) < 2 || len(values) > 3 {
+		return nil, fmt.Errorf("The source specified is invalid - %s", specifier)
+	}
+
+	var secret types.NamespacedName
+	// If secret has been specified let's handle it.
+	if len(values) == 3 {
+		s := values[2]
+		split := strings.Split(s, "/")
+		if len(split) != 2 {
+			return nil, fmt.Errorf("invalid source, secret specified is malformed - %s", s)
+		}
+
+		secret.Namespace = strings.TrimSpace(split[0])
+		secret.Name = strings.TrimSpace(split[1])
+	}
+
+	source := &Source{
+		Endpoint:          values[0],
+		RegistryNamespace: values[1],
+		Secret:            secret,
+	}
+
+	return source, nil
+}

--- a/pkg/appregistry/registry_specifier_test.go
+++ b/pkg/appregistry/registry_specifier_test.go
@@ -1,0 +1,101 @@
+package appregistry
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestParseSource(t *testing.T) {
+	p := registrySpecifier{}
+
+	sourceWant := &Source{
+		Endpoint:          "https://quay.io/cnr",
+		RegistryNamespace: "community-operators",
+		Secret: types.NamespacedName{
+			Namespace: "mynamespace",
+			Name:      "mysecret",
+		},
+	}
+
+	input := fmt.Sprintf("%s | %s |%s /  %s", sourceWant.Endpoint,
+		sourceWant.RegistryNamespace, sourceWant.Secret.Namespace, sourceWant.Secret.Name)
+	sourceGot, errGot := p.ParseOne(input)
+
+	assert.NoError(t, errGot)
+	assert.Equal(t, sourceWant, sourceGot)
+}
+
+func TestParseSourceWithLeadingOrTrailingDelimiter(t *testing.T) {
+	p := registrySpecifier{}
+
+	sourceWant := &Source{
+		Endpoint:          "https://quay.io/cnr",
+		RegistryNamespace: "community-operators",
+		Secret: types.NamespacedName{
+			Namespace: "mynamespace",
+			Name:      "mysecret",
+		},
+	}
+
+	input := fmt.Sprintf("|%s|%s|%s/%s|", sourceWant.Endpoint,
+		sourceWant.RegistryNamespace, sourceWant.Secret.Namespace, sourceWant.Secret.Name)
+	sourceGot, errGot := p.ParseOne(input)
+
+	assert.NoError(t, errGot)
+	assert.Equal(t, sourceWant, sourceGot)
+}
+
+func TestParseSourceWithNoSecret(t *testing.T) {
+	p := registrySpecifier{}
+
+	sourceWant := &Source{
+		Endpoint:          "https://quay.io/cnr",
+		RegistryNamespace: "community-operators",
+		Secret: types.NamespacedName{
+			Namespace: "",
+			Name:      "",
+		},
+	}
+
+	input := fmt.Sprintf("%s|%s|", sourceWant.Endpoint, sourceWant.RegistryNamespace)
+	sourceGot, errGot := p.ParseOne(input)
+
+	assert.NoError(t, errGot)
+	assert.Equal(t, sourceWant, sourceGot)
+}
+
+func TestParseSourcesWithError(t *testing.T) {
+	sourcesWant := []*Source{
+		&Source{
+			Endpoint:          "https://quay.io/cnr",
+			RegistryNamespace: "community-operators",
+			Secret: types.NamespacedName{
+				Namespace: "mynamespace",
+				Name:      "mysecret",
+			},
+		},
+		&Source{
+			Endpoint:          "https://quay.io/cnr",
+			RegistryNamespace: "redhat-operators",
+			Secret: types.NamespacedName{
+				Namespace: "",
+				Name:      "",
+			},
+		},
+	}
+
+	input := []string{
+		fmt.Sprintf("|%s|%s|%s/%s|", sourcesWant[0].Endpoint, sourcesWant[0].RegistryNamespace, sourcesWant[0].Secret.Namespace, sourcesWant[0].Secret.Name),
+		fmt.Sprintf("|%s|%s|", sourcesWant[1].Endpoint, sourcesWant[1].RegistryNamespace),
+		fmt.Sprintf("abc|xyz|123|pqr"),
+	}
+
+	p := registrySpecifier{}
+	sourcesGot, errGot := p.Parse(input)
+
+	assert.Error(t, errGot)
+	assert.ElementsMatch(t, sourcesWant, sourcesGot)
+}

--- a/pkg/appregistry/source.go
+++ b/pkg/appregistry/source.go
@@ -1,0 +1,32 @@
+package appregistry
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type Source struct {
+	// Endpoint points to the base URL of remote AppRegistry server.
+	Endpoint string
+
+	// RegistryNamespace is the namespace in remote registry where the operator
+	// metadata is located.
+	RegistryNamespace string
+
+	// Secret is the kubernetes secret object that contains the authorization
+	// token that can be used to access private repositories.
+	Secret types.NamespacedName
+}
+
+func (s *Source) String() string {
+	return fmt.Sprintf("%s/%s", s.Endpoint, s.RegistryNamespace)
+}
+
+func (s *Source) IsSecretSpecified() bool {
+	if s.Secret.Name == "" || s.Secret.Namespace == "" {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
Currently the way we specify an operator source is by providing a namespaced name of an OperatorSource CR. This introduces a tight coupling between operator registry and marketplace operator.

Make the following changes to remove OperatorSource dependency:
- Specify a single operator source using the following format
{base url with cnr prefix}|{quay registry namespace}|{secret namespace/secret name}
 -- Use '|' as a delimiter to separate operator source elements.
 -- k8s secret object is optional and if specified should have the
    format - {k8s namespace}/{secret name}.
 -- Add a new flag 'registry' to specify operator source using the
    above format.

- Convert the existing flag 'sources' from string to string slice so that we
  can accept multiple operator source specifier(s).

We can maintain backwards compatibility by having both flags for now.

Example:
--registry="https://quay.io/cnr|community-operators" --registry="https://quay.io/cnr|custom-operators|mynamespace/mysecret"