### PR TITLE
Bug 1728223: fix(build): don't build static in downstream images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY vendor vendor
 COPY cmd cmd
 COPY pkg pkg
 COPY Makefile go.mod go.sum ./
-RUN make static-rh
+RUN make build
 
 # copy and build vendored grpc_health_probe
 RUN mkdir -p /go/src/github.com/grpc-ecosystem && \

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,6 @@ build: clean $(CMDS)
 static: extra_flags=-ldflags '-w -extldflags "-static"'
 static: build
 
-static-rh: extra_flags=-ldflags '-w -extldflags "-Wl,-Bstatic -ldl -lc -lpthread -lcrypto -lz -static"'
-static-rh: build
-
 unit:
 	go test $(MOD_FLAGS) -count=1 --tags json1 -v -race ./pkg/...
 


### PR DESCRIPTION
Seeing these warnings building statically:

```
go build -mod=vendor -tags json1 -ldflags '-w -extldflags "-Wl,-Bstatic -ldl -lc -lpthread -lcrypto -lz -static"' -o bin/appregistry-server ./cmd/appregistry-server
# github.com/operator-framework/operator-registry/cmd/appregistry-server
/tmp/go-link-621145489/000032.o: In function `unixDlOpen':
/src/vendor/github.com/mattn/go-sqlite3/sqlite3-binding.c:38461: warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-621145489/000019.o: In function `mygetgrouplist':
/builddir/build/BUILD/go1.11-openssl-fips/src/os/user/getgrouplist_unix.go:16: warning: Using 'getgrouplist' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-621145489/000018.o: In function `mygetgrgid_r':
/builddir/build/BUILD/go1.11-openssl-fips/src/os/user/cgo_lookup_unix.go:38: warning: Using 'getgrgid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-621145489/000018.o: In function `mygetgrnam_r':
/builddir/build/BUILD/go1.11-openssl-fips/src/os/user/cgo_lookup_unix.go:43: warning: Using 'getgrnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-621145489/000018.o: In function `mygetpwnam_r':
/builddir/build/BUILD/go1.11-openssl-fips/src/os/user/cgo_lookup_unix.go:33: warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-621145489/000018.o: In function `mygetpwuid_r':
/builddir/build/BUILD/go1.11-openssl-fips/src/os/user/cgo_lookup_unix.go:28: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-621145489/000004.o: In function `_cgo_18049202ccd9_C2func_getaddrinfo':
/tmp/go-build/cgo-gcc-prolog:56: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
go build -mod=vendor -tags json1 -ldflags '-w -extldflags "-Wl,-Bstatic -ldl -lc -lpthread -lcrypto -lz -static"' -o bin/configmap-server ./cmd/configmap-server
# github.com/operator-framework/operator-registry/cmd/configmap-server
/tmp/go-link-464693852/000028.o: In function `unixDlOpen':
/src/vendor/github.com/mattn/go-sqlite3/sqlite3-binding.c:38461: warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-464693852/000032.o: In function `mygetgrouplist':
/builddir/build/BUILD/go1.11-openssl-fips/src/os/user/getgrouplist_unix.go:16: warning: Using 'getgrouplist' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-464693852/000031.o: In function `mygetgrgid_r':
/builddir/build/BUILD/go1.11-openssl-fips/src/os/user/cgo_lookup_unix.go:38: warning: Using 'getgrgid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-464693852/000031.o: In function `mygetgrnam_r':
/builddir/build/BUILD/go1.11-openssl-fips/src/os/user/cgo_lookup_unix.go:43: warning: Using 'getgrnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-464693852/000031.o: In function `mygetpwnam_r':
/builddir/build/BUILD/go1.11-openssl-fips/src/os/user/cgo_lookup_unix.go:33: warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-464693852/000031.o: In function `mygetpwuid_r':
/builddir/build/BUILD/go1.11-openssl-fips/src/os/user/cgo_lookup_unix.go:28: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-464693852/000004.o: In function `_cgo_18049202ccd9_C2func_getaddrinfo':
/tmp/go-build/cgo-gcc-prolog:56: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
go build -mod=vendor -tags json1 -ldflags '-w -extldflags "-Wl,-Bstatic -ldl -lc -lpthread -lcrypto -lz -static"' -o bin/initializer ./cmd/initializer
# github.com/operator-framework/operator-registry/cmd/initializer
/tmp/go-link-127376862/000011.o: In function `unixDlOpen':
/src/vendor/github.com/mattn/go-sqlite3/sqlite3-binding.c:38461: warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-127376862/000032.o: In function `mygetgrouplist':
/builddir/build/BUILD/go1.11-openssl-fips/src/os/user/getgrouplist_unix.go:16: warning: Using 'getgrouplist' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-127376862/000031.o: In function `mygetgrgid_r':
/builddir/build/BUILD/go1.11-openssl-fips/src/os/user/cgo_lookup_unix.go:38: warning: Using 'getgrgid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-127376862/000031.o: In function `mygetgrnam_r':
/builddir/build/BUILD/go1.11-openssl-fips/src/os/user/cgo_lookup_unix.go:43: warning: Using 'getgrnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-127376862/000031.o: In function `mygetpwnam_r':
/builddir/build/BUILD/go1.11-openssl-fips/src/os/user/cgo_lookup_unix.go:33: warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-127376862/000031.o: In function `mygetpwuid_r':
/builddir/build/BUILD/go1.11-openssl-fips/src/os/user/cgo_lookup_unix.go:28: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-127376862/000017.o: In function `_cgo_18049202ccd9_C2func_getaddrinfo':
/tmp/go-build/cgo-gcc-prolog:56: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
go build -mod=vendor -tags json1 -ldflags '-w -extldflags "-Wl,-Bstatic -ldl -lc -lpthread -lcrypto -lz -static"' -o bin/registry-server ./cmd/registry-server
# github.com/operator-framework/operator-registry/cmd/registry-server
/tmp/go-link-802234231/000028.o: In function `unixDlOpen':
/src/vendor/github.com/mattn/go-sqlite3/sqlite3-binding.c:38461: warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-802234231/000049.o: In function `mygetgrouplist':
/builddir/build/BUILD/go1.11-openssl-fips/src/os/user/getgrouplist_unix.go:16: warning: Using 'getgrouplist' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-802234231/000048.o: In function `mygetgrgid_r':
/builddir/build/BUILD/go1.11-openssl-fips/src/os/user/cgo_lookup_unix.go:38: warning: Using 'getgrgid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-802234231/000048.o: In function `mygetgrnam_r':
/builddir/build/BUILD/go1.11-openssl-fips/src/os/user/cgo_lookup_unix.go:43: warning: Using 'getgrnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-802234231/000048.o: In function `mygetpwnam_r':
/builddir/build/BUILD/go1.11-openssl-fips/src/os/user/cgo_lookup_unix.go:33: warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-802234231/000048.o: In function `mygetpwuid_r':
/builddir/build/BUILD/go1.11-openssl-fips/src/os/user/cgo_lookup_unix.go:28: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-802234231/000004.o: In function `_cgo_18049202ccd9_C2func_getaddrinfo':
/tmp/go-build/cgo-gcc-prolog:56: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
```

We only really need the static images when running in scratch, so for downstream builds I've switched to load glibc dynamically.