### PR TITLE
Skip non yaml or json files in initializer

### DIFF
--- a/pkg/sqlite/directory.go
+++ b/pkg/sqlite/directory.go
@@ -201,6 +201,11 @@ func (d *DirectoryLoader) LoadPackagesWalkFunc(path string, f os.FileInfo, err e
 		return nil
 	}
 
+	if !strings.HasSuffix(f.Name(), ".yaml") && !strings.HasSuffix(f.Name(), ".json") {
+		log.Info("skipping non yaml or json file")
+		return nil
+	}
+
 	fileReader, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("unable to load package from file %s: %s", path, err)

--- a/pkg/sqlite/directory_test.go
+++ b/pkg/sqlite/directory_test.go
@@ -30,6 +30,39 @@ func TestDirectoryLoader(t *testing.T) {
 	require.NoError(t, loader.Populate())
 }
 
+func TestLoadBundleWalkFuncBadSuffix(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+
+	store, err := NewSQLLiteLoader("test.db")
+	require.NoError(t, err)
+	defer func() {
+		if err := os.Remove("test.db"); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Copy golden manifests to a temp dir
+	dir, err := ioutil.TempDir("testdata", "manifests-")
+	require.NoError(t, err)
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	require.NoError(t, copy.Copy("../../manifests", dir))
+
+	// Create a non json or yaml file to trip parser
+	path := filepath.Join(dir, "etcd/README.md")
+	data := []byte("# This is not yaml or json")
+	err = ioutil.WriteFile(path, data, 0644)
+	require.NoError(t, err)
+
+	// Expect the loader to skip the README.md otherwise it will attempt to parse it and fail
+	loader := NewSQLLoaderForDirectory(store, dir)
+	require.NoError(t, loader.Populate())
+
+}
+
 func TestDirectoryLoaderWithBadManifests(t *testing.T) {
 	logrus.SetLevel(logrus.DebugLevel)
 


### PR DESCRIPTION
This PR attempts to fix an error where the initializer attempts to load files that are not yaml or json. The change from non permissive to permissive errors in #74 broke our builds because we have a README.md in all our repos at the package.yaml level.