### PR TITLE
feat(client): add health check to high-level client interface

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -2,8 +2,10 @@ package client
 
 import (
 	"context"
+	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 
 	"github.com/operator-framework/operator-registry/pkg/api"
 	"github.com/operator-framework/operator-registry/pkg/api/grpc_health_v1"
@@ -15,6 +17,8 @@ type Interface interface {
 	GetBundleInPackageChannel(ctx context.Context, packageName, channelName string) (*registry.Bundle, error)
 	GetReplacementBundleInPackageChannel(ctx context.Context, currentName, packageName, channelName string) (*registry.Bundle, error)
 	GetBundleThatProvides(ctx context.Context, group, version, kind string) (*registry.Bundle, error)
+	HealthCheck(ctx context.Context, reconnectTimeout time.Duration) (bool, error)
+	Close() error
 }
 
 type Client struct {
@@ -59,6 +63,31 @@ func (c *Client) GetBundleThatProvides(ctx context.Context, group, version, kind
 		return nil, err
 	}
 	return parsedBundle, nil
+}
+
+func (c *Client) Close() error {
+	if c.Conn == nil {
+		return nil
+	}
+	return c.Conn.Close()
+}
+
+func (c *Client) HealthCheck(ctx context.Context, reconnectTimeout time.Duration) (bool, error) {
+	res, err := c.Health.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: "Registry"})
+	if err != nil {
+		if c.Conn.GetState() == connectivity.TransientFailure {
+			ctx, cancel := context.WithTimeout(ctx, reconnectTimeout)
+			defer cancel()
+			if !c.Conn.WaitForStateChange(ctx, connectivity.TransientFailure) {
+				return false, NewHealthError(c.Conn, HealthErrReasonUnrecoveredTransient, "connection didn't recover from TransientFailure")
+			}
+		}
+		return false, NewHealthError(c.Conn, HealthErrReasonConnection, err.Error())
+	}
+	if res.Status != grpc_health_v1.HealthCheckResponse_SERVING {
+		return false, nil
+	}
+	return true, nil
 }
 
 func NewClient(address string) (*Client, error) {

--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -1,0 +1,61 @@
+package client
+
+import (
+	"fmt"
+
+	"google.golang.org/grpc"
+)
+
+const (
+	HealthErrReasonUnrecoveredTransient HealthErrorReason = "UnrecoveredTransient"
+	HealthErrReasonConnection           HealthErrorReason = "ConnectionError"
+	HealthErrReasonUnknown              HealthErrorReason = "Unknown"
+)
+
+type HealthErrorReason string
+
+// HealthError is used to represent error types for health checks
+type HealthError struct {
+	ClientState string
+	Reason      HealthErrorReason
+	Message     string
+}
+
+var _ error = HealthError{}
+
+// Error implements the Error interface.
+func (e HealthError) Error() string {
+	return fmt.Sprintf("%s: %s", e.ClientState, e.Message)
+}
+
+// unrecoverableErrors are the set of errors that mean we can't recover the connection
+var unrecoverableErrors = map[HealthErrorReason]struct{}{
+	HealthErrReasonUnrecoveredTransient: {},
+}
+
+func NewHealthError(conn *grpc.ClientConn, reason HealthErrorReason, msg string) HealthError {
+	return HealthError{
+		ClientState: conn.GetState().String(),
+		Reason:      reason,
+		Message:     msg,
+	}
+}
+
+// IsErrorUnrecoverable reports if a given error is one of the predefined unrecoverable types
+func IsErrorUnrecoverable(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := unrecoverableErrors[reasonForError(err)]
+	return ok
+}
+
+func reasonForError(err error) HealthErrorReason {
+	switch t := err.(type) {
+	case HealthError:
+		return t.Reason
+	case *HealthError:
+		return t.Reason
+	}
+	return HealthErrReasonUnknown
+}


### PR DESCRIPTION
Without this, client consumers need to access the underlying Conn object to perform a health check.