### PR TITLE
fix(registry): Validate alm-examples in operator registry

### DIFF
--- a/manifests/etcd/0.6.1/etcdoperator.clusterserviceversion.yaml
+++ b/manifests/etcd/0.6.1/etcdoperator.clusterserviceversion.yaml
@@ -1,12 +1,11 @@
-#! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
 #! parse-kind: ClusterServiceVersion
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   name: etcdoperator.v0.6.1
   namespace: placeholder
-  annotations:		
-    tectonic-visibility: ocs		
+  annotations:
+    tectonic-visibility: ocs
 spec:
   displayName: etcd
   description: |

--- a/manifests/etcd/0.9.0/etcdoperator.v0.9.0.yaml
+++ b/manifests/etcd/0.9.0/etcdoperator.v0.9.0.yaml
@@ -1,4 +1,3 @@
-#! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
 #! parse-kind: ClusterServiceVersion
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
@@ -224,28 +223,28 @@ spec:
         - description: Specifies the endpoints of an etcd cluster.
           displayName: etcd Endpoint(s)
           path: etcdEndpoints
-          x-descriptors: 
+          x-descriptors:
             - 'urn:alm:descriptor:etcd:endpoint'
         - description: The full AWS S3 path where the backup is saved.
           displayName: S3 Path
           path: s3.path
-          x-descriptors: 
+          x-descriptors:
             - 'urn:alm:descriptor:aws:s3:path'
         - description: The name of the secret object that stores the AWS credential and config files.
           displayName: AWS Secret
           path: s3.awsSecret
-          x-descriptors: 
+          x-descriptors:
             - 'urn:alm:descriptor:io.kubernetes:Secret'
       statusDescriptors:
         - description: Indicates if the backup was successful.
           displayName: Succeeded
           path: succeeded
-          x-descriptors: 
+          x-descriptors:
             - 'urn:alm:descriptor:text'
         - description: Indicates the reason for any backup related failures.
           displayName: Reason
           path: reason
-          x-descriptors: 
+          x-descriptors:
             - 'urn:alm:descriptor:io.kubernetes.phase:reason'
     - name: etcdrestores.etcd.database.coreos.com
       version: v1beta2
@@ -256,27 +255,27 @@ spec:
         - description: References the EtcdCluster which should be restored,
           displayName: etcd Cluster
           path: etcdCluster.name
-          x-descriptors: 
+          x-descriptors:
             - 'urn:alm:descriptor:io.kubernetes:EtcdCluster'
             - 'urn:alm:descriptor:text'
         - description: The full AWS S3 path where the backup is saved.
           displayName: S3 Path
           path: s3.path
-          x-descriptors: 
+          x-descriptors:
             - 'urn:alm:descriptor:aws:s3:path'
         - description: The name of the secret object that stores the AWS credential and config files.
           displayName: AWS Secret
           path: s3.awsSecret
-          x-descriptors: 
+          x-descriptors:
             - 'urn:alm:descriptor:io.kubernetes:Secret'
       statusDescriptors:
         - description: Indicates if the restore was successful.
           displayName: Succeeded
           path: succeeded
-          x-descriptors: 
+          x-descriptors:
             - 'urn:alm:descriptor:text'
         - description: Indicates the reason for any restore related failures.
           displayName: Reason
           path: reason
-          x-descriptors: 
+          x-descriptors:
             - 'urn:alm:descriptor:io.kubernetes.phase:reason'

--- a/manifests/etcd/0.9.2/etcdoperator.v0.9.2.clusterserviceversion.yaml
+++ b/manifests/etcd/0.9.2/etcdoperator.v0.9.2.clusterserviceversion.yaml
@@ -1,4 +1,3 @@
-#! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
 #! parse-kind: ClusterServiceVersion
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
@@ -226,28 +225,28 @@ spec:
         - description: Specifies the endpoints of an etcd cluster.
           displayName: etcd Endpoint(s)
           path: etcdEndpoints
-          x-descriptors: 
+          x-descriptors:
             - 'urn:alm:descriptor:etcd:endpoint'
         - description: The full AWS S3 path where the backup is saved.
           displayName: S3 Path
           path: s3.path
