### PR TITLE
fix(query): return all channels when querying

### DIFF
--- a/manifests/etcd/etcd.package.yaml
+++ b/manifests/etcd/etcd.package.yaml
@@ -4,4 +4,6 @@ channels:
   currentCSV: etcdoperator.v0.9.2
 - name: beta
   currentCSV: etcdoperator.v0.9.0
+- name: stable
+  currentCSV: etcdoperator.v0.9.2
 defaultChannel: alpha

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -110,6 +110,10 @@ func TestGetPackage(t *testing.T) {
 				Name:    "beta",
 				CsvName: "etcdoperator.v0.9.0",
 			},
+			{
+				Name:    "stable",
+				CsvName: "etcdoperator.v0.9.2",
+			},
 		},
 		DefaultChannelName: "alpha",
 	}
@@ -195,6 +199,12 @@ func TestGetChannelEntriesThatReplace(t *testing.T) {
 		{
 			PackageName: "etcd",
 			ChannelName: "beta",
+			BundleName:  "etcdoperator.v0.9.0",
+			Replaces:    "etcdoperator.v0.6.1",
+		},
+		{
+			PackageName: "etcd",
+			ChannelName: "stable",
 			BundleName:  "etcdoperator.v0.9.0",
 			Replaces:    "etcdoperator.v0.6.1",
 		},
@@ -310,6 +320,30 @@ func TestGetChannelEntriesThatProvide(t *testing.T) {
 			BundleName:  "etcdoperator.v0.9.0",
 			Replaces:    "etcdoperator.v0.6.1",
 		},
+		{
+			PackageName: "etcd",
+			ChannelName: "stable",
+			BundleName:  "etcdoperator.v0.6.1",
+			Replaces:    "",
+		},
+		{
+			PackageName: "etcd",
+			ChannelName: "stable",
+			BundleName:  "etcdoperator.v0.9.0",
+			Replaces:    "etcdoperator.v0.6.1",
+		},
+		{
+			PackageName: "etcd",
+			ChannelName: "stable",
+			BundleName:  "etcdoperator.v0.9.2",
+			Replaces:    "etcdoperator.v0.9.1",
+		},
+		{
+			PackageName: "etcd",
+			ChannelName: "stable",
+			BundleName:  "etcdoperator.v0.9.2",
+			Replaces:    "etcdoperator.v0.9.0",
+		},
 	}
 
 	require.ElementsMatch(t, expected, channelEntries)
@@ -354,6 +388,12 @@ func TestGetLatestChannelEntriesThatProvide(t *testing.T) {
 			ChannelName: "beta",
 			BundleName:  "etcdoperator.v0.9.0",
 			Replaces:    "etcdoperator.v0.6.1",
+		},
+		{
+			PackageName: "etcd",
+			ChannelName: "stable",
+			BundleName:  "etcdoperator.v0.9.2",
+			Replaces:    "etcdoperator.v0.9.0",
 		},
 	}
 

--- a/pkg/sqlite/directory_test.go
+++ b/pkg/sqlite/directory_test.go
@@ -51,6 +51,10 @@ func TestQuerierForDirectory(t *testing.T) {
 				Name:           "beta",
 				CurrentCSVName: "etcdoperator.v0.9.0",
 			},
+			{
+				Name:           "stable",
+				CurrentCSVName: "etcdoperator.v0.9.2",
+			},
 		},
 	}, etcdPackage)
 
@@ -65,7 +69,7 @@ func TestQuerierForDirectory(t *testing.T) {
 
 	etcdChannelEntries, err := store.GetChannelEntriesThatReplace(context.TODO(), "etcdoperator.v0.9.0")
 	require.NoError(t, err)
-	require.ElementsMatch(t, []*registry.ChannelEntry{{"etcd", "alpha", "etcdoperator.v0.9.2", "etcdoperator.v0.9.0"}}, etcdChannelEntries)
+	require.ElementsMatch(t, []*registry.ChannelEntry{{"etcd", "alpha", "etcdoperator.v0.9.2", "etcdoperator.v0.9.0"},{"etcd", "stable", "etcdoperator.v0.9.2", "etcdoperator.v0.9.0"}, }, etcdChannelEntries)
 
 	etcdBundleByReplaces, err := store.GetBundleThatReplaces(context.TODO(), "etcdoperator.v0.9.0", "etcd", "alpha")
 	require.NoError(t, err)
@@ -78,12 +82,17 @@ func TestQuerierForDirectory(t *testing.T) {
 		{"etcd", "alpha", "etcdoperator.v0.9.2", "etcdoperator.v0.9.1"},
 		{"etcd", "alpha", "etcdoperator.v0.9.2", "etcdoperator.v0.9.0"},
 		{"etcd", "beta", "etcdoperator.v0.6.1", ""},
-		{"etcd", "beta", "etcdoperator.v0.9.0", "etcdoperator.v0.6.1"}}, etcdChannelEntriesThatProvide)
+		{"etcd", "beta", "etcdoperator.v0.9.0", "etcdoperator.v0.6.1"},
+		{"etcd", "stable", "etcdoperator.v0.6.1", ""},
+		{"etcd", "stable", "etcdoperator.v0.9.0", "etcdoperator.v0.6.1"},
+		{"etcd", "stable", "etcdoperator.v0.9.2", "etcdoperator.v0.9.1"},
+		{"etcd", "stable", "etcdoperator.v0.9.2", "etcdoperator.v0.9.0"},}, etcdChannelEntriesThatProvide)
 
 	etcdLatestChannelEntriesThatProvide, err := store.GetLatestChannelEntriesThatProvide(context.TODO(), "etcd.database.coreos.com", "v1beta2", "EtcdCluster")
 	require.NoError(t, err)
 	require.ElementsMatch(t, []*registry.ChannelEntry{{"etcd", "alpha", "etcdoperator.v0.9.2", "etcdoperator.v0.9.0"},
-		                                              {"etcd", "beta", "etcdoperator.v0.9.0", "etcdoperator.v0.6.1"}}, etcdLatestChannelEntriesThatProvide)
+		                                              {"etcd", "beta", "etcdoperator.v0.9.0", "etcdoperator.v0.6.1"},
+		                                              {"etcd", "stable", "etcdoperator.v0.9.2", "etcdoperator.v0.9.0"}}, etcdLatestChannelEntriesThatProvide)
 
 	etcdBundleByProvides, entry, err := store.GetBundleThatProvides(context.TODO(), "etcd.database.coreos.com", "v1beta2", "EtcdCluster")
 	require.NoError(t, err)

--- a/pkg/sqlite/query.go
+++ b/pkg/sqlite/query.go
@@ -94,7 +94,7 @@ func (s *SQLQuerier) GetPackage(ctx context.Context, name string) (*registry.Pac
 		},
 	}
 
-	if rows.Next() {
+	for rows.Next() {
 		if err := rows.Scan(&pkgName, &defaultChannel, &channelName, &bundleName); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Previously this was returning a maximum of 2 channels