### PR TITLE
fix(registry) Fix incorrect error return and handle

### DIFF
--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -360,7 +360,7 @@ func validateExamplesAnnotations(csv *v1alpha1.ClusterServiceVersion) error {
 		return err
 	}
 
-	if matchGVKProvidedAPIs(parsedExamples, providedAPIs) != nil {
+	if err = matchGVKProvidedAPIs(parsedExamples, providedAPIs); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The error from `matchGVKProvidedAPIs` is not captured correctly which
may lead to incorrect error from previous functions to be returned
instead.

Signed-off-by: Vu Dinh <vdinh@redhat.com>