### PR TITLE
[bug] Remove duplicate packages from list

### DIFF
--- a/pkg/appregistry/input.go
+++ b/pkg/appregistry/input.go
@@ -75,6 +75,7 @@ func sanitizePackageList(in []string) []string {
 			continue
 		}
 
+		inMap[item] = true
 		out = append(out, item)
 	}
 

--- a/pkg/appregistry/input_test.go
+++ b/pkg/appregistry/input_test.go
@@ -1,0 +1,16 @@
+package appregistry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDuplicatePackage(t *testing.T) {
+	parser := inputParser{sourceSpecifier: &registrySpecifier{}}
+	expectedPackages := []string{"Jaeger"}
+
+	actual, err := parser.Parse([]string{"https://quay.io/cnr|community-operator|"}, "Jaeger,Jaeger")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedPackages, actual.Packages)
+}


### PR DESCRIPTION
This change fixes a bug in the sanatizePackageList function that
allows duplicate packages to be included in the list.