### PR TITLE
Permissive/Strict Options

### DIFF
--- a/cmd/configmap-server/main.go
+++ b/cmd/configmap-server/main.go
@@ -22,21 +22,21 @@ import (
 	"github.com/operator-framework/operator-registry/pkg/sqlite"
 )
 
-func main() {
-	var rootCmd = &cobra.Command{
-		Short: "configmap-server",
-		Long:  `configmap-server reads a configmap and builds a sqlite database containing operator manifests and serves a grpc API to query it`,
+var rootCmd = &cobra.Command{
+	Short: "configmap-server",
+	Long:  `configmap-server reads a configmap and builds a sqlite database containing operator manifests and serves a grpc API to query it`,
 
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if debug, _ := cmd.Flags().GetBool("debug"); debug {
-				logrus.SetLevel(logrus.DebugLevel)
-			}
-			return nil
-		},
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if debug, _ := cmd.Flags().GetBool("debug"); debug {
+			logrus.SetLevel(logrus.DebugLevel)
+		}
+		return nil
+	},
 
-		RunE: runCmdFunc,
-	}
+	RunE: runCmdFunc,
+}
 
+func init() {
 	rootCmd.Flags().Bool("debug", false, "enable debug logging")
 	rootCmd.Flags().StringP("kubeconfig", "k", "", "absolute path to kubeconfig file")
 	rootCmd.Flags().StringP("database", "d", "bundles.db", "name of db to output")
@@ -48,7 +48,9 @@ func main() {
 	if err := rootCmd.Flags().MarkHidden("debug"); err != nil {
 		logrus.Panic(err.Error())
 	}
+}
 
+func main() {
 	if err := rootCmd.Execute(); err != nil {
 		logrus.Panic(err.Error())
 	}

--- a/cmd/configmap-server/main.go
+++ b/cmd/configmap-server/main.go
@@ -59,7 +59,7 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 	}
 	err = log.AddDefaultWriterHooks(terminationLogPath)
 	if err != nil {
-		return err
+		logrus.WithError(err).Warn("unable to set termination log path")
 	}
 	kubeconfig, err := cmd.Flags().GetString("kubeconfig")
 	if err != nil {

--- a/cmd/initializer/main.go
+++ b/cmd/initializer/main.go
@@ -9,21 +9,21 @@ import (
 	"github.com/operator-framework/operator-registry/pkg/sqlite"
 )
 
-func main() {
-	var rootCmd = &cobra.Command{
-		Short: "initializer",
-		Long:  `initializer takes a directory of OLM manifests and outputs a sqlite database containing them`,
+var rootCmd = &cobra.Command{
+	Short: "initializer",
+	Long:  `initializer takes a directory of OLM manifests and outputs a sqlite database containing them`,
 
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if debug, _ := cmd.Flags().GetBool("debug"); debug {
-				logrus.SetLevel(logrus.DebugLevel)
-			}
-			return nil
-		},
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if debug, _ := cmd.Flags().GetBool("debug"); debug {
+			logrus.SetLevel(logrus.DebugLevel)
+		}
+		return nil
+	},
 
-		RunE: runCmdFunc,
-	}
+	RunE: runCmdFunc,
+}
 
+func init() {
 	rootCmd.Flags().Bool("debug", false, "enable debug logging")
 	rootCmd.Flags().StringP("manifests", "m", "manifests", "relative path to directory of manifests")
 	rootCmd.Flags().StringP("output", "o", "bundles.db", "relative path to a sqlite file to create or overwrite")
@@ -31,7 +31,9 @@ func main() {
 	if err := rootCmd.Flags().MarkHidden("debug"); err != nil {
 		panic(err)
 	}
+}
 
+func main() {
 	if err := rootCmd.Execute(); err != nil {
 		panic(err)
 	}

--- a/cmd/registry-server/main.go
+++ b/cmd/registry-server/main.go
@@ -17,21 +17,21 @@ import (
 	"github.com/operator-framework/operator-registry/pkg/sqlite"
 )
 
-func main() {
-	var rootCmd = &cobra.Command{
-		Short: "registry-server",
-		Long:  `registry loads a sqlite database containing operator manifests and serves a grpc API to query it`,
+var rootCmd = &cobra.Command{
+	Short: "registry-server",
+	Long:  `registry loads a sqlite database containing operator manifests and serves a grpc API to query it`,
 
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if debug, _ := cmd.Flags().GetBool("debug"); debug {
-				logrus.SetLevel(logrus.DebugLevel)
-			}
-			return nil
-		},
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if debug, _ := cmd.Flags().GetBool("debug"); debug {
+			logrus.SetLevel(logrus.DebugLevel)
+		}
+		return nil
+	},
 
-		RunE: runCmdFunc,
-	}
+	RunE: runCmdFunc,
+}
 
+func init() {
 	rootCmd.Flags().Bool("debug", false, "enable debug logging")
 	rootCmd.Flags().StringP("database", "d", "bundles.db", "relative path to sqlite db")
 	rootCmd.Flags().StringP("port", "p", "50051", "port number to serve on")
@@ -39,7 +39,9 @@ func main() {
 	if err := rootCmd.Flags().MarkHidden("debug"); err != nil {
 		logrus.Panic(err.Error())
 	}
+}
 
+func main() {
 	if err := rootCmd.Execute(); err != nil {
 		logrus.Panic(err.Error())
 	}
@@ -53,7 +55,7 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 	}
 	err = log.AddDefaultWriterHooks(terminationLogPath)
 	if err != nil {
-		return err
+		logrus.WithError(err).Warn("unable to set termination log path")
 	}
 	dbName, err := cmd.Flags().GetString("database")
 	if err != nil {


### PR DESCRIPTION
- Adds a permissive option to the intializer and configmap-server commands that, when given, permits load errors with out failing.
- Adds a strict option to the appregistry-server command that, when given, fails when load errors are encountered.