-          x-descriptors: 
+          x-descriptors:
             - 'urn:alm:descriptor:aws:s3:path'
         - description: The name of the secret object that stores the AWS credential and config files.
           displayName: AWS Secret
           path: s3.awsSecret
-          x-descriptors: 
+          x-descriptors:
             - 'urn:alm:descriptor:io.kubernetes:Secret'
       statusDescriptors:
         - description: Indicates if the backup was successful.
           displayName: Succeeded
           path: succeeded
-          x-descriptors: 
+          x-descriptors:
             - 'urn:alm:descriptor:text'
         - description: Indicates the reason for any backup related failures.
           displayName: Reason
           path: reason
-          x-descriptors: 
+          x-descriptors:
             - 'urn:alm:descriptor:io.kubernetes.phase:reason'
     - name: etcdrestores.etcd.database.coreos.com
       version: v1beta2
@@ -258,27 +257,27 @@ spec:
         - description: References the EtcdCluster which should be restored,
           displayName: etcd Cluster
           path: etcdCluster.name
-          x-descriptors: 
+          x-descriptors:
             - 'urn:alm:descriptor:io.kubernetes:EtcdCluster'
             - 'urn:alm:descriptor:text'
         - description: The full AWS S3 path where the backup is saved.
           displayName: S3 Path
           path: s3.path
-          x-descriptors: 
+          x-descriptors:
             - 'urn:alm:descriptor:aws:s3:path'
         - description: The name of the secret object that stores the AWS credential and config files.
           displayName: AWS Secret
           path: s3.awsSecret
-          x-descriptors: 
+          x-descriptors:
             - 'urn:alm:descriptor:io.kubernetes:Secret'
       statusDescriptors:
         - description: Indicates if the restore was successful.
           displayName: Succeeded
           path: succeeded
-          x-descriptors: 
+          x-descriptors:
             - 'urn:alm:descriptor:text'
         - description: Indicates the reason for any restore related failures.
           displayName: Reason
           path: reason
-          x-descriptors: 
+          x-descriptors:
             - 'urn:alm:descriptor:io.kubernetes.phase:reason'

--- a/manifests/etcd/etcd.package.yaml
+++ b/manifests/etcd/etcd.package.yaml
@@ -1,4 +1,3 @@
-#! package-manifest: ./deploy/chart/catalog_resources/rh-operators/etcdoperator.v0.9.2.clusterserviceversion.yaml
 packageName: etcd
 channels:
 - name: alpha

--- a/manifests/prometheus/0.14.0/prometheusoperator.0.14.0.clusterserviceversion.yaml
+++ b/manifests/prometheus/0.14.0/prometheusoperator.0.14.0.clusterserviceversion.yaml
@@ -1,4 +1,3 @@
-#! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
 #! parse-kind: ClusterServiceVersion
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion

--- a/manifests/prometheus/0.15.0/prometheusoperator.0.15.0.clusterserviceversion.yaml
+++ b/manifests/prometheus/0.15.0/prometheusoperator.0.15.0.clusterserviceversion.yaml
@@ -1,4 +1,3 @@
-#! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
 #! parse-kind: ClusterServiceVersion
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion

--- a/manifests/prometheus/0.22.2/prometheusoperator.0.22.2.clusterserviceversion.yaml
+++ b/manifests/prometheus/0.22.2/prometheusoperator.0.22.2.clusterserviceversion.yaml
@@ -1,4 +1,3 @@
-#! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
 #! parse-kind: ClusterServiceVersion
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion

--- a/manifests/prometheus/prometheus.package.yaml
+++ b/manifests/prometheus/prometheus.package.yaml
@@ -1,4 +1,3 @@
-#! package-manifest: ./deploy/chart/catalog_resources/rh-operators/prometheusoperator.0.22.2.clusterserviceversion.yaml
 packageName: prometheus
 channels:
 - name: preview


### PR DESCRIPTION
Validate alm-examples for CSV from registry to ensure it is parsable
and match provided APIs

Signed-off-by: Vu Dinh <vdinh@redhat.com>