### PR TITLE
Allow users to specify a release for a package

### DIFF
--- a/pkg/appregistry/downloader.go
+++ b/pkg/appregistry/downloader.go
@@ -51,7 +51,7 @@ func (d *downloader) Download(input *Input) (manifests []*apprclient.OperatorMet
 
 	d.logger.Infof("resolved the following packages: %s", items)
 
-	manifests, err = d.DownloadRepositories(items)
+	manifests, err = d.DownloadRepositories(items, input.Packages)
 
 	return
 }
@@ -118,7 +118,7 @@ func (d *downloader) Prepare(input *Input) (items []*downloadItem, err error) {
 
 // DownloadRepositories iterates through each download item and downloads
 // operator manifest from the corresponding repository.
-func (d *downloader) DownloadRepositories(items []*downloadItem) (manifests []*apprclient.OperatorMetadata, err error) {
+func (d *downloader) DownloadRepositories(items []*downloadItem, packages []*Package) (manifests []*apprclient.OperatorMetadata, err error) {
 	allErrors := []error{}
 
 	manifests = make([]*apprclient.OperatorMetadata, 0)
@@ -145,6 +145,11 @@ func (d *downloader) DownloadRepositories(items []*downloadItem) (manifests []*a
 			continue
 		}
 
+		for _, pkg := range packages {
+			if item.RepositoryMetadata.Name == pkg.Name && pkg.Release != "" {
+				item.RepositoryMetadata.Release = pkg.Release
+			}
+		}
 		manifest, err := client.RetrieveOne(item.RepositoryMetadata.ID(), item.RepositoryMetadata.Release)
 		if err != nil {
 			allErrors = append(allErrors, err)

--- a/pkg/appregistry/input.go
+++ b/pkg/appregistry/input.go
@@ -17,7 +17,7 @@ type Input struct {
 	Sources []*Source
 
 	// Packages is the set of package name(s) specified.
-	Packages []string
+	Packages []*Package
 }
 
 func (i *Input) IsGoodToProceed() bool {
@@ -28,7 +28,7 @@ func (i *Input) PackagesToMap() map[string]bool {
 	packages := map[string]bool{}
 
 	for _, pkg := range i.Packages {
-		packages[pkg] = false
+		packages[pkg.Name] = false
 	}
 
 	return packages
@@ -66,17 +66,19 @@ func (p *inputParser) Parse(csvSources []string, csvPackages string) (*Input, er
 
 // sanitizePackageList sanitizes the set of package(s) specified. It removes
 // duplicates and ignores empty string.
-func sanitizePackageList(in []string) []string {
-	out := make([]string, 0)
+func sanitizePackageList(in []string) []*Package {
+	out := make([]*Package, 0)
 
 	inMap := map[string]bool{}
 	for _, item := range in {
-		if _, ok := inMap[item]; ok || item == "" {
+		pkg := packageFromString(item)
+
+		if _, ok := inMap[pkg.Name]; ok || pkg.Name == "" {
 			continue
 		}
 
-		inMap[item] = true
-		out = append(out, item)
+		inMap[pkg.Name] = true
+		out = append(out, pkg)
 	}
 
 	return out

--- a/pkg/appregistry/input_test.go
+++ b/pkg/appregistry/input_test.go
@@ -6,11 +6,29 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDuplicatePackage(t *testing.T) {
+func TestDuplicatePackageResultHasNoRelease(t *testing.T) {
 	parser := inputParser{sourceSpecifier: &registrySpecifier{}}
-	expectedPackages := []string{"Jaeger"}
+	expectedPackages := []*Package{&Package{Name: "Jaeger", Release: ""}}
 
-	actual, err := parser.Parse([]string{"https://quay.io/cnr|community-operator|"}, "Jaeger,Jaeger")
+	actual, err := parser.Parse([]string{"https://quay.io/cnr|community-operator|"}, "Jaeger,Jaeger,Jaeger:0.0.1,Jaeger:0.0.2")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedPackages, actual.Packages)
+}
+
+func TestDuplicatePackageResultHasRelease(t *testing.T) {
+	parser := inputParser{sourceSpecifier: &registrySpecifier{}}
+	expectedPackages := []*Package{&Package{Name: "Jaeger", Release: "0.0.1"}}
+
+	actual, err := parser.Parse([]string{"https://quay.io/cnr|community-operator|"}, "Jaeger:0.0.1,Jaeger,Jaeger,Jaeger:0.0.2")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedPackages, actual.Packages)
+}
+
+func TestPackageListIncludesPackageWithAndWithoutRelease(t *testing.T) {
+	parser := inputParser{sourceSpecifier: &registrySpecifier{}}
+	expectedPackages := []*Package{&Package{Name: "Jaeger", Release: ""}, &Package{Name: "Syndesis", Release: "0.0.1"}}
+
+	actual, err := parser.Parse([]string{"https://quay.io/cnr|community-operator|"}, "Jaeger,Syndesis:0.0.1")
 	assert.NoError(t, err)
 	assert.Equal(t, expectedPackages, actual.Packages)
 }

--- a/pkg/appregistry/package.go
+++ b/pkg/appregistry/package.go
@@ -1,0 +1,28 @@
+package appregistry
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Package struct {
+	Name    string
+	Release string
+}
+
+func (p *Package) String() string {
+	return fmt.Sprintf("%s/%s", p.Name, p.Release)
+}
+
+// packageFromString will generate a Package from a string
+// The in parameter is expected to match the following format:
+// <package name>:<release>
+func packageFromString(in string) *Package {
+	split := strings.Split(in, ":")
+	release := ""
+
+	if len(split) == 2 {
+		release = split[1]
+	}
+	return &Package{Name: split[0], Release: release}
+}


### PR DESCRIPTION
Currently, the AppRegistry Server will download the latest release of
a package from quay. This update allows users to specify a specific
release.