### PR TITLE
Adding OPM cli with registry add and rm commands

### DIFF
--- a/bundles/etcd.0.9.0/manifests/etcdbackup.crd.yaml
+++ b/bundles/etcd.0.9.0/manifests/etcdbackup.crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: etcdbackups.etcd.database.coreos.com
+spec:
+  group: etcd.database.coreos.com
+  version: v1beta2
+  scope: Namespaced
+  names:
+    kind: EtcdBackup
+    listKind: EtcdBackupList
+    plural: etcdbackups
+    singular: etcdbackup

--- a/bundles/etcd.0.9.0/manifests/etcdcluster.crd.yaml
+++ b/bundles/etcd.0.9.0/manifests/etcdcluster.crd.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: etcdclusters.etcd.database.coreos.com
+spec:
+  group: etcd.database.coreos.com
+  version: v1beta2
+  scope: Namespaced
+  names:
+    plural: etcdclusters
+    singular: etcdcluster
+    kind: EtcdCluster
+    listKind: EtcdClusterList
+    shortNames:
+      - etcdclus
+      - etcd

--- a/bundles/etcd.0.9.0/manifests/etcdoperator.v0.9.0.yaml
+++ b/bundles/etcd.0.9.0/manifests/etcdoperator.v0.9.0.yaml
@@ -1,0 +1,280 @@
+#! parse-kind: ClusterServiceVersion
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: etcdoperator.v0.9.0
+  namespace: placeholder
+  annotations:
+    tectonic-visibility: ocs
+    alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
+spec:
+  displayName: etcd
+  description: |
+    etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. It’s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader. Your applications can read and write data into etcd.
+    A simple use-case is to store database connection details or feature flags within etcd as key value pairs. These values can be watched, allowing your app to reconfigure itself when they change. Advanced uses take advantage of the consistency guarantees to implement database leader elections or do distributed locking across a cluster of workers.
+
+    _The etcd Open Cloud Service is Public Alpha. The goal before Beta is to fully implement backup features._
+
+    ### Reading and writing to etcd
+
+    Communicate with etcd though its command line utility `etcdctl` or with the API using the automatically generated Kubernetes Service.
+
+    [Read the complete guide to using the etcd Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/etcd-ocs.html)
+
+    ### Supported Features
+
+
+    **High availability**
+
+
+    Multiple instances of etcd are networked together and secured. Individual failures or networking issues are transparently handled to keep your cluster up and running.
+
+
+    **Automated updates**
+
+
+    Rolling out a new etcd version works like all Kubernetes rolling updates. Simply declare the desired version, and the etcd service starts a safe rolling update to the new version automatically.
+
+
+    **Backups included**
+
+
+    Coming soon, the ability to schedule backups to happen on or off cluster.
+  keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
+  version: 0.9.0
+  maturity: alpha
+  maintainers:
+  - name: CoreOS, Inc
+    email: support@coreos.com
+
+  provider:
+    name: CoreOS, Inc
+  labels:
+    alm-owner-etcd: etcdoperator
+    operated-by: etcdoperator
+  selector:
+    matchLabels:
+      alm-owner-etcd: etcdoperator
+      operated-by: etcdoperator
+  links:
+  - name: Blog
+    url: https://coreos.com/etcd
+  - name: Documentation
+    url: https://coreos.com/operators/etcd/docs/latest/
+  - name: etcd Operator Source Code
+    url: https://github.com/coreos/etcd-operator
+
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAOEAAADZCAYAAADWmle6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAEKlJREFUeNrsndt1GzkShmEev4sTgeiHfRYdgVqbgOgITEVgOgLTEQydwIiKwFQCayoCU6+7DyYjsBiBFyVVz7RkXvqCSxXw/+f04XjGQ6IL+FBVuL769euXgZ7r39f/G9iP0X+u/jWDNZzZdGI/Ftama1jjuV4BwmcNpbAf1Fgu+V/9YRvNAyzT2a59+/GT/3hnn5m16wKWedJrmOCxkYztx9Q+py/+E0GJxtJdReWfz+mxNt+QzS2Mc0AI+HbBBwj9QViKbH5t64DsP2fvmGXUkWU4WgO+Uve2YQzBUGd7r+zH2ZG/tiUQc4QxKwgbwFfVGwwmdLL5wH78aPC/ZBem9jJpCAX3xtcNASSNgJLzUPSQyjB1zQNl8IQJ9MIU4lx2+Jo72ysXYKl1HSzN02BMa/vbZ5xyNJIshJzwf3L0dQhJw4Sih/SFw9Tk8sVeghVPoefaIYCkMZCKbrcP9lnZuk0uPUjGE/KE8JQry7W2tgfuC3vXgvNV+qSQbyFtAtyWk7zWiYevvuUQ9QEQCvJ+5mmu6dTjz1zFHLFj8Eb87MtxaZh/IQFIHom+9vgTWwZxAQjT9X4vtbEVPojwjiV471s00mhAckpwGuCn1HtFtRDaSh6y9zsL+LNBvCG/24ThcxHObdlWc1v+VQJe8LcO0jwtuF8BwnAAUgP9M8JPU2Me+Oh12auPGT6fHuTePE3bLDy+x9pTLnhMn+07TQGh//Bz1iI0c6kvtqInjvPZcYR3KsPVmUsPYt9nFig9SCY8VQNhpPBzn952bbgcsk2EvM89wzh3UEffBbyPqvBUBYQ8ODGPFOLsa7RF096WJ69L+E4EmnpjWu5o4ChlKaRTKT39RMMaVPEQRsz/nIWlDN80chjdJlSd1l0pJCAMVZsniobQVuxceMM9OFoaMd9zqZtjMEYYDW38Drb8Y0DYPLShxn0pvIFuOSxd7YCPet9zk452wsh54FJoeN05hcgSQoG5RR0Qh9Q4E4VvL4wcZq8UACgaRFEQKgSwWrkr5WFnGxiHSutqJGlXjBgIOayhwYBTA0ER0oisIVSUV0AAMT0IASCUO4hRIQSAEECMCCEPwqyQA0JCQBzEGjWNAqHiUVAoXUWbvggOIQCEAOJzxTjoaQ4AIaE64/aZridUsBYUgkhB15oGg1DBIl8IqirYwV6hPSGBSFteMCUBSVXwfYixBmamRubeMyjzMJQBDDowE3OesDD+zwqFoDqiEwXoXJpljB+PvWJGy75BKF1FPxhKygJuqUdYQGlLxNEXkrYyjQ0GbaAwEnUIlLRNvVjQDYUAsJB0HKLE4y0AIpQNgCIhBIhQTgCKhZBBpAN/v6LtQI50JfUgYOnnjmLUFHKhjxbAmdTCaTiBm3ovLPqG2urWAij6im0Nd9aTN9ygLUEt9LgSRnohxUPIKxlGaE+/6Y7znFf0yX+GnkvFFWmarkab2o9PmTeq8sbd2a7DaysXz7i64VeznN4jCQhN9gdDbRiuWrfrsq0mHIrlaq+hlotCtd3Um9u0BYWY8y5D67wccJoZjFca7iUs9VqZcfsZwTd1sbWGG+OcYaTnPAP7rTQVVlM4Sg3oGvB1tmNh0t/HKXZ1jFoIMwCQjtqbhNxUmkGYqgZEDZP11HN/S3gAYRozf0l8C5kKEKUvW0t1IfeWG/5MwgheZTT1E0AEhDkAePQO+Ig2H3DncAkQM4cwUQCD530dU4B5Yvmi2LlDqXfWrxMCcMth51RToRMNUXFnfc2KJ0+Ryl0VNOUwlhh6NoxK5gnViTgQpUG4SqSyt5z3zRJpuKmt3Q1614QaCBPaN6je+2XiFcWAKOXcUfIYKRyL/1lb7pe5VxSxxjQ6hImshqGRt5GWZVKO6q2wHwujfwDtIvaIdexj8Cm8+a68EqMfox6x/voMouZF4dHnEGNeCDMwT6vdNfekH1MafMk4PI06YtqLVGl95aEM9Z5vAeCTOA++YLtoVJRrsqNCaJ6WRmkdYaNec5BT/lcTRMqrhmwfjbpkj55+OKp8IEbU/JLgPJE6Wa3TTe9sHS+ShVD5QIyqIxMEwKh12olC6mHIed5ewEop80CNlfIOADYOT2nd6ZXCop+Ebqchc0JqxKcKASxChycJgUh1rnHA5ow9eTrhqNI7JWiAYYwBGGdpyNLoGw0Pkh96h1BpHihyywtATDM/7Hk2fN9EnH8BgKJCU4ooBkbXFMZJiPbrOyecGl3zgQDQL4hk10IZiOe+5w99Q/gBAEIJgPhJM4QAEEoFREAIAAEiIASAkD8Qt4AQAEIAERAGFlX4CACKAXGVM4ivMwWwCLFAlyeoaa70QePKm5Dlp+/n+ye/5dYgva6YsUaVeMa+tzNFeJtWwc+udbJ0Fg399kLielQJ5Ze61c2+7ytA6EZetiPxZC6tj22yJCv6jUwOyj/zcbqAxOMyAKEbfeHtNa7DtYXptjsk2kJxR+eIeim/tHNofUKYy8DMrQcAKWz6brpvzyIAlpwPhQ49l6b7skJf5Z+YTOYQc4FwLDxvoTDwaygQK+U/kVr+ytSFBG01Q3gnJJR4cNiAhx4HDub8/b5DULXlj6SVZghFiE+LdvE9vo/o8Lp1RmH5hzm0T6wdbZ6n+D6i44zDRc3ln6CpAEJfXiRU45oqLz8gFAThWsh7ughrRibc0QynHgZpNJa/ENJ+loCwu/qOGnFIjYR/n7TfgycULhcQhu6VC+HfF+L3BoAQ4WiZTw1M+FPCnA2gKC6/FAhXgDC+ojQGh3NuWsvfF1L/D5ohlCKtl1j2ldu9a/nPAKFwN56Bst10zCG0CPleXN/zXPgHQZXaZaBgrbzyY5V/mUA+6F0hwtGN9rwu5DVZPuwWqfxdFz1LWbJ2lwKEa+0Qsm4Dl3fp+Pu0lV97PgwIPfSsS+UQhj5Oo+vvFULazRIQyvGEcxPuNLCth2MvFsrKn8UOilAQShkh7TTczYNMoS6OdP47msrPi82lXKGWhCdMZYS0bFy+vcnGAjP1CIfvgbKNA9glecEH9RD6Ol4wRuWyN/G9MHnksS6o/GPf5XcwNSUlHzQhDuAKtWJmkwKElU7lylP5rgIcsquh/FI8YZCDpkJBuE4FQm7Icw8N+SrUGaQKyi8FwiDt1ve5o+Vu7qYHy/psgK8cvh+FTYuO77bhEC7GuaPiys/L1X4IgXDL+e3M5+ovLxBy5VLuIebw1oqcHoPfoaMJUsHays878r8KbDc3xtPx/84gZPBG/JwaufrsY/SRG/OY3//8QMNdsvdZCFtbW6f8pFuf5bflILAlX7O+4fdfugKyFYS8T2zAsXthdG0VurPGKwI06oF5vkBgHWkNp6ry29+lsPZMU3vijnXFNmoclr+6+Ou/FIb8yb30sS8YGjmTqCLyQsi5N/6ZwKs0Yenj68pfPjF6N782Dp2FzV9CTyoSeY8mLK16qGxIkLI8oa1n8tz9juP40DlK0epxYEbojbq+9QfurBeVIlCO9D2396bxiV4lkYQ3hOAFw2pbhqMGISkkQOMcQ9EqhDmGZZdo92JC0YHRNTfoSg+5e0IT+opqCKHoIU+4ztQIgBD1EFNrQAgIpYSil9lDmPHqkROPt+JC6AgPquSuumJmg0YARVCuneDfvPVeJokZ6pIXDkNxQtGzTF9/BQjRG0tQznfb74RwCQghpALBtIQnfK4zhxdyQvVCUeknMIT3hLyY+T5jo0yABqKPQNpUNw/09tGZod5jgCaYFxyYvJcNPkv9eof+I3pnCFEHIETjSM8L9tHZHYCQT9PaZGycU6yg8S4akDnJ+P03L0+t23XGzCLzRgII/Wqa+fv/xlfvmKvMUOcOrlCDdoei1MGdZm6G5VEIfRzzjd4aQs69n699Rx7ewhvCGzr2gmTPs8zNsJOrXt24FbkhhOjCfT4ICA/rPbyhUy94Dks0gJCX1NzCZui9YUd3oei+c257TalFbgg19ILHrlrL2gvWgXAL26EX76gZTNASQnad8Ibwhl284NhgXpB0c+jKhWO3Ms1hP9ihJYB9eMF6qd1BCPk0qA1s+LimFIu7m4nsdQIzPK4VbQ8hYvrnuSH2G9b2ggP78QmWqBdF9Vx8SSY6QYdUW7BTA1schZATyhvY8lHvcRbNUS9YGFy2U+qmzh2YPVc0I7yAOFyHfRpyUwtCSzOdPXMHmz7qDIM0e0V2wZTEk+6Ym6N63eBLp/b5Bts+2cKCSJ/LuoZO3ANSiE5hKAZjnvNSS4931jcw9jpwT0feV/qSJ1pVtCyfHKDkvK8Ejx7pUxGh2xFNSwx8QTi2H9ceC0/nni64MS/5N5dG39pDqvRV+WgGk71c9VFXF9b+xYvOw/d61iv7m3MvEHryhvecwC52jSSx4VIIgwnMNT/UsTxIgpPt3K/ARj15CptwL3Zd/ceDSATj2DGQjbxgWwhdeMMte7zpy5On9vymRm/YxBYljGVjKWF9VJf7I1+sex3wY8w/V1QPTborW/72gkdsRDaZMJBdbdHIC7aCkAu9atlLbtnrzerMnyToDaGwelOnk3/hHSem/ZK7e/t7jeeR20LYBgqa8J80gS8jbwi5F02Uj1u2NYJxap8PLkJfLxA2hIJyvnHX/AfeEPLpBfe0uSFHbnXaea3Qd5d6HcpYZ8L6M7lnFwMQ3MNg+RxUR1+6AshtbsVgfXTEg1sIGax9UND2p7f270wdG3eK9gXVGHdw2k5sOyZv+Nbs39Z308XR9DqWb2J+PwKDhuKHPobfuXf7gnYGHdCs7bhDDadD4entDug7LWNsnRNW4mYqwJ9dk+GGSTPBiA2j0G8RWNM5upZtcG4/3vMfP7KnbK2egx6CCnDPhRn7NgD3cghLIad5WcM2SO38iqHvvMOosyeMpQ5zlVCaaj06GVs9xUbHdiKoqrHWgquFEFMWUEWfXUxJAML23hAHFOctmjZQffKD2pywkhtSGHKNtpitLroscAeE7kCkSsC60vxEl6yMtL9EL5HKGCMszU5bk8gdkklAyEn5FO0yK419rIxBOIqwFMooDE0tHEVYijAUECIshRCGIhxFWIowFJ5QkEYIS5PTJrUwNGlPyN6QQPyKtpuM1E/K5+YJDV/MiA3AaehzqgAm7QnZG9IGYKo8bHnSK7VblLL3hOwNHziPuEGOqE5brrdR6i+atCfckyeWD47HkAkepRGLY/e8A8J0gCwYSNypF08bBm+e6zVz2UL4AshhBUjML/rXLefqC82bcQFhGC9JDwZ1uuu+At0S5gCETYHsV4DUeD9fDN2Zfy5OXaW2zAwQygCzBLJ8cvaW5OXKC1FxfTggFAHmoAJnSiOw2wps9KwRWgJCLaEswaj5NqkLwAYIU4BxqTSXbHXpJdRMPZgAOiAMqABCNGYIEEJutEK5IUAIwYMDQgiCACEEAcJs1Vda7gGqDhCmoiEghAAhBAHCrKXVo2C1DCBMRlp37uMIEECoX7xrX3P5C9QiINSuIcoPAUI0YkAICLNWgfJDh4T9hH7zqYH9+JHAq7zBqWjwhPAicTVCVQJCNF50JghHocahKK0X/ZnQKyEkhSdUpzG8OgQI42qC94EQjsYLRSmH+pbgq73L6bYkeEJ4DYTYmeg1TOBFc/usTTp3V9DdEuXJ2xDCUbXhaXk0/kAYmBvuMB4qkC35E5e5AMKkwSQgyxufyuPy6fMMgAFCSI73LFXU/N8AmEL9X4ABACNSKMHAgb34AAAAAElFTkSuQmCC
+    mediatype: image/png
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+      - serviceAccountName: etcd-operator
+        rules:
+        - apiGroups:
+          - etcd.database.coreos.com
+          resources:
+          - etcdclusters
+          - etcdbackups
+          - etcdrestores
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          verbs:
+          - "*"
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+      deployments:
+      - name: etcd-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: etcd-operator-alm-owned
+          template:
+            metadata:
+              name: etcd-operator-alm-owned
+              labels:
+                name: etcd-operator-alm-owned
+            spec:
+              serviceAccountName: etcd-operator
+              containers:
+              - name: etcd-operator
+                command:
+                - etcd-operator
+                - --create-crd=false
+                image: quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8
+                env:
+                - name: MY_POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: MY_POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              - name: etcd-backup-operator
+                image: quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8
+                command:
+                - etcd-backup-operator
+                - --create-crd=false
+                env:
+                - name: MY_POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: MY_POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              - name: etcd-restore-operator
+                image: quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8
+                command:
+                - etcd-restore-operator
+                - --create-crd=false
+                env:
+                - name: MY_POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: MY_POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+  customresourcedefinitions:
+    owned:
+    - name: etcdclusters.etcd.database.coreos.com
+      version: v1beta2
+      kind: EtcdCluster
+      displayName: etcd Cluster
+      description: Represents a cluster of etcd nodes.
+      resources:
+        - kind: Service
+          version: v1
+        - kind: Pod
+          version: v1
+      specDescriptors:
+        - description: The desired number of member Pods for the etcd cluster.
+          displayName: Size
+          path: size
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+        - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+          displayName: Resource Requirements
+          path: pod.resources
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      statusDescriptors:
+        - description: The status of each of the member Pods for the etcd cluster.
+          displayName: Member Status
+          path: members
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+        - description: The service at which the running etcd cluster can be accessed.
+          displayName: Service
+          path: serviceName
+          x-descriptors:
+            - 'urn:alm:descriptor:io.kubernetes:Service'
+        - description: The current size of the etcd cluster.
+          displayName: Cluster Size
+          path: size
+        - description: The current version of the etcd cluster.
+          displayName: Current Version
+          path: currentVersion
+        - description: 'The target version of the etcd cluster, after upgrading.'
+          displayName: Target Version
+          path: targetVersion
+        - description: The current status of the etcd cluster.
+          displayName: Status
+          path: phase
+          x-descriptors:
+            - 'urn:alm:descriptor:io.kubernetes.phase'
+        - description: Explanation for the current status of the cluster.
+          displayName: Status Details
+          path: reason
+          x-descriptors:
+            - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+    - name: etcdbackups.etcd.database.coreos.com
+      version: v1beta2
+      kind: EtcdBackup
+      displayName: etcd Backup
+      description: Represents the intent to backup an etcd cluster.
+      specDescriptors:
+        - description: Specifies the endpoints of an etcd cluster.
+          displayName: etcd Endpoint(s)
+          path: etcdEndpoints
+          x-descriptors:
+            - 'urn:alm:descriptor:etcd:endpoint'
+        - description: The full AWS S3 path where the backup is saved.
+          displayName: S3 Path
+          path: s3.path
+          x-descriptors:
+            - 'urn:alm:descriptor:aws:s3:path'
+        - description: The name of the secret object that stores the AWS credential and config files.
+          displayName: AWS Secret
+          path: s3.awsSecret
+          x-descriptors:
+            - 'urn:alm:descriptor:io.kubernetes:Secret'
+      statusDescriptors:
+        - description: Indicates if the backup was successful.
+          displayName: Succeeded
+          path: succeeded
+          x-descriptors:
+            - 'urn:alm:descriptor:text'
+        - description: Indicates the reason for any backup related failures.
+          displayName: Reason
+          path: reason
+          x-descriptors:
+            - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+    - name: etcdrestores.etcd.database.coreos.com
+      version: v1beta2
+      kind: EtcdRestore
+      displayName: etcd Restore
+      description: Represents the intent to restore an etcd cluster from a backup.
+      specDescriptors:
+        - description: References the EtcdCluster which should be restored,
+          displayName: etcd Cluster
+          path: etcdCluster.name
+          x-descriptors:
+            - 'urn:alm:descriptor:io.kubernetes:EtcdCluster'
+            - 'urn:alm:descriptor:text'
+        - description: The full AWS S3 path where the backup is saved.
+          displayName: S3 Path
+          path: s3.path
+          x-descriptors:
+            - 'urn:alm:descriptor:aws:s3:path'
+        - description: The name of the secret object that stores the AWS credential and config files.
+          displayName: AWS Secret
+          path: s3.awsSecret
+          x-descriptors:
+            - 'urn:alm:descriptor:io.kubernetes:Secret'
+      statusDescriptors:
+        - description: Indicates if the restore was successful.
+          displayName: Succeeded
+          path: succeeded
+          x-descriptors:
+            - 'urn:alm:descriptor:text'
+        - description: Indicates the reason for any restore related failures.
+          displayName: Reason
+          path: reason
+          x-descriptors:
+            - 'urn:alm:descriptor:io.kubernetes.phase:reason'

--- a/bundles/etcd.0.9.0/manifests/etcdrestore.crd.yaml
+++ b/bundles/etcd.0.9.0/manifests/etcdrestore.crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: etcdrestores.etcd.database.coreos.com
+spec:
+  group: etcd.database.coreos.com
+  version: v1beta2
+  scope: Namespaced
+  names:
+    kind: EtcdRestore
+    listKind: EtcdRestoreList
+    plural: etcdrestores
+    singular: etcdrestore

--- a/bundles/etcd.0.9.0/metadata/annotations.yaml
+++ b/bundles/etcd.0.9.0/metadata/annotations.yaml
@@ -1,0 +1,4 @@
+annotations:
+  operators.operatorframework.io.bundle.package.v1: "etcd"
+  operators.operatorframework.io.bundle.channels.v1: "alpha,stable"
+  operators.operatorframework.io.bundle.channel.default.v1: "stable"

--- a/bundles/etcd.0.9.2/manifests/etcdbackup.crd.yaml
+++ b/bundles/etcd.0.9.2/manifests/etcdbackup.crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: etcdbackups.etcd.database.coreos.com
+spec:
+  group: etcd.database.coreos.com
+  version: v1beta2
+  scope: Namespaced
+  names:
+    kind: EtcdBackup
+    listKind: EtcdBackupList
+    plural: etcdbackups
+    singular: etcdbackup

--- a/bundles/etcd.0.9.2/manifests/etcdcluster.crd.yaml
+++ b/bundles/etcd.0.9.2/manifests/etcdcluster.crd.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: etcdclusters.etcd.database.coreos.com
+spec:
+  group: etcd.database.coreos.com
+  version: v1beta2
+  scope: Namespaced
+  names:
+    plural: etcdclusters
+    singular: etcdcluster
+    kind: EtcdCluster
+    listKind: EtcdClusterList
+    shortNames:
+      - etcdclus
+      - etcd

--- a/bundles/etcd.0.9.2/manifests/etcdoperator.v0.9.2.clusterserviceversion.yaml
+++ b/bundles/etcd.0.9.2/manifests/etcdoperator.v0.9.2.clusterserviceversion.yaml
@@ -1,0 +1,283 @@
+#! parse-kind: ClusterServiceVersion
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: etcdoperator.v0.9.2
+  namespace: placeholder
+  annotations:
+    tectonic-visibility: ocs
+    alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
+spec:
+  displayName: etcd
+  description: |
+    etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. It’s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader. Your applications can read and write data into etcd.
+    A simple use-case is to store database connection details or feature flags within etcd as key value pairs. These values can be watched, allowing your app to reconfigure itself when they change. Advanced uses take advantage of the consistency guarantees to implement database leader elections or do distributed locking across a cluster of workers.
+
+    _The etcd Open Cloud Service is Public Alpha. The goal before Beta is to fully implement backup features._
+
+    ### Reading and writing to etcd
+
+    Communicate with etcd though its command line utility `etcdctl` or with the API using the automatically generated Kubernetes Service.
+
+    [Read the complete guide to using the etcd Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/etcd-ocs.html)
+
+    ### Supported Features
+
+
+    **High availability**
+
+
+    Multiple instances of etcd are networked together and secured. Individual failures or networking issues are transparently handled to keep your cluster up and running.
+
+
+    **Automated updates**
+
+
+    Rolling out a new etcd version works like all Kubernetes rolling updates. Simply declare the desired version, and the etcd service starts a safe rolling update to the new version automatically.
+
+
+    **Backups included**
+
+
+    Coming soon, the ability to schedule backups to happen on or off cluster.
+  keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
+  version: 0.9.2
+  maturity: alpha
+  replaces: etcdoperator.v0.9.0
+  skips:
+  - etcdoperator.v0.9.1
+  maintainers:
+  - name: CoreOS, Inc
+    email: support@coreos.com
+
+  provider:
+    name: CoreOS, Inc
+  labels:
+    alm-owner-etcd: etcdoperator
+    operated-by: etcdoperator
+  selector:
+    matchLabels:
+      alm-owner-etcd: etcdoperator
+      operated-by: etcdoperator
+  links:
+  - name: Blog
+    url: https://coreos.com/etcd
+  - name: Documentation
+    url: https://coreos.com/operators/etcd/docs/latest/
+  - name: etcd Operator Source Code
+    url: https://github.com/coreos/etcd-operator
+
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAOEAAADZCAYAAADWmle6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAEKlJREFUeNrsndt1GzkShmEev4sTgeiHfRYdgVqbgOgITEVgOgLTEQydwIiKwFQCayoCU6+7DyYjsBiBFyVVz7RkXvqCSxXw/+f04XjGQ6IL+FBVuL769euXgZ7r39f/G9iP0X+u/jWDNZzZdGI/Ftama1jjuV4BwmcNpbAf1Fgu+V/9YRvNAyzT2a59+/GT/3hnn5m16wKWedJrmOCxkYztx9Q+py/+E0GJxtJdReWfz+mxNt+QzS2Mc0AI+HbBBwj9QViKbH5t64DsP2fvmGXUkWU4WgO+Uve2YQzBUGd7r+zH2ZG/tiUQc4QxKwgbwFfVGwwmdLL5wH78aPC/ZBem9jJpCAX3xtcNASSNgJLzUPSQyjB1zQNl8IQJ9MIU4lx2+Jo72ysXYKl1HSzN02BMa/vbZ5xyNJIshJzwf3L0dQhJw4Sih/SFw9Tk8sVeghVPoefaIYCkMZCKbrcP9lnZuk0uPUjGE/KE8JQry7W2tgfuC3vXgvNV+qSQbyFtAtyWk7zWiYevvuUQ9QEQCvJ+5mmu6dTjz1zFHLFj8Eb87MtxaZh/IQFIHom+9vgTWwZxAQjT9X4vtbEVPojwjiV471s00mhAckpwGuCn1HtFtRDaSh6y9zsL+LNBvCG/24ThcxHObdlWc1v+VQJe8LcO0jwtuF8BwnAAUgP9M8JPU2Me+Oh12auPGT6fHuTePE3bLDy+x9pTLnhMn+07TQGh//Bz1iI0c6kvtqInjvPZcYR3KsPVmUsPYt9nFig9SCY8VQNhpPBzn952bbgcsk2EvM89wzh3UEffBbyPqvBUBYQ8ODGPFOLsa7RF096WJ69L+E4EmnpjWu5o4ChlKaRTKT39RMMaVPEQRsz/nIWlDN80chjdJlSd1l0pJCAMVZsniobQVuxceMM9OFoaMd9zqZtjMEYYDW38Drb8Y0DYPLShxn0pvIFuOSxd7YCPet9zk452wsh54FJoeN05hcgSQoG5RR0Qh9Q4E4VvL4wcZq8UACgaRFEQKgSwWrkr5WFnGxiHSutqJGlXjBgIOayhwYBTA0ER0oisIVSUV0AAMT0IASCUO4hRIQSAEECMCCEPwqyQA0JCQBzEGjWNAqHiUVAoXUWbvggOIQCEAOJzxTjoaQ4AIaE64/aZridUsBYUgkhB15oGg1DBIl8IqirYwV6hPSGBSFteMCUBSVXwfYixBmamRubeMyjzMJQBDDowE3OesDD+zwqFoDqiEwXoXJpljB+PvWJGy75BKF1FPxhKygJuqUdYQGlLxNEXkrYyjQ0GbaAwEnUIlLRNvVjQDYUAsJB0HKLE4y0AIpQNgCIhBIhQTgCKhZBBpAN/v6LtQI50JfUgYOnnjmLUFHKhjxbAmdTCaTiBm3ovLPqG2urWAij6im0Nd9aTN9ygLUEt9LgSRnohxUPIKxlGaE+/6Y7znFf0yX+GnkvFFWmarkab2o9PmTeq8sbd2a7DaysXz7i64VeznN4jCQhN9gdDbRiuWrfrsq0mHIrlaq+hlotCtd3Um9u0BYWY8y5D67wccJoZjFca7iUs9VqZcfsZwTd1sbWGG+OcYaTnPAP7rTQVVlM4Sg3oGvB1tmNh0t/HKXZ1jFoIMwCQjtqbhNxUmkGYqgZEDZP11HN/S3gAYRozf0l8C5kKEKUvW0t1IfeWG/5MwgheZTT1E0AEhDkAePQO+Ig2H3DncAkQM4cwUQCD530dU4B5Yvmi2LlDqXfWrxMCcMth51RToRMNUXFnfc2KJ0+Ryl0VNOUwlhh6NoxK5gnViTgQpUG4SqSyt5z3zRJpuKmt3Q1614QaCBPaN6je+2XiFcWAKOXcUfIYKRyL/1lb7pe5VxSxxjQ6hImshqGRt5GWZVKO6q2wHwujfwDtIvaIdexj8Cm8+a68EqMfox6x/voMouZF4dHnEGNeCDMwT6vdNfekH1MafMk4PI06YtqLVGl95aEM9Z5vAeCTOA++YLtoVJRrsqNCaJ6WRmkdYaNec5BT/lcTRMqrhmwfjbpkj55+OKp8IEbU/JLgPJE6Wa3TTe9sHS+ShVD5QIyqIxMEwKh12olC6mHIed5ewEop80CNlfIOADYOT2nd6ZXCop+Ebqchc0JqxKcKASxChycJgUh1rnHA5ow9eTrhqNI7JWiAYYwBGGdpyNLoGw0Pkh96h1BpHihyywtATDM/7Hk2fN9EnH8BgKJCU4ooBkbXFMZJiPbrOyecGl3zgQDQL4hk10IZiOe+5w99Q/gBAEIJgPhJM4QAEEoFREAIAAEiIASAkD8Qt4AQAEIAERAGFlX4CACKAXGVM4ivMwWwCLFAlyeoaa70QePKm5Dlp+/n+ye/5dYgva6YsUaVeMa+tzNFeJtWwc+udbJ0Fg399kLielQJ5Ze61c2+7ytA6EZetiPxZC6tj22yJCv6jUwOyj/zcbqAxOMyAKEbfeHtNa7DtYXptjsk2kJxR+eIeim/tHNofUKYy8DMrQcAKWz6brpvzyIAlpwPhQ49l6b7skJf5Z+YTOYQc4FwLDxvoTDwaygQK+U/kVr+ytSFBG01Q3gnJJR4cNiAhx4HDub8/b5DULXlj6SVZghFiE+LdvE9vo/o8Lp1RmH5hzm0T6wdbZ6n+D6i44zDRc3ln6CpAEJfXiRU45oqLz8gFAThWsh7ughrRibc0QynHgZpNJa/ENJ+loCwu/qOGnFIjYR/n7TfgycULhcQhu6VC+HfF+L3BoAQ4WiZTw1M+FPCnA2gKC6/FAhXgDC+ojQGh3NuWsvfF1L/D5ohlCKtl1j2ldu9a/nPAKFwN56Bst10zCG0CPleXN/zXPgHQZXaZaBgrbzyY5V/mUA+6F0hwtGN9rwu5DVZPuwWqfxdFz1LWbJ2lwKEa+0Qsm4Dl3fp+Pu0lV97PgwIPfSsS+UQhj5Oo+vvFULazRIQyvGEcxPuNLCth2MvFsrKn8UOilAQShkh7TTczYNMoS6OdP47msrPi82lXKGWhCdMZYS0bFy+vcnGAjP1CIfvgbKNA9glecEH9RD6Ol4wRuWyN/G9MHnksS6o/GPf5XcwNSUlHzQhDuAKtWJmkwKElU7lylP5rgIcsquh/FI8YZCDpkJBuE4FQm7Icw8N+SrUGaQKyi8FwiDt1ve5o+Vu7qYHy/psgK8cvh+FTYuO77bhEC7GuaPiys/L1X4IgXDL+e3M5+ovLxBy5VLuIebw1oqcHoPfoaMJUsHays878r8KbDc3xtPx/84gZPBG/JwaufrsY/SRG/OY3//8QMNdsvdZCFtbW6f8pFuf5bflILAlX7O+4fdfugKyFYS8T2zAsXthdG0VurPGKwI06oF5vkBgHWkNp6ry29+lsPZMU3vijnXFNmoclr+6+Ou/FIb8yb30sS8YGjmTqCLyQsi5N/6ZwKs0Yenj68pfPjF6N782Dp2FzV9CTyoSeY8mLK16qGxIkLI8oa1n8tz9juP40DlK0epxYEbojbq+9QfurBeVIlCO9D2396bxiV4lkYQ3hOAFw2pbhqMGISkkQOMcQ9EqhDmGZZdo92JC0YHRNTfoSg+5e0IT+opqCKHoIU+4ztQIgBD1EFNrQAgIpYSil9lDmPHqkROPt+JC6AgPquSuumJmg0YARVCuneDfvPVeJokZ6pIXDkNxQtGzTF9/BQjRG0tQznfb74RwCQghpALBtIQnfK4zhxdyQvVCUeknMIT3hLyY+T5jo0yABqKPQNpUNw/09tGZod5jgCaYFxyYvJcNPkv9eof+I3pnCFEHIETjSM8L9tHZHYCQT9PaZGycU6yg8S4akDnJ+P03L0+t23XGzCLzRgII/Wqa+fv/xlfvmKvMUOcOrlCDdoei1MGdZm6G5VEIfRzzjd4aQs69n699Rx7ewhvCGzr2gmTPs8zNsJOrXt24FbkhhOjCfT4ICA/rPbyhUy94Dks0gJCX1NzCZui9YUd3oei+c257TalFbgg19ILHrlrL2gvWgXAL26EX76gZTNASQnad8Ibwhl284NhgXpB0c+jKhWO3Ms1hP9ihJYB9eMF6qd1BCPk0qA1s+LimFIu7m4nsdQIzPK4VbQ8hYvrnuSH2G9b2ggP78QmWqBdF9Vx8SSY6QYdUW7BTA1schZATyhvY8lHvcRbNUS9YGFy2U+qmzh2YPVc0I7yAOFyHfRpyUwtCSzOdPXMHmz7qDIM0e0V2wZTEk+6Ym6N63eBLp/b5Bts+2cKCSJ/LuoZO3ANSiE5hKAZjnvNSS4931jcw9jpwT0feV/qSJ1pVtCyfHKDkvK8Ejx7pUxGh2xFNSwx8QTi2H9ceC0/nni64MS/5N5dG39pDqvRV+WgGk71c9VFXF9b+xYvOw/d61iv7m3MvEHryhvecwC52jSSx4VIIgwnMNT/UsTxIgpPt3K/ARj15CptwL3Zd/ceDSATj2DGQjbxgWwhdeMMte7zpy5On9vymRm/YxBYljGVjKWF9VJf7I1+sex3wY8w/V1QPTborW/72gkdsRDaZMJBdbdHIC7aCkAu9atlLbtnrzerMnyToDaGwelOnk3/hHSem/ZK7e/t7jeeR20LYBgqa8J80gS8jbwi5F02Uj1u2NYJxap8PLkJfLxA2hIJyvnHX/AfeEPLpBfe0uSFHbnXaea3Qd5d6HcpYZ8L6M7lnFwMQ3MNg+RxUR1+6AshtbsVgfXTEg1sIGax9UND2p7f270wdG3eK9gXVGHdw2k5sOyZv+Nbs39Z308XR9DqWb2J+PwKDhuKHPobfuXf7gnYGHdCs7bhDDadD4entDug7LWNsnRNW4mYqwJ9dk+GGSTPBiA2j0G8RWNM5upZtcG4/3vMfP7KnbK2egx6CCnDPhRn7NgD3cghLIad5WcM2SO38iqHvvMOosyeMpQ5zlVCaaj06GVs9xUbHdiKoqrHWgquFEFMWUEWfXUxJAML23hAHFOctmjZQffKD2pywkhtSGHKNtpitLroscAeE7kCkSsC60vxEl6yMtL9EL5HKGCMszU5bk8gdkklAyEn5FO0yK419rIxBOIqwFMooDE0tHEVYijAUECIshRCGIhxFWIowFJ5QkEYIS5PTJrUwNGlPyN6QQPyKtpuM1E/K5+YJDV/MiA3AaehzqgAm7QnZG9IGYKo8bHnSK7VblLL3hOwNHziPuEGOqE5brrdR6i+atCfckyeWD47HkAkepRGLY/e8A8J0gCwYSNypF08bBm+e6zVz2UL4AshhBUjML/rXLefqC82bcQFhGC9JDwZ1uuu+At0S5gCETYHsV4DUeD9fDN2Zfy5OXaW2zAwQygCzBLJ8cvaW5OXKC1FxfTggFAHmoAJnSiOw2wps9KwRWgJCLaEswaj5NqkLwAYIU4BxqTSXbHXpJdRMPZgAOiAMqABCNGYIEEJutEK5IUAIwYMDQgiCACEEAcJs1Vda7gGqDhCmoiEghAAhBAHCrKXVo2C1DCBMRlp37uMIEECoX7xrX3P5C9QiINSuIcoPAUI0YkAICLNWgfJDh4T9hH7zqYH9+JHAq7zBqWjwhPAicTVCVQJCNF50JghHocahKK0X/ZnQKyEkhSdUpzG8OgQI42qC94EQjsYLRSmH+pbgq73L6bYkeEJ4DYTYmeg1TOBFc/usTTp3V9DdEuXJ2xDCUbXhaXk0/kAYmBvuMB4qkC35E5e5AMKkwSQgyxufyuPy6fMMgAFCSI73LFXU/N8AmEL9X4ABACNSKMHAgb34AAAAAElFTkSuQmCC
+    mediatype: image/png
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+      - serviceAccountName: etcd-operator
+        rules:
+        - apiGroups:
+          - etcd.database.coreos.com
+          resources:
+          - etcdclusters
+          - etcdbackups
+          - etcdrestores
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          verbs:
+          - "*"
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+      deployments:
+      - name: etcd-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: etcd-operator-alm-owned
+          template:
+            metadata:
+              name: etcd-operator-alm-owned
+              labels:
+                name: etcd-operator-alm-owned
+            spec:
+              serviceAccountName: etcd-operator
+              containers:
+              - name: etcd-operator
+                command:
+                - etcd-operator
+                - --create-crd=false
+                image: quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2
+                env:
+                - name: MY_POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: MY_POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              - name: etcd-backup-operator
+                image: quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2
+                command:
+                - etcd-backup-operator
+                - --create-crd=false
+                env:
+                - name: MY_POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: MY_POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              - name: etcd-restore-operator
+                image: quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2
+                command:
+                - etcd-restore-operator
+                - --create-crd=false
+                env:
+                - name: MY_POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: MY_POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+  customresourcedefinitions:
+    owned:
+    - name: etcdclusters.etcd.database.coreos.com
+      version: v1beta2
+      kind: EtcdCluster
+      displayName: etcd Cluster
+      description: Represents a cluster of etcd nodes.
+      resources:
+        - kind: Service
+          version: v1
+        - kind: Pod
+          version: v1
+      specDescriptors:
+        - description: The desired number of member Pods for the etcd cluster.
+          displayName: Size
+          path: size
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+        - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+          displayName: Resource Requirements
+          path: pod.resources
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      statusDescriptors:
+        - description: The status of each of the member Pods for the etcd cluster.
+          displayName: Member Status
+          path: members
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+        - description: The service at which the running etcd cluster can be accessed.
+          displayName: Service
+          path: serviceName
+          x-descriptors:
+            - 'urn:alm:descriptor:io.kubernetes:Service'
+        - description: The current size of the etcd cluster.
+          displayName: Cluster Size
+          path: size
+        - description: The current version of the etcd cluster.
+          displayName: Current Version
+          path: currentVersion
+        - description: 'The target version of the etcd cluster, after upgrading.'
+          displayName: Target Version
+          path: targetVersion
+        - description: The current status of the etcd cluster.
+          displayName: Status
+          path: phase
+          x-descriptors:
+            - 'urn:alm:descriptor:io.kubernetes.phase'
+        - description: Explanation for the current status of the cluster.
+          displayName: Status Details
+          path: reason
+          x-descriptors:
+            - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+    - name: etcdbackups.etcd.database.coreos.com
+      version: v1beta2
+      kind: EtcdBackup
+      displayName: etcd Backup
+      description: Represents the intent to backup an etcd cluster.
+      specDescriptors:
+        - description: Specifies the endpoints of an etcd cluster.
+          displayName: etcd Endpoint(s)
+          path: etcdEndpoints
+          x-descriptors:
+            - 'urn:alm:descriptor:etcd:endpoint'
+        - description: The full AWS S3 path where the backup is saved.
+          displayName: S3 Path
+          path: s3.path
+          x-descriptors:
+            - 'urn:alm:descriptor:aws:s3:path'
+        - description: The name of the secret object that stores the AWS credential and config files.
+          displayName: AWS Secret
+          path: s3.awsSecret
+          x-descriptors:
+            - 'urn:alm:descriptor:io.kubernetes:Secret'
+      statusDescriptors:
+        - description: Indicates if the backup was successful.
+          displayName: Succeeded
+          path: succeeded
+          x-descriptors:
+            - 'urn:alm:descriptor:text'
+        - description: Indicates the reason for any backup related failures.
+          displayName: Reason
+          path: reason
+          x-descriptors:
+            - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+    - name: etcdrestores.etcd.database.coreos.com
+      version: v1beta2
+      kind: EtcdRestore
+      displayName: etcd Restore
+      description: Represents the intent to restore an etcd cluster from a backup.
+      specDescriptors:
+        - description: References the EtcdCluster which should be restored,
+          displayName: etcd Cluster
+          path: etcdCluster.name
+          x-descriptors:
+            - 'urn:alm:descriptor:io.kubernetes:EtcdCluster'
+            - 'urn:alm:descriptor:text'
+        - description: The full AWS S3 path where the backup is saved.
+          displayName: S3 Path
+          path: s3.path
+          x-descriptors:
+            - 'urn:alm:descriptor:aws:s3:path'
+        - description: The name of the secret object that stores the AWS credential and config files.
+          displayName: AWS Secret
+          path: s3.awsSecret
+          x-descriptors:
+            - 'urn:alm:descriptor:io.kubernetes:Secret'
+      statusDescriptors:
+        - description: Indicates if the restore was successful.
+          displayName: Succeeded
+          path: succeeded
+          x-descriptors:
+            - 'urn:alm:descriptor:text'
+        - description: Indicates the reason for any restore related failures.
+          displayName: Reason
+          path: reason
+          x-descriptors:
+            - 'urn:alm:descriptor:io.kubernetes.phase:reason'

--- a/bundles/etcd.0.9.2/manifests/etcdrestore.crd.yaml
+++ b/bundles/etcd.0.9.2/manifests/etcdrestore.crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: etcdrestores.etcd.database.coreos.com
+spec:
+  group: etcd.database.coreos.com
+  version: v1beta2
+  scope: Namespaced
+  names:
+    kind: EtcdRestore
+    listKind: EtcdRestoreList
+    plural: etcdrestores
+    singular: etcdrestore

--- a/bundles/etcd.0.9.2/metadata/annotations.yaml
+++ b/bundles/etcd.0.9.2/metadata/annotations.yaml
@@ -1,0 +1,4 @@
+annotations:
+  operators.operatorframework.io.bundle.package.v1: "etcd"
+  operators.operatorframework.io.bundle.channels.v1: "alpha,stable"
+  operators.operatorframework.io.bundle.channel.default.v1: "alpha"

--- a/bundles/prometheus.0.14.0/manifests/alertmanager.crd.yaml
+++ b/bundles/prometheus.0.14.0/manifests/alertmanager.crd.yaml
@@ -1,0 +1,2398 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: alertmanagers.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    kind: Alertmanager
+    plural: alertmanagers
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: 'Specification of the desired behavior of the Alertmanager
+            cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          properties:
+            affinity:
+              description: Affinity is a group of affinity scheduling rules.
+              properties:
+                nodeAffinity:
+                  description: Node affinity is a group of node affinity scheduling
+                    rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node matches the corresponding matchExpressions; the
+                        node(s) with the highest sum are the most preferred.
+                      items:
+                        description: An empty preferred scheduling term matches all
+                          objects with implicit weight 0 (i.e. it's a no-op). A null
+                          preferred scheduling term matches no objects (i.e. is also
+                          a no-op).
+                        properties:
+                          preference:
+                            description: A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The
+                              TopologySelectorTerm type implements a subset of the
+                              NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                          weight:
+                            description: Weight associated with matching the corresponding
+                              nodeSelectorTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - preference
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: A node selector represents the union of the results
+                        of one or more label queries over a set of nodes; that is,
+                        it represents the OR of the selectors represented by the node
+                        selector terms.
+                      properties:
+                        nodeSelectorTerms:
+                          description: Required. A list of node selector terms. The
+                            terms are ORed.
+                          items:
+                            description: A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The
+                              TopologySelectorTerm type implements a subset of the
+                              NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                          type: array
+                      required:
+                      - nodeSelectorTerms
+                podAffinity:
+                  description: Pod affinity is a group of inter pod affinity scheduling
+                    rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node has pods which matches the corresponding podAffinityTerm;
+                        the node(s) with the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label selector is a label query over
+                                  a set of resources. The result of matchLabels and
+                                  matchExpressions are ANDed. An empty label selector
+                                  matches all objects. A null label selector matches
+                                  no objects.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                    type: array
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - podAffinityTerm
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to a pod label update), the system may or may not
+                        try to eventually evict the pod from its node. When there
+                        are multiple elements, the lists of nodes corresponding to
+                        each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label selector is a label query over a
+                              set of resources. The result of matchLabels and matchExpressions
+                              are ANDed. An empty label selector matches all objects.
+                              A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchLabels:
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                      type: array
+                podAntiAffinity:
+                  description: Pod anti affinity is a group of inter pod anti affinity
+                    scheduling rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the anti-affinity expressions specified by this
+                        field, but it may choose a node that violates one or more
+                        of the expressions. The node that is most preferred is the
+                        one with the greatest sum of weights, i.e. for each node that
+                        meets all of the scheduling requirements (resource request,
+                        requiredDuringScheduling anti-affinity expressions, etc.),
+                        compute a sum by iterating through the elements of this field
+                        and adding "weight" to the sum if the node has pods which
+                        matches the corresponding podAffinityTerm; the node(s) with
+                        the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label selector is a label query over
+                                  a set of resources. The result of matchLabels and
+                                  matchExpressions are ANDed. An empty label selector
+                                  matches all objects. A null label selector matches
+                                  no objects.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                    type: array
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - podAffinityTerm
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the anti-affinity requirements specified by
+                        this field are not met at scheduling time, the pod will not
+                        be scheduled onto the node. If the anti-affinity requirements
+                        specified by this field cease to be met at some point during
+                        pod execution (e.g. due to a pod label update), the system
+                        may or may not try to eventually evict the pod from its node.
+                        When there are multiple elements, the lists of nodes corresponding
+                        to each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label selector is a label query over a
+                              set of resources. The result of matchLabels and matchExpressions
+                              are ANDed. An empty label selector matches all objects.
+                              A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchLabels:
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                      type: array
+            baseImage:
+              description: Base image that is used to deploy pods, without tag.
+              type: string
+            containers:
+              description: Containers allows injecting additional containers. This
+                is meant to allow adding an authentication proxy to an Alertmanager
+                pod.
+              items:
+                description: A single application container that you want to run within
+                  a pod.
+                properties:
+                  args:
+                    description: 'Arguments to the entrypoint. The docker image''s
+                      CMD is used if this is not provided. Variable references $(VAR_NAME)
+                      are expanded using the container''s environment. If a variable
+                      cannot be resolved, the reference in the input string will be
+                      unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                      $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                      regardless of whether the variable exists or not. Cannot be
+                      updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    description: 'Entrypoint array. Not executed within a shell. The
+                      docker image''s ENTRYPOINT is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container''s
+                      environment. If a variable cannot be resolved, the reference
+                      in the input string will be unchanged. The $(VAR_NAME) syntax
+                      can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                      will never be expanded, regardless of whether the variable exists
+                      or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: List of environment variables to set in the container.
+                      Cannot be updated.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: EnvVarSource represents a source for the value
+                            of an EnvVar.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key from a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or it's
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                            fieldRef:
+                              description: ObjectFieldSelector selects an APIVersioned
+                                field of an object.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                            resourceFieldRef:
+                              description: ResourceFieldSelector represents container
+                                resources (cpu, memory) and their output format
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor: {}
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                            secretKeyRef:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or it's
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                      required:
+                      - name
+                    type: array
+                  envFrom:
+                    description: List of sources to populate environment variables
+                      in the container. The keys defined within a source must be a
+                      C_IDENTIFIER. All invalid keys will be reported as an event
+                      when the container is starting. When a key exists in multiple
+                      sources, the value associated with the last source will take
+                      precedence. Values defined by an Env with a duplicate key will
+                      take precedence. Cannot be updated.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: |-
+                            ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+
+                            The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: |-
+                            SecretEnvSource selects a Secret to populate the environment variables with.
+
+                            The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                    type: array
+                  image:
+                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                      This field is optional to allow higher level config management
+                      to default or override container images in workload controllers
+                      like Deployments and StatefulSets.'
+                    type: string
+                  imagePullPolicy:
+                    description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                      Defaults to Always if :latest tag is specified, or IfNotPresent
+                      otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                    type: string
+                  lifecycle:
+                    description: Lifecycle describes actions that the management system
+                      should take in response to container lifecycle events. For the
+                      PostStart and PreStop lifecycle handlers, management of the
+                      container blocks until the action is complete, unless the container
+                      process fails, in which case the handler is aborted.
+                    properties:
+                      postStart:
+                        description: Handler defines a specific action that should
+                          be taken
+                        properties:
+                          exec:
+                            description: ExecAction describes a "run in container"
+                              action.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                          httpGet:
+                            description: HTTPGetAction describes an action based on
+                              HTTP Get requests.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                          tcpSocket:
+                            description: TCPSocketAction describes an action based
+                              on opening a socket
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                            required:
+                            - port
+                      preStop:
+                        description: Handler defines a specific action that should
+                          be taken
+                        properties:
+                          exec:
+                            description: ExecAction describes a "run in container"
+                              action.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                          httpGet:
+                            description: HTTPGetAction describes an action based on
+                              HTTP Get requests.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                          tcpSocket:
+                            description: TCPSocketAction describes an action based
+                              on opening a socket
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                            required:
+                            - port
+                  livenessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: ExecAction describes a "run in container" action.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGetAction describes an action based on HTTP
+                          Get requests.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocketAction describes an action based on
+                          opening a socket
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                        required:
+                        - port
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                  name:
+                    description: Name of the container specified as a DNS_LABEL. Each
+                      container in a pod must have a unique name (DNS_LABEL). Cannot
+                      be updated.
+                    type: string
+                  ports:
+                    description: List of ports to expose from the container. Exposing
+                      a port here gives the system additional information about the
+                      network connections a container uses, but is primarily informational.
+                      Not specifying a port here DOES NOT prevent that port from being
+                      exposed. Any port which is listening on the default "0.0.0.0"
+                      address inside a container will be accessible from the network.
+                      Cannot be updated.
+                    items:
+                      description: ContainerPort represents a network port in a single
+                        container.
+                      properties:
+                        containerPort:
+                          description: Number of port to expose on the pod's IP address.
+                            This must be a valid port number, 0 < x < 65536.
+                          format: int32
+                          type: integer
+                        hostIP:
+                          description: What host IP to bind the external port to.
+                          type: string
+                        hostPort:
+                          description: Number of port to expose on the host. If specified,
+                            this must be a valid port number, 0 < x < 65536. If HostNetwork
+                            is specified, this must match ContainerPort. Most containers
+                            do not need this.
+                          format: int32
+                          type: integer
+                        name:
+                          description: If specified, this must be an IANA_SVC_NAME
+                            and unique within the pod. Each named port in a pod must
+                            have a unique name. Name for the port that can be referred
+                            to by services.
+                          type: string
+                        protocol:
+                          description: Protocol for port. Must be UDP or TCP. Defaults
+                            to "TCP".
+                          type: string
+                      required:
+                      - containerPort
+                    type: array
+                  readinessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: ExecAction describes a "run in container" action.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGetAction describes an action based on HTTP
+                          Get requests.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocketAction describes an action based on
+                          opening a socket
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                        required:
+                        - port
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                  securityContext:
+                    description: SecurityContext holds security configuration that
+                      will be applied to a container. Some fields are present in both
+                      SecurityContext and PodSecurityContext.  When both are set,
+                      the values in SecurityContext take precedence.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: Adds and removes POSIX capabilities from running
+                          containers.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              type: string
+                            type: array
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: SELinuxOptions are the labels to be applied to
+                          the container
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                  stdin:
+                    description: Whether this container should allocate a buffer for
+                      stdin in the container runtime. If this is not set, reads from
+                      stdin in the container will always result in EOF. Default is
+                      false.
+                    type: boolean
+                  stdinOnce:
+                    description: Whether the container runtime should close the stdin
+                      channel after it has been opened by a single attach. When stdin
+                      is true the stdin stream will remain open across multiple attach
+                      sessions. If stdinOnce is set to true, stdin is opened on container
+                      start, is empty until the first client attaches to stdin, and
+                      then remains open and accepts data until the client disconnects,
+                      at which time stdin is closed and remains closed until the container
+                      is restarted. If this flag is false, a container processes that
+                      reads from stdin will never receive an EOF. Default is false
+                    type: boolean
+                  terminationMessagePath:
+                    description: 'Optional: Path at which the file to which the container''s
+                      termination message will be written is mounted into the container''s
+                      filesystem. Message written is intended to be brief final status,
+                      such as an assertion failure message. Will be truncated by the
+                      node if greater than 4096 bytes. The total message length across
+                      all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                      Cannot be updated.'
+                    type: string
+                  terminationMessagePolicy:
+                    description: Indicate how the termination message should be populated.
+                      File will use the contents of terminationMessagePath to populate
+                      the container status message on both success and failure. FallbackToLogsOnError
+                      will use the last chunk of container log output if the termination
+                      message file is empty and the container exited with an error.
+                      The log output is limited to 2048 bytes or 80 lines, whichever
+                      is smaller. Defaults to File. Cannot be updated.
+                    type: string
+                  tty:
+                    description: Whether this container should allocate a TTY for
+                      itself, also requires 'stdin' to be true. Default is false.
+                    type: boolean
+                  volumeDevices:
+                    description: volumeDevices is the list of block devices to be
+                      used by the container. This is an alpha feature and may change
+                      in the future.
+                    items:
+                      description: volumeDevice describes a mapping of a raw block
+                        device within a container.
+                      properties:
+                        devicePath:
+                          description: devicePath is the path inside of the container
+                            that the device will be mapped to.
+                          type: string
+                        name:
+                          description: name must match the name of a persistentVolumeClaim
+                            in the pod
+                          type: string
+                      required:
+                      - name
+                      - devicePath
+                    type: array
+                  volumeMounts:
+                    description: Pod volumes to mount into the container's filesystem.
+                      Cannot be updated.
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: Path within the container at which the volume
+                            should be mounted.  Must not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: mountPropagation determines how mounts are
+                            propagated from the host to container and the other way
+                            around. When not set, MountPropagationHostToContainer
+                            is used. This field is beta in 1.10.
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: Mounted read-only if true, read-write otherwise
+                            (false or unspecified). Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: Path within the volume from which the container's
+                            volume should be mounted. Defaults to "" (volume's root).
+                          type: string
+                      required:
+                      - name
+                      - mountPath
+                    type: array
+                  workingDir:
+                    description: Container's working directory. If not specified,
+                      the container runtime's default will be used, which might be
+                      configured in the container image. Cannot be updated.
+                    type: string
+                required:
+                - name
+              type: array
+            externalUrl:
+              description: The external URL the Alertmanager instances will be available
+                under. This is necessary to generate correct URLs. This is necessary
+                if Alertmanager is not served from root of a DNS name.
+              type: string
+            imagePullSecrets:
+              description: An optional list of references to secrets in the same namespace
+                to use for pulling prometheus and alertmanager images from registries
+                see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
+              items:
+                description: LocalObjectReference contains enough information to let
+                  you locate the referenced object inside the same namespace.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+              type: array
+            listenLocal:
+              description: ListenLocal makes the Alertmanager server listen on loopback,
+                so that it does not bind against the Pod IP. Note this is only for
+                the Alertmanager UI, not the gossip communication.
+              type: boolean
+            logLevel:
+              description: Log level for Alertmanager to be configured with.
+              type: string
+            nodeSelector:
+              description: Define which Nodes the Pods are scheduled on.
+              type: object
+            paused:
+              description: If set to true all actions on the underlaying managed objects
+                are not goint to be performed, except for delete actions.
+              type: boolean
+            podMetadata:
+              description: ObjectMeta is metadata that all persisted resources must
+                have, which includes all objects users must create.
+              properties:
+                annotations:
+                  description: 'Annotations is an unstructured key value map stored
+                    with a resource that may be set by external tools to store and
+                    retrieve arbitrary metadata. They are not queryable and should
+                    be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                  type: object
+                clusterName:
+                  description: The name of the cluster which the object belongs to.
+                    This is used to distinguish resources with same name and namespace
+                    in different clusters. This field is not set anywhere right now
+                    and apiserver is going to ignore it if set in create or update
+                    request.
+                  type: string
+                creationTimestamp:
+                  description: Time is a wrapper around time.Time which supports correct
+                    marshaling to YAML and JSON.  Wrappers are provided for many of
+                    the factory methods that the time package offers.
+                  format: date-time
+                  type: string
+                deletionGracePeriodSeconds:
+                  description: Number of seconds allowed for this object to gracefully
+                    terminate before it will be removed from the system. Only set
+                    when deletionTimestamp is also set. May only be shortened. Read-only.
+                  format: int64
+                  type: integer
+                deletionTimestamp:
+                  description: Time is a wrapper around time.Time which supports correct
+                    marshaling to YAML and JSON.  Wrappers are provided for many of
+                    the factory methods that the time package offers.
+                  format: date-time
+                  type: string
+                finalizers:
+                  description: Must be empty before the object is deleted from the
+                    registry. Each entry is an identifier for the responsible component
+                    that will remove the entry from the list. If the deletionTimestamp
+                    of the object is non-nil, entries in this list can only be removed.
+                  items:
+                    type: string
+                  type: array
+                generateName:
+                  description: |-
+                    GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+                    If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
+                    Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                  type: string
+                generation:
+                  description: A sequence number representing a specific generation
+                    of the desired state. Populated by the system. Read-only.
+                  format: int64
+                  type: integer
+                initializers:
+                  description: Initializers tracks the progress of initialization.
+                  properties:
+                    pending:
+                      description: Pending is a list of initializers that must execute
+                        in order before this object is visible. When the last pending
+                        initializer is removed, and no failing result is set, the
+                        initializers struct will be set to nil and the object is considered
+                        as initialized and visible to all clients.
+                      items:
+                        description: Initializer is information about an initializer
+                          that has not yet completed.
+                        properties:
+                          name:
+                            description: name of the process that is responsible for
+                              initializing this object.
+                            type: string
+                        required:
+                        - name
+                      type: array
+                    result:
+                      description: Status is a return value for calls that don't return
+                        other objects.
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of
+                            this representation of an object. Servers should convert
+                            recognized schemas to the latest internal value, and may
+                            reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                          type: string
+                        code:
+                          description: Suggested HTTP return code for this status,
+                            0 if not set.
+                          format: int32
+                          type: integer
+                        details:
+                          description: StatusDetails is a set of additional properties
+                            that MAY be set by the server to provide additional information
+                            about a response. The Reason field of a Status object
+                            defines what attributes will be set. Clients must ignore
+                            fields that do not match the defined type of each attribute,
+                            and should assume that any attribute may be empty, invalid,
+                            or under defined.
+                          properties:
+                            causes:
+                              description: The Causes array includes more details
+                                associated with the StatusReason failure. Not all
+                                StatusReasons may provide detailed causes.
+                              items:
+                                description: StatusCause provides more information
+                                  about an api.Status failure, including cases when
+                                  multiple errors are encountered.
+                                properties:
+                                  field:
+                                    description: |-
+                                      The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
+                                      Examples:
+                                        "name" - the field "name" on the current resource
+                                        "items[0].name" - the field "name" on the first array entry in "items"
+                                    type: string
+                                  message:
+                                    description: A human-readable description of the
+                                      cause of the error.  This field may be presented
+                                      as-is to a reader.
+                                    type: string
+                                  reason:
+                                    description: A machine-readable description of
+                                      the cause of the error. If this value is empty
+                                      there is no information available.
+                                    type: string
+                              type: array
+                            group:
+                              description: The group attribute of the resource associated
+                                with the status StatusReason.
+                              type: string
+                            kind:
+                              description: 'The kind attribute of the resource associated
+                                with the status StatusReason. On some operations may
+                                differ from the requested resource Kind. More info:
+                                https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: The name attribute of the resource associated
+                                with the status StatusReason (when there is a single
+                                name which can be described).
+                              type: string
+                            retryAfterSeconds:
+                              description: If specified, the time in seconds before
+                                the operation should be retried. Some errors may indicate
+                                the client must take an alternate action - for those
+                                errors this field may indicate how long to wait before
+                                taking the alternate action.
+                              format: int32
+                              type: integer
+                            uid:
+                              description: 'UID of the resource. (when there is a
+                                single resource which can be described). More info:
+                                http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST
+                            resource this object represents. Servers may infer this
+                            from the endpoint the client submits requests to. Cannot
+                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                          type: string
+                        message:
+                          description: A human-readable description of the status
+                            of this operation.
+                          type: string
+                        metadata:
+                          description: ListMeta describes metadata that synthetic
+                            resources must have, including lists and various status
+                            objects. A resource may have only one of {ObjectMeta,
+                            ListMeta}.
+                          properties:
+                            continue:
+                              description: continue may be set if the user set a limit
+                                on the number of items returned, and indicates that
+                                the server has more data available. The value is opaque
+                                and may be used to issue another request to the endpoint
+                                that served this list to retrieve the next set of
+                                available objects. Continuing a list may not be possible
+                                if the server configuration has changed or more than
+                                a few minutes have passed. The resourceVersion field
+                                returned when using this continue value will be identical
+                                to the value in the first response.
+                              type: string
+                            resourceVersion:
+                              description: 'String that identifies the server''s internal
+                                version of this object that can be used by clients
+                                to determine when objects have changed. Value must
+                                be treated as opaque by clients and passed unmodified
+                                back to the server. Populated by the system. Read-only.
+                                More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            selfLink:
+                              description: selfLink is a URL representing this object.
+                                Populated by the system. Read-only.
+                              type: string
+                        reason:
+                          description: A machine-readable description of why this
+                            operation is in the "Failure" status. If this value is
+                            empty there is no information available. A Reason clarifies
+                            an HTTP status code but does not override it.
+                          type: string
+                        status:
+                          description: 'Status of the operation. One of: "Success"
+                            or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                          type: string
+                  required:
+                  - pending
+                labels:
+                  description: 'Map of string keys and values that can be used to
+                    organize and categorize (scope and select) objects. May match
+                    selectors of replication controllers and services. More info:
+                    http://kubernetes.io/docs/user-guide/labels'
+                  type: object
+                name:
+                  description: 'Name must be unique within a namespace. Is required
+                    when creating resources, although some resources may allow a client
+                    to request the generation of an appropriate name automatically.
+                    Name is primarily intended for creation idempotence and configuration
+                    definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+                    Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                  type: string
+                ownerReferences:
+                  description: List of objects depended by this object. If ALL objects
+                    in the list have been deleted, this object will be garbage collected.
+                    If this object is managed by a controller, then an entry in this
+                    list will point to this controller, with the controller field
+                    set to true. There cannot be more than one managing controller.
+                  items:
+                    description: OwnerReference contains enough information to let
+                      you identify an owning object. Currently, an owning object must
+                      be in the same namespace, so there is no namespace field.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      blockOwnerDeletion:
+                        description: If true, AND if the owner has the "foregroundDeletion"
+                          finalizer, then the owner cannot be deleted from the key-value
+                          store until this reference is removed. Defaults to false.
+                          To set this field, a user needs "delete" permission of the
+                          owner, otherwise 422 (Unprocessable Entity) will be returned.
+                        type: boolean
+                      controller:
+                        description: If true, this reference points to the managing
+                          controller.
+                        type: boolean
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                  type: array
+                resourceVersion:
+                  description: |-
+                    An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+                    Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                  type: string
+                selfLink:
+                  description: SelfLink is a URL representing this object. Populated
+                    by the system. Read-only.
+                  type: string
+                uid:
+                  description: |-
+                    UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+                    Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                  type: string
+            replicas:
+              description: Size is the expected size of the alertmanager cluster.
+                The controller will eventually make the size of the running cluster
+                equal to the expected size.
+              format: int32
+              type: integer
+            resources:
+              description: ResourceRequirements describes the compute resource requirements.
+              properties:
+                limits:
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+            routePrefix:
+              description: The route prefix Alertmanager registers HTTP handlers for.
+                This is useful, if using ExternalURL and a proxy is rewriting HTTP
+                routes of a request, and the actual ExternalURL is still true, but
+                the server serves requests under a different route prefix. For example
+                for use with `kubectl proxy`.
+              type: string
+            secrets:
+              description: Secrets is a list of Secrets in the same namespace as the
+                Alertmanager object, which shall be mounted into the Alertmanager
+                Pods. The Secrets are mounted into /etc/alertmanager/secrets/<secret-name>.
+              items:
+                type: string
+              type: array
+            securityContext:
+              description: PodSecurityContext holds pod-level security attributes
+                and common container settings. Some fields are also present in container.securityContext.  Field
+                values of container.securityContext take precedence over field values
+                of PodSecurityContext.
+              properties:
+                fsGroup:
+                  description: |-
+                    A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                    1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                    If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                  format: int64
+                  type: integer
+                runAsGroup:
+                  description: The GID to run the entrypoint of the container process.
+                    Uses runtime default if unset. May also be set in SecurityContext.  If
+                    set in both SecurityContext and PodSecurityContext, the value
+                    specified in SecurityContext takes precedence for that container.
+                  format: int64
+                  type: integer
+                runAsNonRoot:
+                  description: Indicates that the container must run as a non-root
+                    user. If true, the Kubelet will validate the image at runtime
+                    to ensure that it does not run as UID 0 (root) and fail to start
+                    the container if it does. If unset or false, no such validation
+                    will be performed. May also be set in SecurityContext.  If set
+                    in both SecurityContext and PodSecurityContext, the value specified
+                    in SecurityContext takes precedence.
+                  type: boolean
+                runAsUser:
+                  description: The UID to run the entrypoint of the container process.
+                    Defaults to user specified in image metadata if unspecified. May
+                    also be set in SecurityContext.  If set in both SecurityContext
+                    and PodSecurityContext, the value specified in SecurityContext
+                    takes precedence for that container.
+                  format: int64
+                  type: integer
+                seLinuxOptions:
+                  description: SELinuxOptions are the labels to be applied to the
+                    container
+                  properties:
+                    level:
+                      description: Level is SELinux level label that applies to the
+                        container.
+                      type: string
+                    role:
+                      description: Role is a SELinux role label that applies to the
+                        container.
+                      type: string
+                    type:
+                      description: Type is a SELinux type label that applies to the
+                        container.
+                      type: string
+                    user:
+                      description: User is a SELinux user label that applies to the
+                        container.
+                      type: string
+                supplementalGroups:
+                  description: A list of groups applied to the first process run in
+                    each container, in addition to the container's primary GID.  If
+                    unspecified, no groups will be added to any container.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                sysctls:
+                  description: Sysctls hold a list of namespaced sysctls used for
+                    the pod. Pods with unsupported sysctls (by the container runtime)
+                    might fail to launch.
+                  items:
+                    description: Sysctl defines a kernel parameter to be set
+                    properties:
+                      name:
+                        description: Name of a property to set
+                        type: string
+                      value:
+                        description: Value of a property to set
+                        type: string
+                    required:
+                    - name
+                    - value
+                  type: array
+            serviceAccountName:
+              description: ServiceAccountName is the name of the ServiceAccount to
+                use to run the Prometheus Pods.
+              type: string
+            storage:
+              description: StorageSpec defines the configured storage for a group
+                Prometheus servers.
+              properties:
+                class:
+                  description: 'Name of the StorageClass to use when requesting storage
+                    provisioning. More info: https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses
+                    DEPRECATED'
+                  type: string
+                emptyDir:
+                  description: Represents an empty directory for a pod. Empty directory
+                    volumes support ownership management and SELinux relabeling.
+                  properties:
+                    medium:
+                      description: 'What type of storage medium should back this directory.
+                        The default is "" which means to use the node''s default medium.
+                        Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                      type: string
+                    sizeLimit: {}
+                resources:
+                  description: ResourceRequirements describes the compute resource
+                    requirements.
+                  properties:
+                    limits:
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                selector:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                      type: array
+                    matchLabels:
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                                     of matchExpressions, whose key field is "key", the operator
+                                     is "In", and the values array contains only "value". The requirements
+                                     are ANDed.
+                      type: object
+                volumeClaimTemplate:
+                  description: PersistentVolumeClaim is a user's request for and claim
+                    to a persistent volume
+                  properties:
+                    apiVersion:
+                      description: 'APIVersion defines the versioned schema of this
+                        representation of an object. Servers should convert recognized
+                        schemas to the latest internal value, and may reject unrecognized
+                        values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                      type: string
+                    kind:
+                      description: 'Kind is a string value representing the REST resource
+                        this object represents. Servers may infer this from the endpoint
+                        the client submits requests to. Cannot be updated. In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                      type: string
+                    metadata:
+                      description: ObjectMeta is metadata that all persisted resources
+                        must have, which includes all objects users must create.
+                      properties:
+                        annotations:
+                          description: 'Annotations is an unstructured key value map
+                            stored with a resource that may be set by external tools
+                            to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: http://kubernetes.io/docs/user-guide/annotations'
+                          type: object
+                        clusterName:
+                          description: The name of the cluster which the object belongs
+                            to. This is used to distinguish resources with same name
+                            and namespace in different clusters. This field is not
+                            set anywhere right now and apiserver is going to ignore
+                            it if set in create or update request.
+                          type: string
+                        creationTimestamp:
+                          description: Time is a wrapper around time.Time which supports
+                            correct marshaling to YAML and JSON.  Wrappers are provided
+                            for many of the factory methods that the time package
+                            offers.
+                          format: date-time
+                          type: string
+                        deletionGracePeriodSeconds:
+                          description: Number of seconds allowed for this object to
+                            gracefully terminate before it will be removed from the
+                            system. Only set when deletionTimestamp is also set. May
+                            only be shortened. Read-only.
+                          format: int64
+                          type: integer
+                        deletionTimestamp:
+                          description: Time is a wrapper around time.Time which supports
+                            correct marshaling to YAML and JSON.  Wrappers are provided
+                            for many of the factory methods that the time package
+                            offers.
+                          format: date-time
+                          type: string
+                        finalizers:
+                          description: Must be empty before the object is deleted
+                            from the registry. Each entry is an identifier for the
+                            responsible component that will remove the entry from
+                            the list. If the deletionTimestamp of the object is non-nil,
+                            entries in this list can only be removed.
+                          items:
+                            type: string
+                          type: array
+                        generateName:
+                          description: |-
+                            GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+                            If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
+                            Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                          type: string
+                        generation:
+                          description: A sequence number representing a specific generation
+                            of the desired state. Populated by the system. Read-only.
+                          format: int64
+                          type: integer
+                        initializers:
+                          description: Initializers tracks the progress of initialization.
+                          properties:
+                            pending:
+                              description: Pending is a list of initializers that
+                                must execute in order before this object is visible.
+                                When the last pending initializer is removed, and
+                                no failing result is set, the initializers struct
+                                will be set to nil and the object is considered as
+                                initialized and visible to all clients.
+                              items:
+                                description: Initializer is information about an initializer
+                                  that has not yet completed.
+                                properties:
+                                  name:
+                                    description: name of the process that is responsible
+                                      for initializing this object.
+                                    type: string
+                                required:
+                                - name
+                              type: array
+                            result:
+                              description: Status is a return value for calls that
+                                don't return other objects.
+                              properties:
+                                apiVersion:
+                                  description: 'APIVersion defines the versioned schema
+                                    of this representation of an object. Servers should
+                                    convert recognized schemas to the latest internal
+                                    value, and may reject unrecognized values. More
+                                    info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                                  type: string
+                                code:
+                                  description: Suggested HTTP return code for this
+                                    status, 0 if not set.
+                                  format: int32
+                                  type: integer
+                                details:
+                                  description: StatusDetails is a set of additional
+                                    properties that MAY be set by the server to provide
+                                    additional information about a response. The Reason
+                                    field of a Status object defines what attributes
+                                    will be set. Clients must ignore fields that do
+                                    not match the defined type of each attribute,
+                                    and should assume that any attribute may be empty,
+                                    invalid, or under defined.
+                                  properties:
+                                    causes:
+                                      description: The Causes array includes more
+                                        details associated with the StatusReason failure.
+                                        Not all StatusReasons may provide detailed
+                                        causes.
+                                      items:
+                                        description: StatusCause provides more information
+                                          about an api.Status failure, including cases
+                                          when multiple errors are encountered.
+                                        properties:
+                                          field:
+                                            description: |-
+                                              The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
+                                              Examples:
+                                                "name" - the field "name" on the current resource
+                                                "items[0].name" - the field "name" on the first array entry in "items"
+                                            type: string
+                                          message:
+                                            description: A human-readable description
+                                              of the cause of the error.  This field
+                                              may be presented as-is to a reader.
+                                            type: string
+                                          reason:
+                                            description: A machine-readable description
+                                              of the cause of the error. If this value
+                                              is empty there is no information available.
+                                            type: string
+                                      type: array
+                                    group:
+                                      description: The group attribute of the resource
+                                        associated with the status StatusReason.
+                                      type: string
+                                    kind:
+                                      description: 'The kind attribute of the resource
+                                        associated with the status StatusReason. On
+                                        some operations may differ from the requested
+                                        resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: The name attribute of the resource
+                                        associated with the status StatusReason (when
+                                        there is a single name which can be described).
+                                      type: string
+                                    retryAfterSeconds:
+                                      description: If specified, the time in seconds
+                                        before the operation should be retried. Some
+                                        errors may indicate the client must take an
+                                        alternate action - for those errors this field
+                                        may indicate how long to wait before taking
+                                        the alternate action.
+                                      format: int32
+                                      type: integer
+                                    uid:
+                                      description: 'UID of the resource. (when there
+                                        is a single resource which can be described).
+                                        More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                      type: string
+                                kind:
+                                  description: 'Kind is a string value representing
+                                    the REST resource this object represents. Servers
+                                    may infer this from the endpoint the client submits
+                                    requests to. Cannot be updated. In CamelCase.
+                                    More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                  type: string
+                                message:
+                                  description: A human-readable description of the
+                                    status of this operation.
+                                  type: string
+                                metadata:
+                                  description: ListMeta describes metadata that synthetic
+                                                 resources must have, including lists and various
+                                                 status objects. A resource may have only one of
+                                    {ObjectMeta, ListMeta}.
+                                  properties:
+                                    continue:
+                                      description: continue may be set if the user
+                                        set a limit on the number of items returned,
+                                        and indicates that the server has more data
+                                        available. The value is opaque and may be
+                                        used to issue another request to the endpoint
+                                        that served this list to retrieve the next
+                                        set of available objects. Continuing a list
+                                        may not be possible if the server configuration
+                                        has changed or more than a few minutes have
+                                        passed. The resourceVersion field returned
+                                        when using this continue value will be identical
+                                        to the value in the first response.
+                                      type: string
+                                    resourceVersion:
+                                      description: 'String that identifies the server''s
+                                        internal version of this object that can be
+                                        used by clients to determine when objects
+                                        have changed. Value must be treated as opaque
+                                        by clients and passed unmodified back to the
+                                        server. Populated by the system. Read-only.
+                                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                                      type: string
+                                    selfLink:
+                                      description: selfLink is a URL representing
+                                        this object. Populated by the system. Read-only.
+                                      type: string
+                                reason:
+                                  description: A machine-readable description of why
+                                    this operation is in the "Failure" status. If
+                                    this value is empty there is no information available.
+                                    A Reason clarifies an HTTP status code but does
+                                    not override it.
+                                  type: string
+                                status:
+                                  description: 'Status of the operation. One of: "Success"
+                                    or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                                  type: string
+                          required:
+                          - pending
+                        labels:
+                          description: 'Map of string keys and values that can be
+                            used to organize and categorize (scope and select) objects.
+                            May match selectors of replication controllers and services.
+                            More info: http://kubernetes.io/docs/user-guide/labels'
+                          type: object
+                        name:
+                          description: 'Name must be unique within a namespace. Is
+                            required when creating resources, although some resources
+                            may allow a client to request the generation of an appropriate
+                            name automatically. Name is primarily intended for creation
+                            idempotence and configuration definition. Cannot be updated.
+                            More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+                            Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                          type: string
+                        ownerReferences:
+                          description: List of objects depended by this object. If
+                            ALL objects in the list have been deleted, this object
+                            will be garbage collected. If this object is managed by
+                            a controller, then an entry in this list will point to
+                            this controller, with the controller field set to true.
+                            There cannot be more than one managing controller.
+                          items:
+                            description: OwnerReference contains enough information
+                              to let you identify an owning object. Currently, an
+                              owning object must be in the same namespace, so there
+                              is no namespace field.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              blockOwnerDeletion:
+                                description: If true, AND if the owner has the "foregroundDeletion"
+                                               finalizer, then the owner cannot be deleted from
+                                               the key-value store until this reference is removed.
+                                               Defaults to false. To set this field, a user needs
+                                               "delete" permission of the owner, otherwise 422
+                                               (Unprocessable Entity) will be returned.
+                                type: boolean
+                              controller:
+                                description: If true, this reference points to the
+                                  managing controller.
+                                type: boolean
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                type: string
+                            required:
+                            - apiVersion
+                            - kind
+                            - name
+                            - uid
+                          type: array
+                        resourceVersion:
+                          description: |-
+                            An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+                            Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                          type: string
+                        selfLink:
+                          description: SelfLink is a URL representing this object.
+                            Populated by the system. Read-only.
+                          type: string
+                        uid:
+                          description: |-
+                            UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+                            Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                          type: string
+                    spec:
+                      description: PersistentVolumeClaimSpec describes the common
+                        attributes of storage devices and allows a Source for provider-specific
+                        attributes
+                      properties:
+                        accessModes:
+                          description: 'AccessModes contains the desired access modes
+                            the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          items:
+                            type: string
+                          type: array
+                        resources:
+                          description: ResourceRequirements describes the compute
+                            resource requirements.
+                          properties:
+                            limits:
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                        selector:
+                          description: A label selector is a label query over a set
+                            of resources. The result of matchLabels and matchExpressions
+                            are ANDed. An empty label selector matches all objects.
+                            A null label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                              type: array
+                            matchLabels:
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                        storageClassName:
+                          description: 'Name of the StorageClass required by the claim.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                          type: string
+                        volumeMode:
+                          description: volumeMode defines what type of volume is required
+                            by the claim. Value of Filesystem is implied when not
+                            included in claim spec. This is an alpha feature and may
+                            change in the future.
+                          type: string
+                        volumeName:
+                          description: VolumeName is the binding reference to the
+                            PersistentVolume backing this claim.
+                          type: string
+                    status:
+                      description: PersistentVolumeClaimStatus is the current status
+                        of a persistent volume claim.
+                      properties:
+                        accessModes:
+                          description: 'AccessModes contains the actual access modes
+                            the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          items:
+                            type: string
+                          type: array
+                        capacity:
+                          description: Represents the actual resources of the underlying
+                            volume.
+                          type: object
+                        conditions:
+                          description: Current Condition of persistent volume claim.
+                            If underlying persistent volume is being resized then
+                            the Condition will be set to 'ResizeStarted'.
+                          items:
+                            description: PersistentVolumeClaimCondition contails details
+                              about state of pvc
+                            properties:
+                              lastProbeTime:
+                                description: Time is a wrapper around time.Time which
+                                  supports correct marshaling to YAML and JSON.  Wrappers
+                                  are provided for many of the factory methods that
+                                  the time package offers.
+                                format: date-time
+                                type: string
+                              lastTransitionTime:
+                                description: Time is a wrapper around time.Time which
+                                  supports correct marshaling to YAML and JSON.  Wrappers
+                                  are provided for many of the factory methods that
+                                  the time package offers.
+                                format: date-time
+                                type: string
+                              message:
+                                description: Human-readable message indicating details
+                                  about last transition.
+                                type: string
+                              reason:
+                                description: Unique, this should be a short, machine
+                                  understandable string that gives the reason for
+                                  condition's last transition. If it reports "ResizeStarted"
+                                  that means the underlying persistent volume is being
+                                  resized.
+                                type: string
+                              status:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - type
+                            - status
+                          type: array
+                        phase:
+                          description: Phase represents the current phase of PersistentVolumeClaim.
+                          type: string
+            tag:
+              description: Tag of Alertmanager container image to be deployed. Defaults
+                to the value of `version`.
+              type: string
+            tolerations:
+              description: If specified, the pod's tolerations.
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
+                properties:
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
+                    type: string
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
+                    type: string
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
+                    type: string
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
+                    type: string
+              type: array
+            version:
+              description: Version the cluster should be on.
+              type: string
+        status:
+          description: 'Most recent observed status of the Alertmanager cluster. Read-only.
+            Not included when requesting from the apiserver, only from the Prometheus
+            Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          properties:
+            availableReplicas:
+              description: Total number of available pods (ready for at least minReadySeconds)
+                targeted by this Alertmanager cluster.
+              format: int32
+              type: integer
+            paused:
+              description: Represents whether any actions on the underlaying managed
+                objects are being performed. Only delete actions will be performed.
+              type: boolean
+            replicas:
+              description: Total number of non-terminated pods targeted by this Alertmanager
+                cluster (their labels match the selector).
+              format: int32
+              type: integer
+            unavailableReplicas:
+              description: Total number of unavailable pods targeted by this Alertmanager
+                cluster.
+              format: int32
+              type: integer
+            updatedReplicas:
+              description: Total number of non-terminated pods targeted by this Alertmanager
+                cluster that have the desired version spec.
+              format: int32
+              type: integer
+          required:
+          - paused
+          - replicas
+          - updatedReplicas
+          - availableReplicas
+          - unavailableReplicas
+  version: v1

--- a/bundles/prometheus.0.14.0/manifests/prometheus.crd.yaml
+++ b/bundles/prometheus.0.14.0/manifests/prometheus.crd.yaml
@@ -1,0 +1,2971 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: prometheuses.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    kind: Prometheus
+    plural: prometheuses
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: 'Specification of the desired behavior of the Prometheus cluster.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          properties:
+            additionalAlertManagerConfigs:
+              description: SecretKeySelector selects a key of a Secret.
+              properties:
+                key:
+                  description: The key of the secret to select from.  Must be a valid
+                    secret key.
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                optional:
+                  description: Specify whether the Secret or it's key must be defined
+                  type: boolean
+              required:
+              - key
+            additionalScrapeConfigs:
+              description: SecretKeySelector selects a key of a Secret.
+              properties:
+                key:
+                  description: The key of the secret to select from.  Must be a valid
+                    secret key.
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                optional:
+                  description: Specify whether the Secret or it's key must be defined
+                  type: boolean
+              required:
+              - key
+            affinity:
+              description: Affinity is a group of affinity scheduling rules.
+              properties:
+                nodeAffinity:
+                  description: Node affinity is a group of node affinity scheduling
+                    rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node matches the corresponding matchExpressions; the
+                        node(s) with the highest sum are the most preferred.
+                      items:
+                        description: An empty preferred scheduling term matches all
+                          objects with implicit weight 0 (i.e. it's a no-op). A null
+                          preferred scheduling term matches no objects (i.e. is also
+                          a no-op).
+                        properties:
+                          preference:
+                            description: A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The
+                              TopologySelectorTerm type implements a subset of the
+                              NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                          weight:
+                            description: Weight associated with matching the corresponding
+                              nodeSelectorTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - preference
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: A node selector represents the union of the results
+                        of one or more label queries over a set of nodes; that is,
+                        it represents the OR of the selectors represented by the node
+                        selector terms.
+                      properties:
+                        nodeSelectorTerms:
+                          description: Required. A list of node selector terms. The
+                            terms are ORed.
+                          items:
+                            description: A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The
+                              TopologySelectorTerm type implements a subset of the
+                              NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                          type: array
+                      required:
+                      - nodeSelectorTerms
+                podAffinity:
+                  description: Pod affinity is a group of inter pod affinity scheduling
+                    rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node has pods which matches the corresponding podAffinityTerm;
+                        the node(s) with the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label selector is a label query over
+                                  a set of resources. The result of matchLabels and
+                                  matchExpressions are ANDed. An empty label selector
+                                  matches all objects. A null label selector matches
+                                  no objects.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                    type: array
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - podAffinityTerm
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to a pod label update), the system may or may not
+                        try to eventually evict the pod from its node. When there
+                        are multiple elements, the lists of nodes corresponding to
+                        each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label selector is a label query over a
+                              set of resources. The result of matchLabels and matchExpressions
+                              are ANDed. An empty label selector matches all objects.
+                              A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchLabels:
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                      type: array
+                podAntiAffinity:
+                  description: Pod anti affinity is a group of inter pod anti affinity
+                    scheduling rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the anti-affinity expressions specified by this
+                        field, but it may choose a node that violates one or more
+                        of the expressions. The node that is most preferred is the
+                        one with the greatest sum of weights, i.e. for each node that
+                        meets all of the scheduling requirements (resource request,
+                        requiredDuringScheduling anti-affinity expressions, etc.),
+                        compute a sum by iterating through the elements of this field
+                        and adding "weight" to the sum if the node has pods which
+                        matches the corresponding podAffinityTerm; the node(s) with
+                        the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label selector is a label query over
+                                  a set of resources. The result of matchLabels and
+                                  matchExpressions are ANDed. An empty label selector
+                                  matches all objects. A null label selector matches
+                                  no objects.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                    type: array
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - podAffinityTerm
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the anti-affinity requirements specified by
+                        this field are not met at scheduling time, the pod will not
+                        be scheduled onto the node. If the anti-affinity requirements
+                        specified by this field cease to be met at some point during
+                        pod execution (e.g. due to a pod label update), the system
+                        may or may not try to eventually evict the pod from its node.
+                        When there are multiple elements, the lists of nodes corresponding
+                        to each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label selector is a label query over a
+                              set of resources. The result of matchLabels and matchExpressions
+                              are ANDed. An empty label selector matches all objects.
+                              A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchLabels:
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                      type: array
+            alerting:
+              description: AlertingSpec defines parameters for alerting configuration
+                of Prometheus servers.
+              properties:
+                alertmanagers:
+                  description: AlertmanagerEndpoints Prometheus should fire alerts
+                    against.
+                  items:
+                    description: AlertmanagerEndpoints defines a selection of a single
+                      Endpoints object containing alertmanager IPs to fire alerts
+                      against.
+                    properties:
+                      bearerTokenFile:
+                        description: BearerTokenFile to read from filesystem to use
+                          when authenticating to Alertmanager.
+                        type: string
+                      name:
+                        description: Name of Endpoints object in Namespace.
+                        type: string
+                      namespace:
+                        description: Namespace of Endpoints object.
+                        type: string
+                      pathPrefix:
+                        description: Prefix for the HTTP path alerts are pushed to.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: string
+                        - type: integer
+                      scheme:
+                        description: Scheme to use when firing alerts.
+                        type: string
+                      tlsConfig:
+                        description: TLSConfig specifies TLS configuration parameters.
+                        properties:
+                          caFile:
+                            description: The CA cert to use for the targets.
+                            type: string
+                          certFile:
+                            description: The client cert file for the targets.
+                            type: string
+                          insecureSkipVerify:
+                            description: Disable target certificate validation.
+                            type: boolean
+                          keyFile:
+                            description: The client key file for the targets.
+                            type: string
+                          serverName:
+                            description: Used to verify the hostname for the targets.
+                            type: string
+                    required:
+                    - namespace
+                    - name
+                    - port
+                  type: array
+              required:
+              - alertmanagers
+            baseImage:
+              description: Base image to use for a Prometheus deployment.
+              type: string
+            containers:
+              description: Containers allows injecting additional containers. This
+                is meant to allow adding an authentication proxy to a Prometheus pod.
+              items:
+                description: A single application container that you want to run within
+                  a pod.
+                properties:
+                  args:
+                    description: 'Arguments to the entrypoint. The docker image''s
+                      CMD is used if this is not provided. Variable references $(VAR_NAME)
+                      are expanded using the container''s environment. If a variable
+                      cannot be resolved, the reference in the input string will be
+                      unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                      $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                      regardless of whether the variable exists or not. Cannot be
+                      updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    description: 'Entrypoint array. Not executed within a shell. The
+                      docker image''s ENTRYPOINT is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container''s
+                      environment. If a variable cannot be resolved, the reference
+                      in the input string will be unchanged. The $(VAR_NAME) syntax
+                      can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                      will never be expanded, regardless of whether the variable exists
+                      or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: List of environment variables to set in the container.
+                      Cannot be updated.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: EnvVarSource represents a source for the value
+                            of an EnvVar.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key from a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or it's
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                            fieldRef:
+                              description: ObjectFieldSelector selects an APIVersioned
+                                field of an object.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                            resourceFieldRef:
+                              description: ResourceFieldSelector represents container
+                                resources (cpu, memory) and their output format
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor: {}
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                            secretKeyRef:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or it's
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                      required:
+                      - name
+                    type: array
+                  envFrom:
+                    description: List of sources to populate environment variables
+                      in the container. The keys defined within a source must be a
+                      C_IDENTIFIER. All invalid keys will be reported as an event
+                      when the container is starting. When a key exists in multiple
+                      sources, the value associated with the last source will take
+                      precedence. Values defined by an Env with a duplicate key will
+                      take precedence. Cannot be updated.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: |-
+                            ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+                            The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: |-
+                            SecretEnvSource selects a Secret to populate the environment variables with.
+                            The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                    type: array
+                  image:
+                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                      This field is optional to allow higher level config management
+                      to default or override container images in workload controllers
+                      like Deployments and StatefulSets.'
+                    type: string
+                  imagePullPolicy:
+                    description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                      Defaults to Always if :latest tag is specified, or IfNotPresent
+                      otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                    type: string
+                  lifecycle:
+                    description: Lifecycle describes actions that the management system
+                      should take in response to container lifecycle events. For the
+                      PostStart and PreStop lifecycle handlers, management of the
+                      container blocks until the action is complete, unless the container
+                      process fails, in which case the handler is aborted.
+                    properties:
+                      postStart:
+                        description: Handler defines a specific action that should
+                          be taken
+                        properties:
+                          exec:
+                            description: ExecAction describes a "run in container"
+                              action.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                          httpGet:
+                            description: HTTPGetAction describes an action based on
+                              HTTP Get requests.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                          tcpSocket:
+                            description: TCPSocketAction describes an action based
+                              on opening a socket
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                            required:
+                            - port
+                      preStop:
+                        description: Handler defines a specific action that should
+                          be taken
+                        properties:
+                          exec:
+                            description: ExecAction describes a "run in container"
+                              action.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                          httpGet:
+                            description: HTTPGetAction describes an action based on
+                              HTTP Get requests.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                          tcpSocket:
+                            description: TCPSocketAction describes an action based
+                              on opening a socket
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                            required:
+                            - port
+                  livenessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: ExecAction describes a "run in container" action.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGetAction describes an action based on HTTP
+                          Get requests.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocketAction describes an action based on
+                          opening a socket
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                        required:
+                        - port
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                  name:
+                    description: Name of the container specified as a DNS_LABEL. Each
+                      container in a pod must have a unique name (DNS_LABEL). Cannot
+                      be updated.
+                    type: string
+                  ports:
+                    description: List of ports to expose from the container. Exposing
+                      a port here gives the system additional information about the
+                      network connections a container uses, but is primarily informational.
+                      Not specifying a port here DOES NOT prevent that port from being
+                      exposed. Any port which is listening on the default "0.0.0.0"
+                      address inside a container will be accessible from the network.
+                      Cannot be updated.
+                    items:
+                      description: ContainerPort represents a network port in a single
+                        container.
+                      properties:
+                        containerPort:
+                          description: Number of port to expose on the pod's IP address.
+                            This must be a valid port number, 0 < x < 65536.
+                          format: int32
+                          type: integer
+                        hostIP:
+                          description: What host IP to bind the external port to.
+                          type: string
+                        hostPort:
+                          description: Number of port to expose on the host. If specified,
+                            this must be a valid port number, 0 < x < 65536. If HostNetwork
+                            is specified, this must match ContainerPort. Most containers
+                            do not need this.
+                          format: int32
+                          type: integer
+                        name:
+                          description: If specified, this must be an IANA_SVC_NAME
+                            and unique within the pod. Each named port in a pod must
+                            have a unique name. Name for the port that can be referred
+                            to by services.
+                          type: string
+                        protocol:
+                          description: Protocol for port. Must be UDP or TCP. Defaults
+                            to "TCP".
+                          type: string
+                      required:
+                      - containerPort
+                    type: array
+                  readinessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: ExecAction describes a "run in container" action.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGetAction describes an action based on HTTP
+                          Get requests.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocketAction describes an action based on
+                          opening a socket
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                        required:
+                        - port
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                  securityContext:
+                    description: SecurityContext holds security configuration that
+                      will be applied to a container. Some fields are present in both
+                      SecurityContext and PodSecurityContext.  When both are set,
+                      the values in SecurityContext take precedence.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: Adds and removes POSIX capabilities from running
+                          containers.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              type: string
+                            type: array
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: SELinuxOptions are the labels to be applied to
+                          the container
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                  stdin:
+                    description: Whether this container should allocate a buffer for
+                      stdin in the container runtime. If this is not set, reads from
+                      stdin in the container will always result in EOF. Default is
+                      false.
+                    type: boolean
+                  stdinOnce:
+                    description: Whether the container runtime should close the stdin
+                      channel after it has been opened by a single attach. When stdin
+                      is true the stdin stream will remain open across multiple attach
+                      sessions. If stdinOnce is set to true, stdin is opened on container
+                      start, is empty until the first client attaches to stdin, and
+                      then remains open and accepts data until the client disconnects,
+                      at which time stdin is closed and remains closed until the container
+                      is restarted. If this flag is false, a container processes that
+                      reads from stdin will never receive an EOF. Default is false
+                    type: boolean
+                  terminationMessagePath:
+                    description: 'Optional: Path at which the file to which the container''s
+                      termination message will be written is mounted into the container''s
+                      filesystem. Message written is intended to be brief final status,
+                      such as an assertion failure message. Will be truncated by the
+                      node if greater than 4096 bytes. The total message length across
+                      all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                      Cannot be updated.'
+                    type: string
+                  terminationMessagePolicy:
+                    description: Indicate how the termination message should be populated.
+                      File will use the contents of terminationMessagePath to populate
+                      the container status message on both success and failure. FallbackToLogsOnError
+                      will use the last chunk of container log output if the termination
+                      message file is empty and the container exited with an error.
+                      The log output is limited to 2048 bytes or 80 lines, whichever
+                      is smaller. Defaults to File. Cannot be updated.
+                    type: string
+                  tty:
+                    description: Whether this container should allocate a TTY for
+                      itself, also requires 'stdin' to be true. Default is false.
+                    type: boolean
+                  volumeDevices:
+                    description: volumeDevices is the list of block devices to be
+                      used by the container. This is an alpha feature and may change
+                      in the future.
+                    items:
+                      description: volumeDevice describes a mapping of a raw block
+                        device within a container.
+                      properties:
+                        devicePath:
+                          description: devicePath is the path inside of the container
+                            that the device will be mapped to.
+                          type: string
+                        name:
+                          description: name must match the name of a persistentVolumeClaim
+                            in the pod
+                          type: string
+                      required:
+                      - name
+                      - devicePath
+                    type: array
+                  volumeMounts:
+                    description: Pod volumes to mount into the container's filesystem.
+                      Cannot be updated.
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: Path within the container at which the volume
+                            should be mounted.  Must not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: mountPropagation determines how mounts are
+                            propagated from the host to container and the other way
+                            around. When not set, MountPropagationHostToContainer
+                            is used. This field is beta in 1.10.
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: Mounted read-only if true, read-write otherwise
+                            (false or unspecified). Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: Path within the volume from which the container's
+                            volume should be mounted. Defaults to "" (volume's root).
+                          type: string
+                      required:
+                      - name
+                      - mountPath
+                    type: array
+                  workingDir:
+                    description: Container's working directory. If not specified,
+                      the container runtime's default will be used, which might be
+                      configured in the container image. Cannot be updated.
+                    type: string
+                required:
+                - name
+              type: array
+            evaluationInterval:
+              description: Interval between consecutive evaluations.
+              type: string
+            externalLabels:
+              description: The labels to add to any time series or alerts when communicating
+                with external systems (federation, remote storage, Alertmanager).
+              type: object
+            externalUrl:
+              description: The external URL the Prometheus instances will be available
+                under. This is necessary to generate correct URLs. This is necessary
+                if Prometheus is not served from root of a DNS name.
+              type: string
+            imagePullSecrets:
+              description: An optional list of references to secrets in the same namespace
+                to use for pulling prometheus and alertmanager images from registries
+                see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
+              items:
+                description: LocalObjectReference contains enough information to let
+                  you locate the referenced object inside the same namespace.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+              type: array
+            listenLocal:
+              description: ListenLocal makes the Prometheus server listen on loopback,
+                so that it does not bind against the Pod IP.
+              type: boolean
+            logLevel:
+              description: Log level for Prometheus to be configured with.
+              type: string
+            nodeSelector:
+              description: Define which Nodes the Pods are scheduled on.
+              type: object
+            paused:
+              description: When a Prometheus deployment is paused, no actions except
+                for deletion will be performed on the underlying objects.
+              type: boolean
+            podMetadata:
+              description: ObjectMeta is metadata that all persisted resources must
+                have, which includes all objects users must create.
+              properties:
+                annotations:
+                  description: 'Annotations is an unstructured key value map stored
+                    with a resource that may be set by external tools to store and
+                    retrieve arbitrary metadata. They are not queryable and should
+                    be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                  type: object
+                clusterName:
+                  description: The name of the cluster which the object belongs to.
+                    This is used to distinguish resources with same name and namespace
+                    in different clusters. This field is not set anywhere right now
+                    and apiserver is going to ignore it if set in create or update
+                    request.
+                  type: string
+                creationTimestamp:
+                  description: Time is a wrapper around time.Time which supports correct
+                    marshaling to YAML and JSON.  Wrappers are provided for many of
+                    the factory methods that the time package offers.
+                  format: date-time
+                  type: string
+                deletionGracePeriodSeconds:
+                  description: Number of seconds allowed for this object to gracefully
+                    terminate before it will be removed from the system. Only set
+                    when deletionTimestamp is also set. May only be shortened. Read-only.
+                  format: int64
+                  type: integer
+                deletionTimestamp:
+                  description: Time is a wrapper around time.Time which supports correct
+                    marshaling to YAML and JSON.  Wrappers are provided for many of
+                    the factory methods that the time package offers.
+                  format: date-time
+                  type: string
+                finalizers:
+                  description: Must be empty before the object is deleted from the
+                    registry. Each entry is an identifier for the responsible component
+                    that will remove the entry from the list. If the deletionTimestamp
+                    of the object is non-nil, entries in this list can only be removed.
+                  items:
+                    type: string
+                  type: array
+                generateName:
+                  description: |-
+                    GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+                    If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+                    Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                  type: string
+                generation:
+                  description: A sequence number representing a specific generation
+                    of the desired state. Populated by the system. Read-only.
+                  format: int64
+                  type: integer
+                initializers:
+                  description: Initializers tracks the progress of initialization.
+                  properties:
+                    pending:
+                      description: Pending is a list of initializers that must execute
+                        in order before this object is visible. When the last pending
+                        initializer is removed, and no failing result is set, the
+                        initializers struct will be set to nil and the object is considered
+                        as initialized and visible to all clients.
+                      items:
+                        description: Initializer is information about an initializer
+                          that has not yet completed.
+                        properties:
+                          name:
+                            description: name of the process that is responsible for
+                              initializing this object.
+                            type: string
+                        required:
+                        - name
+                      type: array
+                    result:
+                      description: Status is a return value for calls that don't return
+                        other objects.
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of
+                            this representation of an object. Servers should convert
+                            recognized schemas to the latest internal value, and may
+                            reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                          type: string
+                        code:
+                          description: Suggested HTTP return code for this status,
+                            0 if not set.
+                          format: int32
+                          type: integer
+                        details:
+                          description: StatusDetails is a set of additional properties
+                            that MAY be set by the server to provide additional information
+                            about a response. The Reason field of a Status object
+                            defines what attributes will be set. Clients must ignore
+                            fields that do not match the defined type of each attribute,
+                            and should assume that any attribute may be empty, invalid,
+                            or under defined.
+                          properties:
+                            causes:
+                              description: The Causes array includes more details
+                                associated with the StatusReason failure. Not all
+                                StatusReasons may provide detailed causes.
+                              items:
+                                description: StatusCause provides more information
+                                  about an api.Status failure, including cases when
+                                  multiple errors are encountered.
+                                properties:
+                                  field:
+                                    description: |-
+                                      The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+                                      Examples:
+                                        "name" - the field "name" on the current resource
+                                        "items[0].name" - the field "name" on the first array entry in "items"
+                                    type: string
+                                  message:
+                                    description: A human-readable description of the
+                                      cause of the error.  This field may be presented
+                                      as-is to a reader.
+                                    type: string
+                                  reason:
+                                    description: A machine-readable description of
+                                      the cause of the error. If this value is empty
+                                      there is no information available.
+                                    type: string
+                              type: array
+                            group:
+                              description: The group attribute of the resource associated
+                                with the status StatusReason.
+                              type: string
+                            kind:
+                              description: 'The kind attribute of the resource associated
+                                with the status StatusReason. On some operations may
+                                differ from the requested resource Kind. More info:
+                                https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: The name attribute of the resource associated
+                                with the status StatusReason (when there is a single
+                                name which can be described).
+                              type: string
+                            retryAfterSeconds:
+                              description: If specified, the time in seconds before
+                                the operation should be retried. Some errors may indicate
+                                the client must take an alternate action - for those
+                                errors this field may indicate how long to wait before
+                                taking the alternate action.
+                              format: int32
+                              type: integer
+                            uid:
+                              description: 'UID of the resource. (when there is a
+                                single resource which can be described). More info:
+                                http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST
+                            resource this object represents. Servers may infer this
+                            from the endpoint the client submits requests to. Cannot
+                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                          type: string
+                        message:
+                          description: A human-readable description of the status
+                            of this operation.
+                          type: string
+                        metadata:
+                          description: ListMeta describes metadata that synthetic
+                            resources must have, including lists and various status
+                            objects. A resource may have only one of {ObjectMeta,
+                            ListMeta}.
+                          properties:
+                            continue:
+                              description: continue may be set if the user set a limit
+                                on the number of items returned, and indicates that
+                                the server has more data available. The value is opaque
+                                and may be used to issue another request to the endpoint
+                                that served this list to retrieve the next set of
+                                available objects. Continuing a list may not be possible
+                                if the server configuration has changed or more than
+                                a few minutes have passed. The resourceVersion field
+                                returned when using this continue value will be identical
+                                to the value in the first response.
+                              type: string
+                            resourceVersion:
+                              description: 'String that identifies the server''s internal
+                                version of this object that can be used by clients
+                                to determine when objects have changed. Value must
+                                be treated as opaque by clients and passed unmodified
+                                back to the server. Populated by the system. Read-only.
+                                More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            selfLink:
+                              description: selfLink is a URL representing this object.
+                                Populated by the system. Read-only.
+                              type: string
+                        reason:
+                          description: A machine-readable description of why this
+                            operation is in the "Failure" status. If this value is
+                            empty there is no information available. A Reason clarifies
+                            an HTTP status code but does not override it.
+                          type: string
+                        status:
+                          description: 'Status of the operation. One of: "Success"
+                            or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                          type: string
+                  required:
+                  - pending
+                labels:
+                  description: 'Map of string keys and values that can be used to
+                    organize and categorize (scope and select) objects. May match
+                    selectors of replication controllers and services. More info:
+                    http://kubernetes.io/docs/user-guide/labels'
+                  type: object
+                name:
+                  description: 'Name must be unique within a namespace. Is required
+                    when creating resources, although some resources may allow a client
+                    to request the generation of an appropriate name automatically.
+                    Name is primarily intended for creation idempotence and configuration
+                    definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+                    Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                  type: string
+                ownerReferences:
+                  description: List of objects depended by this object. If ALL objects
+                    in the list have been deleted, this object will be garbage collected.
+                    If this object is managed by a controller, then an entry in this
+                    list will point to this controller, with the controller field
+                    set to true. There cannot be more than one managing controller.
+                  items:
+                    description: OwnerReference contains enough information to let
+                      you identify an owning object. Currently, an owning object must
+                      be in the same namespace, so there is no namespace field.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      blockOwnerDeletion:
+                        description: If true, AND if the owner has the "foregroundDeletion"
+                          finalizer, then the owner cannot be deleted from the key-value
+                          store until this reference is removed. Defaults to false.
+                          To set this field, a user needs "delete" permission of the
+                          owner, otherwise 422 (Unprocessable Entity) will be returned.
+                        type: boolean
+                      controller:
+                        description: If true, this reference points to the managing
+                          controller.
+                        type: boolean
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                  type: array
+                resourceVersion:
+                  description: |-
+                    An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+                    Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                  type: string
+                selfLink:
+                  description: SelfLink is a URL representing this object. Populated
+                    by the system. Read-only.
+                  type: string
+                uid:
+                  description: |-
+                    UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+                    Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                  type: string
+            remoteRead:
+              description: If specified, the remote_read spec. This is an experimental
+                feature, it may change in any upcoming release in a breaking way.
+              items:
+                description: RemoteReadSpec defines the remote_read configuration
+                  for prometheus.
+                properties:
+                  basicAuth:
+                    description: 'BasicAuth allow an endpoint to authenticate over
+                      basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                    properties:
+                      password:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or it's key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                      username:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or it's key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                  bearerToken:
+                    description: bearer token for remote read.
+                    type: string
+                  bearerTokenFile:
+                    description: File to read bearer token for remote read.
+                    type: string
+                  proxyUrl:
+                    description: Optional ProxyURL
+                    type: string
+                  readRecent:
+                    description: Whether reads should be made for queries for time
+                      ranges that the local storage should have complete data for.
+                    type: boolean
+                  remoteTimeout:
+                    description: Timeout for requests to the remote read endpoint.
+                    type: string
+                  requiredMatchers:
+                    description: An optional list of equality matchers which have
+                      to be present in a selector to query the remote read endpoint.
+                    type: object
+                  tlsConfig:
+                    description: TLSConfig specifies TLS configuration parameters.
+                    properties:
+                      caFile:
+                        description: The CA cert to use for the targets.
+                        type: string
+                      certFile:
+                        description: The client cert file for the targets.
+                        type: string
+                      insecureSkipVerify:
+                        description: Disable target certificate validation.
+                        type: boolean
+                      keyFile:
+                        description: The client key file for the targets.
+                        type: string
+                      serverName:
+                        description: Used to verify the hostname for the targets.
+                        type: string
+                  url:
+                    description: The URL of the endpoint to send samples to.
+                    type: string
+                required:
+                - url
+              type: array
+            remoteWrite:
+              description: If specified, the remote_write spec. This is an experimental
+                feature, it may change in any upcoming release in a breaking way.
+              items:
+                description: RemoteWriteSpec defines the remote_write configuration
+                  for prometheus.
+                properties:
+                  basicAuth:
+                    description: 'BasicAuth allow an endpoint to authenticate over
+                      basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                    properties:
+                      password:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or it's key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                      username:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or it's key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                  bearerToken:
+                    description: File to read bearer token for remote write.
+                    type: string
+                  bearerTokenFile:
+                    description: File to read bearer token for remote write.
+                    type: string
+                  proxyUrl:
+                    description: Optional ProxyURL
+                    type: string
+                  queueConfig:
+                    description: QueueConfig allows the tuning of remote_write queue_config
+                      parameters. This object is referenced in the RemoteWriteSpec
+                      object.
+                    properties:
+                      batchSendDeadline:
+                        description: BatchSendDeadline is the maximum time a sample
+                          will wait in buffer.
+                        type: string
+                      capacity:
+                        description: Capacity is the number of samples to buffer per
+                          shard before we start dropping them.
+                        format: int32
+                        type: integer
+                      maxBackoff:
+                        description: MaxBackoff is the maximum retry delay.
+                        type: string
+                      maxRetries:
+                        description: MaxRetries is the maximum number of times to
+                          retry a batch on recoverable errors.
+                        format: int32
+                        type: integer
+                      maxSamplesPerSend:
+                        description: MaxSamplesPerSend is the maximum number of samples
+                          per send.
+                        format: int32
+                        type: integer
+                      maxShards:
+                        description: MaxShards is the maximum number of shards, i.e.
+                          amount of concurrency.
+                        format: int32
+                        type: integer
+                      minBackoff:
+                        description: MinBackoff is the initial retry delay. Gets doubled
+                          for every retry.
+                        type: string
+                  remoteTimeout:
+                    description: Timeout for requests to the remote write endpoint.
+                    type: string
+                  tlsConfig:
+                    description: TLSConfig specifies TLS configuration parameters.
+                    properties:
+                      caFile:
+                        description: The CA cert to use for the targets.
+                        type: string
+                      certFile:
+                        description: The client cert file for the targets.
+                        type: string
+                      insecureSkipVerify:
+                        description: Disable target certificate validation.
+                        type: boolean
+                      keyFile:
+                        description: The client key file for the targets.
+                        type: string
+                      serverName:
+                        description: Used to verify the hostname for the targets.
+                        type: string
+                  url:
+                    description: The URL of the endpoint to send samples to.
+                    type: string
+                  writeRelabelConfigs:
+                    description: The list of remote write relabel configurations.
+                    items:
+                      description: 'RelabelConfig allows dynamic rewriting of the
+                        label set, being applied to samples before ingestion. It defines
+                        `<metric_relabel_configs>`-section of Prometheus configuration.
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                      properties:
+                        action:
+                          description: Action to perform based on regex matching.
+                            Default is 'replace'
+                          type: string
+                        modulus:
+                          description: Modulus to take of the hash of the source label
+                            values.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched. defailt is '(.*)'
+                          type: string
+                        replacement:
+                          description: Replacement value against which a regex replace
+                            is performed if the regular expression matches. Regex
+                            capture groups are available. Default is '$1'
+                          type: string
+                        separator:
+                          description: Separator placed between concatenated source
+                            label values. default is ';'.
+                          type: string
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            separator and matched against the configured regular expression
+                            for the replace, keep, and drop actions.
+                          items:
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: Label to which the resulting value is written
+                            in a replace action. It is mandatory for replace actions.
+                            Regex capture groups are available.
+                          type: string
+                    type: array
+                required:
+                - url
+              type: array
+            replicas:
+              description: Number of instances to deploy for a Prometheus deployment.
+              format: int32
+              type: integer
+            resources:
+              description: ResourceRequirements describes the compute resource requirements.
+              properties:
+                limits:
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+            retention:
+              description: Time duration Prometheus shall retain data for.
+              type: string
+            routePrefix:
+              description: The route prefix Prometheus registers HTTP handlers for.
+                This is useful, if using ExternalURL and a proxy is rewriting HTTP
+                routes of a request, and the actual ExternalURL is still true, but
+                the server serves requests under a different route prefix. For example
+                for use with `kubectl proxy`.
+              type: string
+            ruleNamespaceSelector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                                 of matchExpressions, whose key field is "key", the operator is
+                                 "In", and the values array contains only "value". The requirements
+                                 are ANDed.
+                  type: object
+            ruleSelector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                                 of matchExpressions, whose key field is "key", the operator is
+                                 "In", and the values array contains only "value". The requirements
+                                 are ANDed.
+                  type: object
+            scrapeInterval:
+              description: Interval between consecutive scrapes.
+              type: string
+            secrets:
+              description: Secrets is a list of Secrets in the same namespace as the
+                Prometheus object, which shall be mounted into the Prometheus Pods.
+                The Secrets are mounted into /etc/prometheus/secrets/<secret-name>.
+                Secrets changes after initial creation of a Prometheus object are
+                not reflected in the running Pods. To change the secrets mounted into
+                the Prometheus Pods, the object must be deleted and recreated with
+                the new list of secrets.
+              items:
+                type: string
+              type: array
+            securityContext:
+              description: PodSecurityContext holds pod-level security attributes
+                and common container settings. Some fields are also present in container.securityContext.  Field
+                values of container.securityContext take precedence over field values
+                of PodSecurityContext.
+              properties:
+                fsGroup:
+                  description: |-
+                    A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+                    1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                    If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                  format: int64
+                  type: integer
+                runAsGroup:
+                  description: The GID to run the entrypoint of the container process.
+                    Uses runtime default if unset. May also be set in SecurityContext.  If
+                    set in both SecurityContext and PodSecurityContext, the value
+                    specified in SecurityContext takes precedence for that container.
+                  format: int64
+                  type: integer
+                runAsNonRoot:
+                  description: Indicates that the container must run as a non-root
+                    user. If true, the Kubelet will validate the image at runtime
+                    to ensure that it does not run as UID 0 (root) and fail to start
+                    the container if it does. If unset or false, no such validation
+                    will be performed. May also be set in SecurityContext.  If set
+                    in both SecurityContext and PodSecurityContext, the value specified
+                    in SecurityContext takes precedence.
+                  type: boolean
+                runAsUser:
+                  description: The UID to run the entrypoint of the container process.
+                    Defaults to user specified in image metadata if unspecified. May
+                    also be set in SecurityContext.  If set in both SecurityContext
+                    and PodSecurityContext, the value specified in SecurityContext
+                    takes precedence for that container.
+                  format: int64
+                  type: integer
+                seLinuxOptions:
+                  description: SELinuxOptions are the labels to be applied to the
+                    container
+                  properties:
+                    level:
+                      description: Level is SELinux level label that applies to the
+                        container.
+                      type: string
+                    role:
+                      description: Role is a SELinux role label that applies to the
+                        container.
+                      type: string
+                    type:
+                      description: Type is a SELinux type label that applies to the
+                        container.
+                      type: string
+                    user:
+                      description: User is a SELinux user label that applies to the
+                        container.
+                      type: string
+                supplementalGroups:
+                  description: A list of groups applied to the first process run in
+                    each container, in addition to the container's primary GID.  If
+                    unspecified, no groups will be added to any container.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                sysctls:
+                  description: Sysctls hold a list of namespaced sysctls used for
+                    the pod. Pods with unsupported sysctls (by the container runtime)
+                    might fail to launch.
+                  items:
+                    description: Sysctl defines a kernel parameter to be set
+                    properties:
+                      name:
+                        description: Name of a property to set
+                        type: string
+                      value:
+                        description: Value of a property to set
+                        type: string
+                    required:
+                    - name
+                    - value
+                  type: array
+            serviceAccountName:
+              description: ServiceAccountName is the name of the ServiceAccount to
+                use to run the Prometheus Pods.
+              type: string
+            serviceMonitorNamespaceSelector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                                 of matchExpressions, whose key field is "key", the operator is
+                                 "In", and the values array contains only "value". The requirements
+                                 are ANDed.
+                  type: object
+            serviceMonitorSelector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                                 of matchExpressions, whose key field is "key", the operator is
+                                 "In", and the values array contains only "value". The requirements
+                                 are ANDed.
+                  type: object
+            storage:
+              description: StorageSpec defines the configured storage for a group
+                Prometheus servers.
+              properties:
+                class:
+                  description: 'Name of the StorageClass to use when requesting storage
+                    provisioning. More info: https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses
+                    DEPRECATED'
+                  type: string
+                emptyDir:
+                  description: Represents an empty directory for a pod. Empty directory
+                    volumes support ownership management and SELinux relabeling.
+                  properties:
+                    medium:
+                      description: 'What type of storage medium should back this directory.
+                        The default is "" which means to use the node''s default medium.
+                        Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                      type: string
+                    sizeLimit: {}
+                resources:
+                  description: ResourceRequirements describes the compute resource
+                    requirements.
+                  properties:
+                    limits:
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                selector:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                      type: array
+                    matchLabels:
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                                     of matchExpressions, whose key field is "key", the operator
+                                     is "In", and the values array contains only "value". The requirements
+                                     are ANDed.
+                      type: object
+                volumeClaimTemplate:
+                  description: PersistentVolumeClaim is a user's request for and claim
+                    to a persistent volume
+                  properties:
+                    apiVersion:
+                      description: 'APIVersion defines the versioned schema of this
+                        representation of an object. Servers should convert recognized
+                        schemas to the latest internal value, and may reject unrecognized
+                        values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                      type: string
+                    kind:
+                      description: 'Kind is a string value representing the REST resource
+                        this object represents. Servers may infer this from the endpoint
+                        the client submits requests to. Cannot be updated. In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                      type: string
+                    metadata:
+                      description: ObjectMeta is metadata that all persisted resources
+                        must have, which includes all objects users must create.
+                      properties:
+                        annotations:
+                          description: 'Annotations is an unstructured key value map
+                            stored with a resource that may be set by external tools
+                            to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: http://kubernetes.io/docs/user-guide/annotations'
+                          type: object
+                        clusterName:
+                          description: The name of the cluster which the object belongs
+                            to. This is used to distinguish resources with same name
+                            and namespace in different clusters. This field is not
+                            set anywhere right now and apiserver is going to ignore
+                            it if set in create or update request.
+                          type: string
+                        creationTimestamp:
+                          description: Time is a wrapper around time.Time which supports
+                            correct marshaling to YAML and JSON.  Wrappers are provided
+                            for many of the factory methods that the time package
+                            offers.
+                          format: date-time
+                          type: string
+                        deletionGracePeriodSeconds:
+                          description: Number of seconds allowed for this object to
+                            gracefully terminate before it will be removed from the
+                            system. Only set when deletionTimestamp is also set. May
+                            only be shortened. Read-only.
+                          format: int64
+                          type: integer
+                        deletionTimestamp:
+                          description: Time is a wrapper around time.Time which supports
+                            correct marshaling to YAML and JSON.  Wrappers are provided
+                            for many of the factory methods that the time package
+                            offers.
+                          format: date-time
+                          type: string
+                        finalizers:
+                          description: Must be empty before the object is deleted
+                            from the registry. Each entry is an identifier for the
+                            responsible component that will remove the entry from
+                            the list. If the deletionTimestamp of the object is non-nil,
+                            entries in this list can only be removed.
+                          items:
+                            type: string
+                          type: array
+                        generateName:
+                          description: |-
+                            GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+                            If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+                            Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                          type: string
+                        generation:
+                          description: A sequence number representing a specific generation
+                            of the desired state. Populated by the system. Read-only.
+                          format: int64
+                          type: integer
+                        initializers:
+                          description: Initializers tracks the progress of initialization.
+                          properties:
+                            pending:
+                              description: Pending is a list of initializers that
+                                must execute in order before this object is visible.
+                                When the last pending initializer is removed, and
+                                no failing result is set, the initializers struct
+                                will be set to nil and the object is considered as
+                                initialized and visible to all clients.
+                              items:
+                                description: Initializer is information about an initializer
+                                  that has not yet completed.
+                                properties:
+                                  name:
+                                    description: name of the process that is responsible
+                                      for initializing this object.
+                                    type: string
+                                required:
+                                - name
+                              type: array
+                            result:
+                              description: Status is a return value for calls that
+                                don't return other objects.
+                              properties:
+                                apiVersion:
+                                  description: 'APIVersion defines the versioned schema
+                                    of this representation of an object. Servers should
+                                    convert recognized schemas to the latest internal
+                                    value, and may reject unrecognized values. More
+                                    info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                                  type: string
+                                code:
+                                  description: Suggested HTTP return code for this
+                                    status, 0 if not set.
+                                  format: int32
+                                  type: integer
+                                details:
+                                  description: StatusDetails is a set of additional
+                                    properties that MAY be set by the server to provide
+                                    additional information about a response. The Reason
+                                    field of a Status object defines what attributes
+                                    will be set. Clients must ignore fields that do
+                                    not match the defined type of each attribute,
+                                    and should assume that any attribute may be empty,
+                                    invalid, or under defined.
+                                  properties:
+                                    causes:
+                                      description: The Causes array includes more
+                                        details associated with the StatusReason failure.
+                                        Not all StatusReasons may provide detailed
+                                        causes.
+                                      items:
+                                        description: StatusCause provides more information
+                                          about an api.Status failure, including cases
+                                          when multiple errors are encountered.
+                                        properties:
+                                          field:
+                                            description: |-
+                                              The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+                                              Examples:
+                                                "name" - the field "name" on the current resource
+                                                "items[0].name" - the field "name" on the first array entry in "items"
+                                            type: string
+                                          message:
+                                            description: A human-readable description
+                                              of the cause of the error.  This field
+                                              may be presented as-is to a reader.
+                                            type: string
+                                          reason:
+                                            description: A machine-readable description
+                                              of the cause of the error. If this value
+                                              is empty there is no information available.
+                                            type: string
+                                      type: array
+                                    group:
+                                      description: The group attribute of the resource
+                                        associated with the status StatusReason.
+                                      type: string
+                                    kind:
+                                      description: 'The kind attribute of the resource
+                                        associated with the status StatusReason. On
+                                        some operations may differ from the requested
+                                        resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: The name attribute of the resource
+                                        associated with the status StatusReason (when
+                                        there is a single name which can be described).
+                                      type: string
+                                    retryAfterSeconds:
+                                      description: If specified, the time in seconds
+                                        before the operation should be retried. Some
+                                        errors may indicate the client must take an
+                                        alternate action - for those errors this field
+                                        may indicate how long to wait before taking
+                                        the alternate action.
+                                      format: int32
+                                      type: integer
+                                    uid:
+                                      description: 'UID of the resource. (when there
+                                        is a single resource which can be described).
+                                        More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                      type: string
+                                kind:
+                                  description: 'Kind is a string value representing
+                                    the REST resource this object represents. Servers
+                                    may infer this from the endpoint the client submits
+                                    requests to. Cannot be updated. In CamelCase.
+                                    More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                  type: string
+                                message:
+                                  description: A human-readable description of the
+                                    status of this operation.
+                                  type: string
+                                metadata:
+                                  description: ListMeta describes metadata that synthetic
+                                                 resources must have, including lists and various
+                                                 status objects. A resource may have only one of
+                                    {ObjectMeta, ListMeta}.
+                                  properties:
+                                    continue:
+                                      description: continue may be set if the user
+                                        set a limit on the number of items returned,
+                                        and indicates that the server has more data
+                                        available. The value is opaque and may be
+                                        used to issue another request to the endpoint
+                                        that served this list to retrieve the next
+                                        set of available objects. Continuing a list
+                                        may not be possible if the server configuration
+                                        has changed or more than a few minutes have
+                                        passed. The resourceVersion field returned
+                                        when using this continue value will be identical
+                                        to the value in the first response.
+                                      type: string
+                                    resourceVersion:
+                                      description: 'String that identifies the server''s
+                                        internal version of this object that can be
+                                        used by clients to determine when objects
+                                        have changed. Value must be treated as opaque
+                                        by clients and passed unmodified back to the
+                                        server. Populated by the system. Read-only.
+                                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                                      type: string
+                                    selfLink:
+                                      description: selfLink is a URL representing
+                                        this object. Populated by the system. Read-only.
+                                      type: string
+                                reason:
+                                  description: A machine-readable description of why
+                                    this operation is in the "Failure" status. If
+                                    this value is empty there is no information available.
+                                    A Reason clarifies an HTTP status code but does
+                                    not override it.
+                                  type: string
+                                status:
+                                  description: 'Status of the operation. One of: "Success"
+                                    or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                                  type: string
+                          required:
+                          - pending
+                        labels:
+                          description: 'Map of string keys and values that can be
+                            used to organize and categorize (scope and select) objects.
+                            May match selectors of replication controllers and services.
+                            More info: http://kubernetes.io/docs/user-guide/labels'
+                          type: object
+                        name:
+                          description: 'Name must be unique within a namespace. Is
+                            required when creating resources, although some resources
+                            may allow a client to request the generation of an appropriate
+                            name automatically. Name is primarily intended for creation
+                            idempotence and configuration definition. Cannot be updated.
+                            More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+                            Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                          type: string
+                        ownerReferences:
+                          description: List of objects depended by this object. If
+                            ALL objects in the list have been deleted, this object
+                            will be garbage collected. If this object is managed by
+                            a controller, then an entry in this list will point to
+                            this controller, with the controller field set to true.
+                            There cannot be more than one managing controller.
+                          items:
+                            description: OwnerReference contains enough information
+                              to let you identify an owning object. Currently, an
+                              owning object must be in the same namespace, so there
+                              is no namespace field.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              blockOwnerDeletion:
+                                description: If true, AND if the owner has the "foregroundDeletion"
+                                               finalizer, then the owner cannot be deleted from
+                                               the key-value store until this reference is removed.
+                                               Defaults to false. To set this field, a user needs
+                                               "delete" permission of the owner, otherwise 422
+                                               (Unprocessable Entity) will be returned.
+                                type: boolean
+                              controller:
+                                description: If true, this reference points to the
+                                  managing controller.
+                                type: boolean
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                type: string
+                            required:
+                            - apiVersion
+                            - kind
+                            - name
+                            - uid
+                          type: array
+                        resourceVersion:
+                          description: |-
+                            An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+                            Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                          type: string
+                        selfLink:
+                          description: SelfLink is a URL representing this object.
+                            Populated by the system. Read-only.
+                          type: string
+                        uid:
+                          description: |-
+                            UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+                            Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                          type: string
+                    spec:
+                      description: PersistentVolumeClaimSpec describes the common
+                        attributes of storage devices and allows a Source for provider-specific
+                        attributes
+                      properties:
+                        accessModes:
+                          description: 'AccessModes contains the desired access modes
+                            the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          items:
+                            type: string
+                          type: array
+                        resources:
+                          description: ResourceRequirements describes the compute
+                            resource requirements.
+                          properties:
+                            limits:
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                        selector:
+                          description: A label selector is a label query over a set
+                            of resources. The result of matchLabels and matchExpressions
+                            are ANDed. An empty label selector matches all objects.
+                            A null label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                              type: array
+                            matchLabels:
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                        storageClassName:
+                          description: 'Name of the StorageClass required by the claim.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                          type: string
+                        volumeMode:
+                          description: volumeMode defines what type of volume is required
+                            by the claim. Value of Filesystem is implied when not
+                            included in claim spec. This is an alpha feature and may
+                            change in the future.
+                          type: string
+                        volumeName:
+                          description: VolumeName is the binding reference to the
+                            PersistentVolume backing this claim.
+                          type: string
+                    status:
+                      description: PersistentVolumeClaimStatus is the current status
+                        of a persistent volume claim.
+                      properties:
+                        accessModes:
+                          description: 'AccessModes contains the actual access modes
+                            the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          items:
+                            type: string
+                          type: array
+                        capacity:
+                          description: Represents the actual resources of the underlying
+                            volume.
+                          type: object
+                        conditions:
+                          description: Current Condition of persistent volume claim.
+                            If underlying persistent volume is being resized then
+                            the Condition will be set to 'ResizeStarted'.
+                          items:
+                            description: PersistentVolumeClaimCondition contails details
+                              about state of pvc
+                            properties:
+                              lastProbeTime:
+                                description: Time is a wrapper around time.Time which
+                                  supports correct marshaling to YAML and JSON.  Wrappers
+                                  are provided for many of the factory methods that
+                                  the time package offers.
+                                format: date-time
+                                type: string
+                              lastTransitionTime:
+                                description: Time is a wrapper around time.Time which
+                                  supports correct marshaling to YAML and JSON.  Wrappers
+                                  are provided for many of the factory methods that
+                                  the time package offers.
+                                format: date-time
+                                type: string
+                              message:
+                                description: Human-readable message indicating details
+                                  about last transition.
+                                type: string
+                              reason:
+                                description: Unique, this should be a short, machine
+                                  understandable string that gives the reason for
+                                  condition's last transition. If it reports "ResizeStarted"
+                                  that means the underlying persistent volume is being
+                                  resized.
+                                type: string
+                              status:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - type
+                            - status
+                          type: array
+                        phase:
+                          description: Phase represents the current phase of PersistentVolumeClaim.
+                          type: string
+            tag:
+              description: Tag of Prometheus container image to be deployed. Defaults
+                to the value of `version`.
+              type: string
+            thanos:
+              description: ThanosSpec defines parameters for a Prometheus server within
+                a Thanos deployment.
+              properties:
+                baseImage:
+                  description: Thanos base image if other than default.
+                  type: string
+                gcs:
+                  description: ThanosGCSSpec defines parameters for use of Google
+                    Cloud Storage (GCS) with Thanos.
+                  properties:
+                    bucket:
+                      description: Google Cloud Storage bucket name for stored blocks.
+                        If empty it won't store any block inside Google Cloud Storage.
+                      type: string
+                peers:
+                  description: Peers is a DNS name for Thanos to discover peers through.
+                  type: string
+                s3:
+                  description: ThanosSpec defines parameters for of AWS Simple Storage
+                    Service (S3) with Thanos. (S3 compatible services apply as well)
+                  properties:
+                    accessKey:
+                      description: SecretKeySelector selects a key of a Secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or it's key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                    bucket:
+                      description: S3-Compatible API bucket name for stored blocks.
+                      type: string
+                    endpoint:
+                      description: S3-Compatible API endpoint for stored blocks.
+                      type: string
+                    insecure:
+                      description: Whether to use an insecure connection with an S3-Compatible
+                        API.
+                      type: boolean
+                    secretKey:
+                      description: SecretKeySelector selects a key of a Secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or it's key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                    signatureVersion2:
+                      description: Whether to use S3 Signature Version 2; otherwise
+                        Signature Version 4 will be used.
+                      type: boolean
+                tag:
+                  description: Tag of Thanos sidecar container image to be deployed.
+                    Defaults to the value of `version`.
+                  type: string
+                version:
+                  description: Version describes the version of Thanos to use.
+                  type: string
+            tolerations:
+              description: If specified, the pod's tolerations.
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
+                properties:
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
+                    type: string
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
+                    type: string
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
+                    type: string
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
+                    type: string
+              type: array
+            version:
+              description: Version of Prometheus to be deployed.
+              type: string
+        status:
+          description: 'Most recent observed status of the Prometheus cluster. Read-only.
+            Not included when requesting from the apiserver, only from the Prometheus
+            Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          properties:
+            availableReplicas:
+              description: Total number of available pods (ready for at least minReadySeconds)
+                targeted by this Prometheus deployment.
+              format: int32
+              type: integer
+            paused:
+              description: Represents whether any actions on the underlaying managed
+                objects are being performed. Only delete actions will be performed.
+              type: boolean
+            replicas:
+              description: Total number of non-terminated pods targeted by this Prometheus
+                deployment (their labels match the selector).
+              format: int32
+              type: integer
+            unavailableReplicas:
+              description: Total number of unavailable pods targeted by this Prometheus
+                deployment.
+              format: int32
+              type: integer
+            updatedReplicas:
+              description: Total number of non-terminated pods targeted by this Prometheus
+                deployment that have the desired version spec.
+              format: int32
+              type: integer
+          required:
+          - paused
+          - replicas
+          - updatedReplicas
+          - availableReplicas
+          - unavailableReplicas
+  version: v1

--- a/bundles/prometheus.0.14.0/manifests/prometheusoperator.0.14.0.clusterserviceversion.yaml
+++ b/bundles/prometheus.0.14.0/manifests/prometheusoperator.0.14.0.clusterserviceversion.yaml
@@ -1,0 +1,240 @@
+#! parse-kind: ClusterServiceVersion
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: prometheusoperator.0.14.0
+  namespace: placeholder
+spec:
+  displayName: Prometheus
+  description: |
+    An open-source monitoring system with a dimensional data model, flexible query language, efficient time series database and modern alerting approach.
+
+    _The Prometheus Open Cloud Service is Public Alpha. The goal before Beta is for additional user testing and minor bug fixes._
+
+    ### Monitoring applications
+
+    Prometheus scrapes your application metrics based on targets maintained in a ServiceMonitor object. When alerts need to be sent, they are processsed by an AlertManager.
+
+    [Read the complete guide to monitoring applications with the Prometheus Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/prometheus-ocs.html)
+
+    ## Supported Features
+
+    **High availability**
+    Multiple instances are run across failure zones and data is replicated. This keeps your monitoring available during an outage, when you need it most.
+    **Updates via automated operations**
+    New Prometheus versions are deployed using a rolling update with no downtime, making it easy to stay up to date.
+    **Handles the dynamic nature of containers**
+    Alerting rules are attached to groups of containers instead of individual instances, which is ideal for the highly dynamic nature of container deployment.
+
+  keywords: ['prometheus', 'monitoring', 'tsdb', 'alerting']
+
+  maintainers:
+  - name: CoreOS, Inc
+    email: support@coreos.com
+
+  provider:
+    name: CoreOS, Inc
+
+  links:
+  - name: Prometheus
+    url: https://www.prometheus.io/
+  - name: Documentation
+    url: https://coreos.com/operators/prometheus/docs/latest/
+  - name: Prometheus Operator Source Code
+    url: https://github.com/coreos/prometheus-operator
+
+  labels:
+    alm-status-descriptors: prometheusoperator.0.14.0
+    alm-owner-prometheus: prometheusoperator
+
+  selector:
+    matchLabels:
+      alm-owner-prometheus: prometheusoperator
+
+  icon:
+  - base64data: PHN2ZyB3aWR0aD0iMjQ5MCIgaGVpZ2h0PSIyNTAwIiB2aWV3Qm94PSIwIDAgMjU2IDI1NyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCI+PHBhdGggZD0iTTEyOC4wMDEuNjY3QzU3LjMxMS42NjcgMCA1Ny45NzEgMCAxMjguNjY0YzAgNzAuNjkgNTcuMzExIDEyNy45OTggMTI4LjAwMSAxMjcuOTk4UzI1NiAxOTkuMzU0IDI1NiAxMjguNjY0QzI1NiA1Ny45NyAxOTguNjg5LjY2NyAxMjguMDAxLjY2N3ptMCAyMzkuNTZjLTIwLjExMiAwLTM2LjQxOS0xMy40MzUtMzYuNDE5LTMwLjAwNGg3Mi44MzhjMCAxNi41NjYtMTYuMzA2IDMwLjAwNC0zNi40MTkgMzAuMDA0em02MC4xNTMtMzkuOTRINjcuODQyVjE3OC40N2gxMjAuMzE0djIxLjgxNmgtLjAwMnptLS40MzItMzMuMDQ1SDY4LjE4NWMtLjM5OC0uNDU4LS44MDQtLjkxLTEuMTg4LTEuMzc1LTEyLjMxNS0xNC45NTQtMTUuMjE2LTIyLjc2LTE4LjAzMi0zMC43MTYtLjA0OC0uMjYyIDE0LjkzMyAzLjA2IDI1LjU1NiA1LjQ1IDAgMCA1LjQ2NiAxLjI2NSAxMy40NTggMi43MjItNy42NzMtOC45OTQtMTIuMjMtMjAuNDI4LTEyLjIzLTMyLjExNiAwLTI1LjY1OCAxOS42OC00OC4wNzkgMTIuNTgtNjYuMjAxIDYuOTEuNTYyIDE0LjMgMTQuNTgzIDE0LjggMzYuNTA1IDcuMzQ2LTEwLjE1MiAxMC40Mi0yOC42OSAxMC40Mi00MC4wNTYgMC0xMS43NjkgNy43NTUtMjUuNDQgMTUuNTEyLTI1LjkwNy02LjkxNSAxMS4zOTYgMS43OSAyMS4xNjUgOS41MyA0NS40IDIuOTAyIDkuMTAzIDIuNTMyIDI0LjQyMyA0Ljc3MiAzNC4xMzguNzQ0LTIwLjE3OCA0LjIxMy00OS42MiAxNy4wMTQtNTkuNzg0LTUuNjQ3IDEyLjguODM2IDI4LjgxOCA1LjI3IDM2LjUxOCA3LjE1NCAxMi40MjQgMTEuNDkgMjEuODM2IDExLjQ5IDM5LjYzOCAwIDExLjkzNi00LjQwNyAyMy4xNzMtMTEuODQgMzEuOTU4IDguNDUyLTEuNTg2IDE0LjI4OS0zLjAxNiAxNC4yODktMy4wMTZsMjcuNDUtNS4zNTVjLjAwMi0uMDAyLTMuOTg3IDE2LjQwMS0xOS4zMTQgMzIuMTk3eiIgZmlsbD0iI0RBNEUzMSIvPjwvc3ZnPg==
+    mediatype: image/svg+xml
+
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+      - serviceAccountName: prometheus-k8s
+        rules:
+        - apiGroups: [""]
+          resources:
+          - nodes
+          - services
+          - endpoints
+          - pods
+          verbs: ["get", "list", "watch"]
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          verbs: ["get"]
+      - serviceAccountName: prometheus-operator-0-14-0
+        rules:
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs: ["get", "list"]
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - alertmanagers
+          - prometheuses
+          - servicemonitors
+          verbs:
+          - "*"
+        - apiGroups:
+          - apps
+          resources:
+          - statefulsets
+          verbs: ["*"]
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - secrets
+          verbs: ["*"]
+        - apiGroups: [""]
+          resources:
+          - pods
+          verbs: ["list", "delete"]
+        - apiGroups: [""]
+          resources:
+          - services
+          - endpoints
+          verbs: ["get", "create", "update"]
+        - apiGroups: [""]
+          resources:
+          - nodes
+          verbs: ["list", "watch"]
+        - apiGroups: [""]
+          resources:
+          - namespaces
+          verbs: ['list']
+      deployments:
+      - name: prometheus-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              k8s-app: prometheus-operator
+          template:
+            metadata:
+              labels:
+                k8s-app: prometheus-operator
+            spec:
+              serviceAccount: prometheus-operator-0-14-0
+              containers:
+              - name: prometheus-operator
+                image: quay.io/coreos/prometheus-operator@sha256:5037b4e90dbb03ebdefaa547ddf6a1f748c8eeebeedf6b9d9f0913ad662b5731
+                command:
+                  - sh
+                  - -c
+                  - >
+                    /bin/operator --namespace=$K8S_NAMESPACE --crd-apigroup monitoring.coreos.com
+                    --labels alm-status-descriptors=prometheusoperator.0.14.0,alm-owner-prometheus=prometheusoperator
+                    --kubelet-service=kube-system/kubelet
+                    --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+                env:
+                  - name: K8S_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.namespace
+                ports:
+                - containerPort: 8080
+                  name: http
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 100Mi
+                  requests:
+                    cpu: 100m
+                    memory: 50Mi
+  maturity: alpha
+  version: 0.14.0
+  customresourcedefinitions:
+    owned:
+    - name: prometheuses.monitoring.coreos.com
+      version: v1
+      kind: Prometheus
+      displayName: Prometheus
+      description: A running Prometheus instance
+      resources:
+        - kind: Pod
+          version: v1
+      specDescriptors:
+      - description: Desired number of Pods for the cluster
+        displayName: Size
+        path: replicas
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      - description: A selector for the ConfigMaps from which to load rule files
+        displayName: Rule Config Map Selector
+        path: ruleSelector
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:ConfigMap'
+      - description: ServiceMonitors to be selected for target discovery
+        displayName: Service Monitor Selector
+        path: serviceMonitorSelector
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:selector:monitoring.coreos.com:v1:ServiceMonitor'
+      - description: The ServiceAccount to use to run the Prometheus pods
+        displayName: Service Account
+        path: serviceAccountName
+        x-descriptors:
+          - 'urn:alm:descriptor:io.kubernetes:ServiceAccount'
+      - description: Define resources requests and limits for single Pods
+        displayName: Resource Request
+        path: resources.requests
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      statusDescriptors:
+        - description: The current number of Pods for the cluster
+          displayName: Cluster Size
+          path: replicas
+        - path: prometheusSelector
+          displayName: Prometheus Service Selector
+          description: Label selector to find the service that routes to this prometheus
+          x-descriptors:
+          - 'urn:alm:descriptor:label:selector'
+    - name: servicemonitors.monitoring.coreos.com
+      version: v1
+      kind: ServiceMonitor
+      displayName: Service Monitor
+      description: Configures prometheus to monitor a particular k8s service
+      resources:
+        - kind: Pod
+          version: v1
+      specDescriptors:
+      - description: Selector to select which namespaces the Endpoints objects are discovered from
+        displayName: Monitoring Namespaces
+        path: namespaceSelector
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:namespaceSelector'
+      - description: The label to use to retrieve the job name from
+        displayName: Job Label
+        path: jobLabel
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - description: A list of endpoints allowed as part of this ServiceMonitor
+        displayName: Endpoints
+        path: endpoints
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:endpointList'
+    - name: alertmanagers.monitoring.coreos.com
+      version: v1
+      kind: Alertmanager
+      displayName: Alert Manager
+      description: Configures an Alert Manager for the namespace
+      resources:
+        - kind: Pod
+          version: v1
+      specDescriptors:
+      - description: Desired number of Pods for the cluster
+        displayName: Size
+        path: replicas
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podCount'

--- a/bundles/prometheus.0.14.0/manifests/prometheusrule.crd.yaml
+++ b/bundles/prometheus.0.14.0/manifests/prometheusrule.crd.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: prometheusrules.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    kind: PrometheusRule
+    plural: prometheusrules
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: PrometheusRuleSpec contains specification parameters for a
+            Rule.
+          properties:
+            groups:
+              description: Content of Prometheus rule file
+              items:
+                description: RuleGroup is a list of sequentially evaluated recording
+                  and alerting rules.
+                properties:
+                  interval:
+                    type: string
+                  name:
+                    type: string
+                  rules:
+                    items:
+                      description: Rule describes an alerting or recording rule.
+                      properties:
+                        alert:
+                          type: string
+                        annotations:
+                          type: object
+                        expr:
+                          type: string
+                        for:
+                          type: string
+                        labels:
+                          type: object
+                        record:
+                          type: string
+                      required:
+                      - expr
+                    type: array
+                required:
+                - name
+                - rules
+              type: array
+  version: v1

--- a/bundles/prometheus.0.14.0/manifests/servicemonitor.crd.yaml
+++ b/bundles/prometheus.0.14.0/manifests/servicemonitor.crd.yaml
@@ -1,0 +1,224 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: servicemonitors.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    kind: ServiceMonitor
+    plural: servicemonitors
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: ServiceMonitorSpec contains specification parameters for a
+            ServiceMonitor.
+          properties:
+            endpoints:
+              description: A list of endpoints allowed as part of this ServiceMonitor.
+              items:
+                description: Endpoint defines a scrapeable endpoint serving Prometheus
+                  metrics.
+                properties:
+                  basicAuth:
+                    description: 'BasicAuth allow an endpoint to authenticate over
+                      basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                    properties:
+                      password:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or it's key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                      username:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or it's key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                  bearerTokenFile:
+                    description: File to read bearer token for scraping targets.
+                    type: string
+                  honorLabels:
+                    description: HonorLabels chooses the metric's labels on collisions
+                      with target labels.
+                    type: boolean
+                  interval:
+                    description: Interval at which metrics should be scraped
+                    type: string
+                  metricRelabelings:
+                    description: MetricRelabelConfigs to apply to samples before ingestion.
+                    items:
+                      description: 'RelabelConfig allows dynamic rewriting of the
+                        label set, being applied to samples before ingestion. It defines
+                        `<metric_relabel_configs>`-section of Prometheus configuration.
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                      properties:
+                        action:
+                          description: Action to perform based on regex matching.
+                            Default is 'replace'
+                          type: string
+                        modulus:
+                          description: Modulus to take of the hash of the source label
+                            values.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched. defailt is '(.*)'
+                          type: string
+                        replacement:
+                          description: Replacement value against which a regex replace
+                            is performed if the regular expression matches. Regex
+                            capture groups are available. Default is '$1'
+                          type: string
+                        separator:
+                          description: Separator placed between concatenated source
+                            label values. default is ';'.
+                          type: string
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            separator and matched against the configured regular expression
+                            for the replace, keep, and drop actions.
+                          items:
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: Label to which the resulting value is written
+                            in a replace action. It is mandatory for replace actions.
+                            Regex capture groups are available.
+                          type: string
+                    type: array
+                  params:
+                    description: Optional HTTP URL parameters
+                    type: object
+                  path:
+                    description: HTTP path to scrape for metrics.
+                    type: string
+                  port:
+                    description: Name of the service port this endpoint refers to.
+                      Mutually exclusive with targetPort.
+                    type: string
+                  proxyUrl:
+                    description: ProxyURL eg http://proxyserver:2195 Directs scrapes
+                      to proxy through this endpoint.
+                    type: string
+                  scheme:
+                    description: HTTP scheme to use for scraping.
+                    type: string
+                  scrapeTimeout:
+                    description: Timeout after which the scrape is ended
+                    type: string
+                  targetPort:
+                    anyOf:
+                    - type: string
+                    - type: integer
+                  tlsConfig:
+                    description: TLSConfig specifies TLS configuration parameters.
+                    properties:
+                      caFile:
+                        description: The CA cert to use for the targets.
+                        type: string
+                      certFile:
+                        description: The client cert file for the targets.
+                        type: string
+                      insecureSkipVerify:
+                        description: Disable target certificate validation.
+                        type: boolean
+                      keyFile:
+                        description: The client key file for the targets.
+                        type: string
+                      serverName:
+                        description: Used to verify the hostname for the targets.
+                        type: string
+              type: array
+            jobLabel:
+              description: The label to use to retrieve the job name from.
+              type: string
+            namespaceSelector:
+              description: A selector for selecting namespaces either selecting all
+                namespaces or a list of namespaces.
+              properties:
+                any:
+                  description: Boolean describing whether all namespaces are selected
+                    in contrast to a list restricting them.
+                  type: boolean
+                matchNames:
+                  description: List of namespace names.
+                  items:
+                    type: string
+                  type: array
+            selector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                                 of matchExpressions, whose key field is "key", the operator is
+                                 "In", and the values array contains only "value". The requirements
+                                 are ANDed.
+                  type: object
+            targetLabels:
+              description: TargetLabels transfers labels on the Kubernetes Service
+                onto the target.
+              items:
+                type: string
+              type: array
+          required:
+          - endpoints
+          - selector
+  version: v1

--- a/bundles/prometheus.0.14.0/metadata/annotations.yaml
+++ b/bundles/prometheus.0.14.0/metadata/annotations.yaml
@@ -1,0 +1,4 @@
+annotations:
+  operators.operatorframework.io.bundle.package.v1: "prometheus"
+  operators.operatorframework.io.bundle.channels.v1: "preview"
+  operators.operatorframework.io.bundle.channel.default.v1: "preview"

--- a/bundles/prometheus.0.15.0/manifests/alertmanager.crd.yaml
+++ b/bundles/prometheus.0.15.0/manifests/alertmanager.crd.yaml
@@ -1,0 +1,2398 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: alertmanagers.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    kind: Alertmanager
+    plural: alertmanagers
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: 'Specification of the desired behavior of the Alertmanager
+            cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          properties:
+            affinity:
+              description: Affinity is a group of affinity scheduling rules.
+              properties:
+                nodeAffinity:
+                  description: Node affinity is a group of node affinity scheduling
+                    rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node matches the corresponding matchExpressions; the
+                        node(s) with the highest sum are the most preferred.
+                      items:
+                        description: An empty preferred scheduling term matches all
+                          objects with implicit weight 0 (i.e. it's a no-op). A null
+                          preferred scheduling term matches no objects (i.e. is also
+                          a no-op).
+                        properties:
+                          preference:
+                            description: A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The
+                              TopologySelectorTerm type implements a subset of the
+                              NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                          weight:
+                            description: Weight associated with matching the corresponding
+                              nodeSelectorTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - preference
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: A node selector represents the union of the results
+                        of one or more label queries over a set of nodes; that is,
+                        it represents the OR of the selectors represented by the node
+                        selector terms.
+                      properties:
+                        nodeSelectorTerms:
+                          description: Required. A list of node selector terms. The
+                            terms are ORed.
+                          items:
+                            description: A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The
+                              TopologySelectorTerm type implements a subset of the
+                              NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                          type: array
+                      required:
+                      - nodeSelectorTerms
+                podAffinity:
+                  description: Pod affinity is a group of inter pod affinity scheduling
+                    rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node has pods which matches the corresponding podAffinityTerm;
+                        the node(s) with the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label selector is a label query over
+                                  a set of resources. The result of matchLabels and
+                                  matchExpressions are ANDed. An empty label selector
+                                  matches all objects. A null label selector matches
+                                  no objects.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                    type: array
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - podAffinityTerm
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to a pod label update), the system may or may not
+                        try to eventually evict the pod from its node. When there
+                        are multiple elements, the lists of nodes corresponding to
+                        each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label selector is a label query over a
+                              set of resources. The result of matchLabels and matchExpressions
+                              are ANDed. An empty label selector matches all objects.
+                              A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchLabels:
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                      type: array
+                podAntiAffinity:
+                  description: Pod anti affinity is a group of inter pod anti affinity
+                    scheduling rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the anti-affinity expressions specified by this
+                        field, but it may choose a node that violates one or more
+                        of the expressions. The node that is most preferred is the
+                        one with the greatest sum of weights, i.e. for each node that
+                        meets all of the scheduling requirements (resource request,
+                        requiredDuringScheduling anti-affinity expressions, etc.),
+                        compute a sum by iterating through the elements of this field
+                        and adding "weight" to the sum if the node has pods which
+                        matches the corresponding podAffinityTerm; the node(s) with
+                        the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label selector is a label query over
+                                  a set of resources. The result of matchLabels and
+                                  matchExpressions are ANDed. An empty label selector
+                                  matches all objects. A null label selector matches
+                                  no objects.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                    type: array
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - podAffinityTerm
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the anti-affinity requirements specified by
+                        this field are not met at scheduling time, the pod will not
+                        be scheduled onto the node. If the anti-affinity requirements
+                        specified by this field cease to be met at some point during
+                        pod execution (e.g. due to a pod label update), the system
+                        may or may not try to eventually evict the pod from its node.
+                        When there are multiple elements, the lists of nodes corresponding
+                        to each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label selector is a label query over a
+                              set of resources. The result of matchLabels and matchExpressions
+                              are ANDed. An empty label selector matches all objects.
+                              A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchLabels:
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                      type: array
+            baseImage:
+              description: Base image that is used to deploy pods, without tag.
+              type: string
+            containers:
+              description: Containers allows injecting additional containers. This
+                is meant to allow adding an authentication proxy to an Alertmanager
+                pod.
+              items:
+                description: A single application container that you want to run within
+                  a pod.
+                properties:
+                  args:
+                    description: 'Arguments to the entrypoint. The docker image''s
+                      CMD is used if this is not provided. Variable references $(VAR_NAME)
+                      are expanded using the container''s environment. If a variable
+                      cannot be resolved, the reference in the input string will be
+                      unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                      $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                      regardless of whether the variable exists or not. Cannot be
+                      updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    description: 'Entrypoint array. Not executed within a shell. The
+                      docker image''s ENTRYPOINT is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container''s
+                      environment. If a variable cannot be resolved, the reference
+                      in the input string will be unchanged. The $(VAR_NAME) syntax
+                      can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                      will never be expanded, regardless of whether the variable exists
+                      or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: List of environment variables to set in the container.
+                      Cannot be updated.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: EnvVarSource represents a source for the value
+                            of an EnvVar.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key from a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or it's
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                            fieldRef:
+                              description: ObjectFieldSelector selects an APIVersioned
+                                field of an object.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                            resourceFieldRef:
+                              description: ResourceFieldSelector represents container
+                                resources (cpu, memory) and their output format
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor: {}
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                            secretKeyRef:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or it's
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                      required:
+                      - name
+                    type: array
+                  envFrom:
+                    description: List of sources to populate environment variables
+                      in the container. The keys defined within a source must be a
+                      C_IDENTIFIER. All invalid keys will be reported as an event
+                      when the container is starting. When a key exists in multiple
+                      sources, the value associated with the last source will take
+                      precedence. Values defined by an Env with a duplicate key will
+                      take precedence. Cannot be updated.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: |-
+                            ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+
+                            The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: |-
+                            SecretEnvSource selects a Secret to populate the environment variables with.
+
+                            The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                    type: array
+                  image:
+                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                      This field is optional to allow higher level config management
+                      to default or override container images in workload controllers
+                      like Deployments and StatefulSets.'
+                    type: string
+                  imagePullPolicy:
+                    description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                      Defaults to Always if :latest tag is specified, or IfNotPresent
+                      otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                    type: string
+                  lifecycle:
+                    description: Lifecycle describes actions that the management system
+                      should take in response to container lifecycle events. For the
+                      PostStart and PreStop lifecycle handlers, management of the
+                      container blocks until the action is complete, unless the container
+                      process fails, in which case the handler is aborted.
+                    properties:
+                      postStart:
+                        description: Handler defines a specific action that should
+                          be taken
+                        properties:
+                          exec:
+                            description: ExecAction describes a "run in container"
+                              action.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                          httpGet:
+                            description: HTTPGetAction describes an action based on
+                              HTTP Get requests.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                          tcpSocket:
+                            description: TCPSocketAction describes an action based
+                              on opening a socket
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                            required:
+                            - port
+                      preStop:
+                        description: Handler defines a specific action that should
+                          be taken
+                        properties:
+                          exec:
+                            description: ExecAction describes a "run in container"
+                              action.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                          httpGet:
+                            description: HTTPGetAction describes an action based on
+                              HTTP Get requests.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                          tcpSocket:
+                            description: TCPSocketAction describes an action based
+                              on opening a socket
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                            required:
+                            - port
+                  livenessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: ExecAction describes a "run in container" action.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGetAction describes an action based on HTTP
+                          Get requests.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocketAction describes an action based on
+                          opening a socket
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                        required:
+                        - port
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                  name:
+                    description: Name of the container specified as a DNS_LABEL. Each
+                      container in a pod must have a unique name (DNS_LABEL). Cannot
+                      be updated.
+                    type: string
+                  ports:
+                    description: List of ports to expose from the container. Exposing
+                      a port here gives the system additional information about the
+                      network connections a container uses, but is primarily informational.
+                      Not specifying a port here DOES NOT prevent that port from being
+                      exposed. Any port which is listening on the default "0.0.0.0"
+                      address inside a container will be accessible from the network.
+                      Cannot be updated.
+                    items:
+                      description: ContainerPort represents a network port in a single
+                        container.
+                      properties:
+                        containerPort:
+                          description: Number of port to expose on the pod's IP address.
+                            This must be a valid port number, 0 < x < 65536.
+                          format: int32
+                          type: integer
+                        hostIP:
+                          description: What host IP to bind the external port to.
+                          type: string
+                        hostPort:
+                          description: Number of port to expose on the host. If specified,
+                            this must be a valid port number, 0 < x < 65536. If HostNetwork
+                            is specified, this must match ContainerPort. Most containers
+                            do not need this.
+                          format: int32
+                          type: integer
+                        name:
+                          description: If specified, this must be an IANA_SVC_NAME
+                            and unique within the pod. Each named port in a pod must
+                            have a unique name. Name for the port that can be referred
+                            to by services.
+                          type: string
+                        protocol:
+                          description: Protocol for port. Must be UDP or TCP. Defaults
+                            to "TCP".
+                          type: string
+                      required:
+                      - containerPort
+                    type: array
+                  readinessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: ExecAction describes a "run in container" action.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGetAction describes an action based on HTTP
+                          Get requests.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocketAction describes an action based on
+                          opening a socket
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                        required:
+                        - port
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                  securityContext:
+                    description: SecurityContext holds security configuration that
+                      will be applied to a container. Some fields are present in both
+                      SecurityContext and PodSecurityContext.  When both are set,
+                      the values in SecurityContext take precedence.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: Adds and removes POSIX capabilities from running
+                          containers.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              type: string
+                            type: array
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: SELinuxOptions are the labels to be applied to
+                          the container
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                  stdin:
+                    description: Whether this container should allocate a buffer for
+                      stdin in the container runtime. If this is not set, reads from
+                      stdin in the container will always result in EOF. Default is
+                      false.
+                    type: boolean
+                  stdinOnce:
+                    description: Whether the container runtime should close the stdin
+                      channel after it has been opened by a single attach. When stdin
+                      is true the stdin stream will remain open across multiple attach
+                      sessions. If stdinOnce is set to true, stdin is opened on container
+                      start, is empty until the first client attaches to stdin, and
+                      then remains open and accepts data until the client disconnects,
+                      at which time stdin is closed and remains closed until the container
+                      is restarted. If this flag is false, a container processes that
+                      reads from stdin will never receive an EOF. Default is false
+                    type: boolean
+                  terminationMessagePath:
+                    description: 'Optional: Path at which the file to which the container''s
+                      termination message will be written is mounted into the container''s
+                      filesystem. Message written is intended to be brief final status,
+                      such as an assertion failure message. Will be truncated by the
+                      node if greater than 4096 bytes. The total message length across
+                      all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                      Cannot be updated.'
+                    type: string
+                  terminationMessagePolicy:
+                    description: Indicate how the termination message should be populated.
+                      File will use the contents of terminationMessagePath to populate
+                      the container status message on both success and failure. FallbackToLogsOnError
+                      will use the last chunk of container log output if the termination
+                      message file is empty and the container exited with an error.
+                      The log output is limited to 2048 bytes or 80 lines, whichever
+                      is smaller. Defaults to File. Cannot be updated.
+                    type: string
+                  tty:
+                    description: Whether this container should allocate a TTY for
+                      itself, also requires 'stdin' to be true. Default is false.
+                    type: boolean
+                  volumeDevices:
+                    description: volumeDevices is the list of block devices to be
+                      used by the container. This is an alpha feature and may change
+                      in the future.
+                    items:
+                      description: volumeDevice describes a mapping of a raw block
+                        device within a container.
+                      properties:
+                        devicePath:
+                          description: devicePath is the path inside of the container
+                            that the device will be mapped to.
+                          type: string
+                        name:
+                          description: name must match the name of a persistentVolumeClaim
+                            in the pod
+                          type: string
+                      required:
+                      - name
+                      - devicePath
+                    type: array
+                  volumeMounts:
+                    description: Pod volumes to mount into the container's filesystem.
+                      Cannot be updated.
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: Path within the container at which the volume
+                            should be mounted.  Must not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: mountPropagation determines how mounts are
+                            propagated from the host to container and the other way
+                            around. When not set, MountPropagationHostToContainer
+                            is used. This field is beta in 1.10.
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: Mounted read-only if true, read-write otherwise
+                            (false or unspecified). Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: Path within the volume from which the container's
+                            volume should be mounted. Defaults to "" (volume's root).
+                          type: string
+                      required:
+                      - name
+                      - mountPath
+                    type: array
+                  workingDir:
+                    description: Container's working directory. If not specified,
+                      the container runtime's default will be used, which might be
+                      configured in the container image. Cannot be updated.
+                    type: string
+                required:
+                - name
+              type: array
+            externalUrl:
+              description: The external URL the Alertmanager instances will be available
+                under. This is necessary to generate correct URLs. This is necessary
+                if Alertmanager is not served from root of a DNS name.
+              type: string
+            imagePullSecrets:
+              description: An optional list of references to secrets in the same namespace
+                to use for pulling prometheus and alertmanager images from registries
+                see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
+              items:
+                description: LocalObjectReference contains enough information to let
+                  you locate the referenced object inside the same namespace.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+              type: array
+            listenLocal:
+              description: ListenLocal makes the Alertmanager server listen on loopback,
+                so that it does not bind against the Pod IP. Note this is only for
+                the Alertmanager UI, not the gossip communication.
+              type: boolean
+            logLevel:
+              description: Log level for Alertmanager to be configured with.
+              type: string
+            nodeSelector:
+              description: Define which Nodes the Pods are scheduled on.
+              type: object
+            paused:
+              description: If set to true all actions on the underlaying managed objects
+                are not goint to be performed, except for delete actions.
+              type: boolean
+            podMetadata:
+              description: ObjectMeta is metadata that all persisted resources must
+                have, which includes all objects users must create.
+              properties:
+                annotations:
+                  description: 'Annotations is an unstructured key value map stored
+                    with a resource that may be set by external tools to store and
+                    retrieve arbitrary metadata. They are not queryable and should
+                    be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                  type: object
+                clusterName:
+                  description: The name of the cluster which the object belongs to.
+                    This is used to distinguish resources with same name and namespace
+                    in different clusters. This field is not set anywhere right now
+                    and apiserver is going to ignore it if set in create or update
+                    request.
+                  type: string
+                creationTimestamp:
+                  description: Time is a wrapper around time.Time which supports correct
+                    marshaling to YAML and JSON.  Wrappers are provided for many of
+                    the factory methods that the time package offers.
+                  format: date-time
+                  type: string
+                deletionGracePeriodSeconds:
+                  description: Number of seconds allowed for this object to gracefully
+                    terminate before it will be removed from the system. Only set
+                    when deletionTimestamp is also set. May only be shortened. Read-only.
+                  format: int64
+                  type: integer
+                deletionTimestamp:
+                  description: Time is a wrapper around time.Time which supports correct
+                    marshaling to YAML and JSON.  Wrappers are provided for many of
+                    the factory methods that the time package offers.
+                  format: date-time
+                  type: string
+                finalizers:
+                  description: Must be empty before the object is deleted from the
+                    registry. Each entry is an identifier for the responsible component
+                    that will remove the entry from the list. If the deletionTimestamp
+                    of the object is non-nil, entries in this list can only be removed.
+                  items:
+                    type: string
+                  type: array
+                generateName:
+                  description: |-
+                    GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+                    If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
+                    Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                  type: string
+                generation:
+                  description: A sequence number representing a specific generation
+                    of the desired state. Populated by the system. Read-only.
+                  format: int64
+                  type: integer
+                initializers:
+                  description: Initializers tracks the progress of initialization.
+                  properties:
+                    pending:
+                      description: Pending is a list of initializers that must execute
+                        in order before this object is visible. When the last pending
+                        initializer is removed, and no failing result is set, the
+                        initializers struct will be set to nil and the object is considered
+                        as initialized and visible to all clients.
+                      items:
+                        description: Initializer is information about an initializer
+                          that has not yet completed.
+                        properties:
+                          name:
+                            description: name of the process that is responsible for
+                              initializing this object.
+                            type: string
+                        required:
+                        - name
+                      type: array
+                    result:
+                      description: Status is a return value for calls that don't return
+                        other objects.
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of
+                            this representation of an object. Servers should convert
+                            recognized schemas to the latest internal value, and may
+                            reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                          type: string
+                        code:
+                          description: Suggested HTTP return code for this status,
+                            0 if not set.
+                          format: int32
+                          type: integer
+                        details:
+                          description: StatusDetails is a set of additional properties
+                            that MAY be set by the server to provide additional information
+                            about a response. The Reason field of a Status object
+                            defines what attributes will be set. Clients must ignore
+                            fields that do not match the defined type of each attribute,
+                            and should assume that any attribute may be empty, invalid,
+                            or under defined.
+                          properties:
+                            causes:
+                              description: The Causes array includes more details
+                                associated with the StatusReason failure. Not all
+                                StatusReasons may provide detailed causes.
+                              items:
+                                description: StatusCause provides more information
+                                  about an api.Status failure, including cases when
+                                  multiple errors are encountered.
+                                properties:
+                                  field:
+                                    description: |-
+                                      The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
+                                      Examples:
+                                        "name" - the field "name" on the current resource
+                                        "items[0].name" - the field "name" on the first array entry in "items"
+                                    type: string
+                                  message:
+                                    description: A human-readable description of the
+                                      cause of the error.  This field may be presented
+                                      as-is to a reader.
+                                    type: string
+                                  reason:
+                                    description: A machine-readable description of
+                                      the cause of the error. If this value is empty
+                                      there is no information available.
+                                    type: string
+                              type: array
+                            group:
+                              description: The group attribute of the resource associated
+                                with the status StatusReason.
+                              type: string
+                            kind:
+                              description: 'The kind attribute of the resource associated
+                                with the status StatusReason. On some operations may
+                                differ from the requested resource Kind. More info:
+                                https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: The name attribute of the resource associated
+                                with the status StatusReason (when there is a single
+                                name which can be described).
+                              type: string
+                            retryAfterSeconds:
+                              description: If specified, the time in seconds before
+                                the operation should be retried. Some errors may indicate
+                                the client must take an alternate action - for those
+                                errors this field may indicate how long to wait before
+                                taking the alternate action.
+                              format: int32
+                              type: integer
+                            uid:
+                              description: 'UID of the resource. (when there is a
+                                single resource which can be described). More info:
+                                http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST
+                            resource this object represents. Servers may infer this
+                            from the endpoint the client submits requests to. Cannot
+                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                          type: string
+                        message:
+                          description: A human-readable description of the status
+                            of this operation.
+                          type: string
+                        metadata:
+                          description: ListMeta describes metadata that synthetic
+                            resources must have, including lists and various status
+                            objects. A resource may have only one of {ObjectMeta,
+                            ListMeta}.
+                          properties:
+                            continue:
+                              description: continue may be set if the user set a limit
+                                on the number of items returned, and indicates that
+                                the server has more data available. The value is opaque
+                                and may be used to issue another request to the endpoint
+                                that served this list to retrieve the next set of
+                                available objects. Continuing a list may not be possible
+                                if the server configuration has changed or more than
+                                a few minutes have passed. The resourceVersion field
+                                returned when using this continue value will be identical
+                                to the value in the first response.
+                              type: string
+                            resourceVersion:
+                              description: 'String that identifies the server''s internal
+                                version of this object that can be used by clients
+                                to determine when objects have changed. Value must
+                                be treated as opaque by clients and passed unmodified
+                                back to the server. Populated by the system. Read-only.
+                                More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            selfLink:
+                              description: selfLink is a URL representing this object.
+                                Populated by the system. Read-only.
+                              type: string
+                        reason:
+                          description: A machine-readable description of why this
+                            operation is in the "Failure" status. If this value is
+                            empty there is no information available. A Reason clarifies
+                            an HTTP status code but does not override it.
+                          type: string
+                        status:
+                          description: 'Status of the operation. One of: "Success"
+                            or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                          type: string
+                  required:
+                  - pending
+                labels:
+                  description: 'Map of string keys and values that can be used to
+                    organize and categorize (scope and select) objects. May match
+                    selectors of replication controllers and services. More info:
+                    http://kubernetes.io/docs/user-guide/labels'
+                  type: object
+                name:
+                  description: 'Name must be unique within a namespace. Is required
+                    when creating resources, although some resources may allow a client
+                    to request the generation of an appropriate name automatically.
+                    Name is primarily intended for creation idempotence and configuration
+                    definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+                    Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                  type: string
+                ownerReferences:
+                  description: List of objects depended by this object. If ALL objects
+                    in the list have been deleted, this object will be garbage collected.
+                    If this object is managed by a controller, then an entry in this
+                    list will point to this controller, with the controller field
+                    set to true. There cannot be more than one managing controller.
+                  items:
+                    description: OwnerReference contains enough information to let
+                      you identify an owning object. Currently, an owning object must
+                      be in the same namespace, so there is no namespace field.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      blockOwnerDeletion:
+                        description: If true, AND if the owner has the "foregroundDeletion"
+                          finalizer, then the owner cannot be deleted from the key-value
+                          store until this reference is removed. Defaults to false.
+                          To set this field, a user needs "delete" permission of the
+                          owner, otherwise 422 (Unprocessable Entity) will be returned.
+                        type: boolean
+                      controller:
+                        description: If true, this reference points to the managing
+                          controller.
+                        type: boolean
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                  type: array
+                resourceVersion:
+                  description: |-
+                    An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+                    Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                  type: string
+                selfLink:
+                  description: SelfLink is a URL representing this object. Populated
+                    by the system. Read-only.
+                  type: string
+                uid:
+                  description: |-
+                    UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+                    Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                  type: string
+            replicas:
+              description: Size is the expected size of the alertmanager cluster.
+                The controller will eventually make the size of the running cluster
+                equal to the expected size.
+              format: int32
+              type: integer
+            resources:
+              description: ResourceRequirements describes the compute resource requirements.
+              properties:
+                limits:
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+            routePrefix:
+              description: The route prefix Alertmanager registers HTTP handlers for.
+                This is useful, if using ExternalURL and a proxy is rewriting HTTP
+                routes of a request, and the actual ExternalURL is still true, but
+                the server serves requests under a different route prefix. For example
+                for use with `kubectl proxy`.
+              type: string
+            secrets:
+              description: Secrets is a list of Secrets in the same namespace as the
+                Alertmanager object, which shall be mounted into the Alertmanager
+                Pods. The Secrets are mounted into /etc/alertmanager/secrets/<secret-name>.
+              items:
+                type: string
+              type: array
+            securityContext:
+              description: PodSecurityContext holds pod-level security attributes
+                and common container settings. Some fields are also present in container.securityContext.  Field
+                values of container.securityContext take precedence over field values
+                of PodSecurityContext.
+              properties:
+                fsGroup:
+                  description: |-
+                    A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                    1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                    If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                  format: int64
+                  type: integer
+                runAsGroup:
+                  description: The GID to run the entrypoint of the container process.
+                    Uses runtime default if unset. May also be set in SecurityContext.  If
+                    set in both SecurityContext and PodSecurityContext, the value
+                    specified in SecurityContext takes precedence for that container.
+                  format: int64
+                  type: integer
+                runAsNonRoot:
+                  description: Indicates that the container must run as a non-root
+                    user. If true, the Kubelet will validate the image at runtime
+                    to ensure that it does not run as UID 0 (root) and fail to start
+                    the container if it does. If unset or false, no such validation
+                    will be performed. May also be set in SecurityContext.  If set
+                    in both SecurityContext and PodSecurityContext, the value specified
+                    in SecurityContext takes precedence.
+                  type: boolean
+                runAsUser:
+                  description: The UID to run the entrypoint of the container process.
+                    Defaults to user specified in image metadata if unspecified. May
+                    also be set in SecurityContext.  If set in both SecurityContext
+                    and PodSecurityContext, the value specified in SecurityContext
+                    takes precedence for that container.
+                  format: int64
+                  type: integer
+                seLinuxOptions:
+                  description: SELinuxOptions are the labels to be applied to the
+                    container
+                  properties:
+                    level:
+                      description: Level is SELinux level label that applies to the
+                        container.
+                      type: string
+                    role:
+                      description: Role is a SELinux role label that applies to the
+                        container.
+                      type: string
+                    type:
+                      description: Type is a SELinux type label that applies to the
+                        container.
+                      type: string
+                    user:
+                      description: User is a SELinux user label that applies to the
+                        container.
+                      type: string
+                supplementalGroups:
+                  description: A list of groups applied to the first process run in
+                    each container, in addition to the container's primary GID.  If
+                    unspecified, no groups will be added to any container.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                sysctls:
+                  description: Sysctls hold a list of namespaced sysctls used for
+                    the pod. Pods with unsupported sysctls (by the container runtime)
+                    might fail to launch.
+                  items:
+                    description: Sysctl defines a kernel parameter to be set
+                    properties:
+                      name:
+                        description: Name of a property to set
+                        type: string
+                      value:
+                        description: Value of a property to set
+                        type: string
+                    required:
+                    - name
+                    - value
+                  type: array
+            serviceAccountName:
+              description: ServiceAccountName is the name of the ServiceAccount to
+                use to run the Prometheus Pods.
+              type: string
+            storage:
+              description: StorageSpec defines the configured storage for a group
+                Prometheus servers.
+              properties:
+                class:
+                  description: 'Name of the StorageClass to use when requesting storage
+                    provisioning. More info: https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses
+                    DEPRECATED'
+                  type: string
+                emptyDir:
+                  description: Represents an empty directory for a pod. Empty directory
+                    volumes support ownership management and SELinux relabeling.
+                  properties:
+                    medium:
+                      description: 'What type of storage medium should back this directory.
+                        The default is "" which means to use the node''s default medium.
+                        Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                      type: string
+                    sizeLimit: {}
+                resources:
+                  description: ResourceRequirements describes the compute resource
+                    requirements.
+                  properties:
+                    limits:
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                selector:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                      type: array
+                    matchLabels:
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                                     of matchExpressions, whose key field is "key", the operator
+                                     is "In", and the values array contains only "value". The requirements
+                                     are ANDed.
+                      type: object
+                volumeClaimTemplate:
+                  description: PersistentVolumeClaim is a user's request for and claim
+                    to a persistent volume
+                  properties:
+                    apiVersion:
+                      description: 'APIVersion defines the versioned schema of this
+                        representation of an object. Servers should convert recognized
+                        schemas to the latest internal value, and may reject unrecognized
+                        values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                      type: string
+                    kind:
+                      description: 'Kind is a string value representing the REST resource
+                        this object represents. Servers may infer this from the endpoint
+                        the client submits requests to. Cannot be updated. In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                      type: string
+                    metadata:
+                      description: ObjectMeta is metadata that all persisted resources
+                        must have, which includes all objects users must create.
+                      properties:
+                        annotations:
+                          description: 'Annotations is an unstructured key value map
+                            stored with a resource that may be set by external tools
+                            to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: http://kubernetes.io/docs/user-guide/annotations'
+                          type: object
+                        clusterName:
+                          description: The name of the cluster which the object belongs
+                            to. This is used to distinguish resources with same name
+                            and namespace in different clusters. This field is not
+                            set anywhere right now and apiserver is going to ignore
+                            it if set in create or update request.
+                          type: string
+                        creationTimestamp:
+                          description: Time is a wrapper around time.Time which supports
+                            correct marshaling to YAML and JSON.  Wrappers are provided
+                            for many of the factory methods that the time package
+                            offers.
+                          format: date-time
+                          type: string
+                        deletionGracePeriodSeconds:
+                          description: Number of seconds allowed for this object to
+                            gracefully terminate before it will be removed from the
+                            system. Only set when deletionTimestamp is also set. May
+                            only be shortened. Read-only.
+                          format: int64
+                          type: integer
+                        deletionTimestamp:
+                          description: Time is a wrapper around time.Time which supports
+                            correct marshaling to YAML and JSON.  Wrappers are provided
+                            for many of the factory methods that the time package
+                            offers.
+                          format: date-time
+                          type: string
+                        finalizers:
+                          description: Must be empty before the object is deleted
+                            from the registry. Each entry is an identifier for the
+                            responsible component that will remove the entry from
+                            the list. If the deletionTimestamp of the object is non-nil,
+                            entries in this list can only be removed.
+                          items:
+                            type: string
+                          type: array
+                        generateName:
+                          description: |-
+                            GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+                            If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
+                            Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                          type: string
+                        generation:
+                          description: A sequence number representing a specific generation
+                            of the desired state. Populated by the system. Read-only.
+                          format: int64
+                          type: integer
+                        initializers:
+                          description: Initializers tracks the progress of initialization.
+                          properties:
+                            pending:
+                              description: Pending is a list of initializers that
+                                must execute in order before this object is visible.
+                                When the last pending initializer is removed, and
+                                no failing result is set, the initializers struct
+                                will be set to nil and the object is considered as
+                                initialized and visible to all clients.
+                              items:
+                                description: Initializer is information about an initializer
+                                  that has not yet completed.
+                                properties:
+                                  name:
+                                    description: name of the process that is responsible
+                                      for initializing this object.
+                                    type: string
+                                required:
+                                - name
+                              type: array
+                            result:
+                              description: Status is a return value for calls that
+                                don't return other objects.
+                              properties:
+                                apiVersion:
+                                  description: 'APIVersion defines the versioned schema
+                                    of this representation of an object. Servers should
+                                    convert recognized schemas to the latest internal
+                                    value, and may reject unrecognized values. More
+                                    info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                                  type: string
+                                code:
+                                  description: Suggested HTTP return code for this
+                                    status, 0 if not set.
+                                  format: int32
+                                  type: integer
+                                details:
+                                  description: StatusDetails is a set of additional
+                                    properties that MAY be set by the server to provide
+                                    additional information about a response. The Reason
+                                    field of a Status object defines what attributes
+                                    will be set. Clients must ignore fields that do
+                                    not match the defined type of each attribute,
+                                    and should assume that any attribute may be empty,
+                                    invalid, or under defined.
+                                  properties:
+                                    causes:
+                                      description: The Causes array includes more
+                                        details associated with the StatusReason failure.
+                                        Not all StatusReasons may provide detailed
+                                        causes.
+                                      items:
+                                        description: StatusCause provides more information
+                                          about an api.Status failure, including cases
+                                          when multiple errors are encountered.
+                                        properties:
+                                          field:
+                                            description: |-
+                                              The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
+                                              Examples:
+                                                "name" - the field "name" on the current resource
+                                                "items[0].name" - the field "name" on the first array entry in "items"
+                                            type: string
+                                          message:
+                                            description: A human-readable description
+                                              of the cause of the error.  This field
+                                              may be presented as-is to a reader.
+                                            type: string
+                                          reason:
+                                            description: A machine-readable description
+                                              of the cause of the error. If this value
+                                              is empty there is no information available.
+                                            type: string
+                                      type: array
+                                    group:
+                                      description: The group attribute of the resource
+                                        associated with the status StatusReason.
+                                      type: string
+                                    kind:
+                                      description: 'The kind attribute of the resource
+                                        associated with the status StatusReason. On
+                                        some operations may differ from the requested
+                                        resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: The name attribute of the resource
+                                        associated with the status StatusReason (when
+                                        there is a single name which can be described).
+                                      type: string
+                                    retryAfterSeconds:
+                                      description: If specified, the time in seconds
+                                        before the operation should be retried. Some
+                                        errors may indicate the client must take an
+                                        alternate action - for those errors this field
+                                        may indicate how long to wait before taking
+                                        the alternate action.
+                                      format: int32
+                                      type: integer
+                                    uid:
+                                      description: 'UID of the resource. (when there
+                                        is a single resource which can be described).
+                                        More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                      type: string
+                                kind:
+                                  description: 'Kind is a string value representing
+                                    the REST resource this object represents. Servers
+                                    may infer this from the endpoint the client submits
+                                    requests to. Cannot be updated. In CamelCase.
+                                    More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                  type: string
+                                message:
+                                  description: A human-readable description of the
+                                    status of this operation.
+                                  type: string
+                                metadata:
+                                  description: ListMeta describes metadata that synthetic
+                                                 resources must have, including lists and various
+                                                 status objects. A resource may have only one of
+                                    {ObjectMeta, ListMeta}.
+                                  properties:
+                                    continue:
+                                      description: continue may be set if the user
+                                        set a limit on the number of items returned,
+                                        and indicates that the server has more data
+                                        available. The value is opaque and may be
+                                        used to issue another request to the endpoint
+                                        that served this list to retrieve the next
+                                        set of available objects. Continuing a list
+                                        may not be possible if the server configuration
+                                        has changed or more than a few minutes have
+                                        passed. The resourceVersion field returned
+                                        when using this continue value will be identical
+                                        to the value in the first response.
+                                      type: string
+                                    resourceVersion:
+                                      description: 'String that identifies the server''s
+                                        internal version of this object that can be
+                                        used by clients to determine when objects
+                                        have changed. Value must be treated as opaque
+                                        by clients and passed unmodified back to the
+                                        server. Populated by the system. Read-only.
+                                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                                      type: string
+                                    selfLink:
+                                      description: selfLink is a URL representing
+                                        this object. Populated by the system. Read-only.
+                                      type: string
+                                reason:
+                                  description: A machine-readable description of why
+                                    this operation is in the "Failure" status. If
+                                    this value is empty there is no information available.
+                                    A Reason clarifies an HTTP status code but does
+                                    not override it.
+                                  type: string
+                                status:
+                                  description: 'Status of the operation. One of: "Success"
+                                    or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                                  type: string
+                          required:
+                          - pending
+                        labels:
+                          description: 'Map of string keys and values that can be
+                            used to organize and categorize (scope and select) objects.
+                            May match selectors of replication controllers and services.
+                            More info: http://kubernetes.io/docs/user-guide/labels'
+                          type: object
+                        name:
+                          description: 'Name must be unique within a namespace. Is
+                            required when creating resources, although some resources
+                            may allow a client to request the generation of an appropriate
+                            name automatically. Name is primarily intended for creation
+                            idempotence and configuration definition. Cannot be updated.
+                            More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+                            Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                          type: string
+                        ownerReferences:
+                          description: List of objects depended by this object. If
+                            ALL objects in the list have been deleted, this object
+                            will be garbage collected. If this object is managed by
+                            a controller, then an entry in this list will point to
+                            this controller, with the controller field set to true.
+                            There cannot be more than one managing controller.
+                          items:
+                            description: OwnerReference contains enough information
+                              to let you identify an owning object. Currently, an
+                              owning object must be in the same namespace, so there
+                              is no namespace field.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              blockOwnerDeletion:
+                                description: If true, AND if the owner has the "foregroundDeletion"
+                                               finalizer, then the owner cannot be deleted from
+                                               the key-value store until this reference is removed.
+                                               Defaults to false. To set this field, a user needs
+                                               "delete" permission of the owner, otherwise 422
+                                               (Unprocessable Entity) will be returned.
+                                type: boolean
+                              controller:
+                                description: If true, this reference points to the
+                                  managing controller.
+                                type: boolean
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                type: string
+                            required:
+                            - apiVersion
+                            - kind
+                            - name
+                            - uid
+                          type: array
+                        resourceVersion:
+                          description: |-
+                            An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+                            Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                          type: string
+                        selfLink:
+                          description: SelfLink is a URL representing this object.
+                            Populated by the system. Read-only.
+                          type: string
+                        uid:
+                          description: |-
+                            UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+                            Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                          type: string
+                    spec:
+                      description: PersistentVolumeClaimSpec describes the common
+                        attributes of storage devices and allows a Source for provider-specific
+                        attributes
+                      properties:
+                        accessModes:
+                          description: 'AccessModes contains the desired access modes
+                            the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          items:
+                            type: string
+                          type: array
+                        resources:
+                          description: ResourceRequirements describes the compute
+                            resource requirements.
+                          properties:
+                            limits:
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                        selector:
+                          description: A label selector is a label query over a set
+                            of resources. The result of matchLabels and matchExpressions
+                            are ANDed. An empty label selector matches all objects.
+                            A null label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                              type: array
+                            matchLabels:
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                        storageClassName:
+                          description: 'Name of the StorageClass required by the claim.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                          type: string
+                        volumeMode:
+                          description: volumeMode defines what type of volume is required
+                            by the claim. Value of Filesystem is implied when not
+                            included in claim spec. This is an alpha feature and may
+                            change in the future.
+                          type: string
+                        volumeName:
+                          description: VolumeName is the binding reference to the
+                            PersistentVolume backing this claim.
+                          type: string
+                    status:
+                      description: PersistentVolumeClaimStatus is the current status
+                        of a persistent volume claim.
+                      properties:
+                        accessModes:
+                          description: 'AccessModes contains the actual access modes
+                            the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          items:
+                            type: string
+                          type: array
+                        capacity:
+                          description: Represents the actual resources of the underlying
+                            volume.
+                          type: object
+                        conditions:
+                          description: Current Condition of persistent volume claim.
+                            If underlying persistent volume is being resized then
+                            the Condition will be set to 'ResizeStarted'.
+                          items:
+                            description: PersistentVolumeClaimCondition contails details
+                              about state of pvc
+                            properties:
+                              lastProbeTime:
+                                description: Time is a wrapper around time.Time which
+                                  supports correct marshaling to YAML and JSON.  Wrappers
+                                  are provided for many of the factory methods that
+                                  the time package offers.
+                                format: date-time
+                                type: string
+                              lastTransitionTime:
+                                description: Time is a wrapper around time.Time which
+                                  supports correct marshaling to YAML and JSON.  Wrappers
+                                  are provided for many of the factory methods that
+                                  the time package offers.
+                                format: date-time
+                                type: string
+                              message:
+                                description: Human-readable message indicating details
+                                  about last transition.
+                                type: string
+                              reason:
+                                description: Unique, this should be a short, machine
+                                  understandable string that gives the reason for
+                                  condition's last transition. If it reports "ResizeStarted"
+                                  that means the underlying persistent volume is being
+                                  resized.
+                                type: string
+                              status:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - type
+                            - status
+                          type: array
+                        phase:
+                          description: Phase represents the current phase of PersistentVolumeClaim.
+                          type: string
+            tag:
+              description: Tag of Alertmanager container image to be deployed. Defaults
+                to the value of `version`.
+              type: string
+            tolerations:
+              description: If specified, the pod's tolerations.
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
+                properties:
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
+                    type: string
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
+                    type: string
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
+                    type: string
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
+                    type: string
+              type: array
+            version:
+              description: Version the cluster should be on.
+              type: string
+        status:
+          description: 'Most recent observed status of the Alertmanager cluster. Read-only.
+            Not included when requesting from the apiserver, only from the Prometheus
+            Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          properties:
+            availableReplicas:
+              description: Total number of available pods (ready for at least minReadySeconds)
+                targeted by this Alertmanager cluster.
+              format: int32
+              type: integer
+            paused:
+              description: Represents whether any actions on the underlaying managed
+                objects are being performed. Only delete actions will be performed.
+              type: boolean
+            replicas:
+              description: Total number of non-terminated pods targeted by this Alertmanager
+                cluster (their labels match the selector).
+              format: int32
+              type: integer
+            unavailableReplicas:
+              description: Total number of unavailable pods targeted by this Alertmanager
+                cluster.
+              format: int32
+              type: integer
+            updatedReplicas:
+              description: Total number of non-terminated pods targeted by this Alertmanager
+                cluster that have the desired version spec.
+              format: int32
+              type: integer
+          required:
+          - paused
+          - replicas
+          - updatedReplicas
+          - availableReplicas
+          - unavailableReplicas
+  version: v1

--- a/bundles/prometheus.0.15.0/manifests/prometheus.crd.yaml
+++ b/bundles/prometheus.0.15.0/manifests/prometheus.crd.yaml
@@ -1,0 +1,2971 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: prometheuses.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    kind: Prometheus
+    plural: prometheuses
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: 'Specification of the desired behavior of the Prometheus cluster.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          properties:
+            additionalAlertManagerConfigs:
+              description: SecretKeySelector selects a key of a Secret.
+              properties:
+                key:
+                  description: The key of the secret to select from.  Must be a valid
+                    secret key.
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                optional:
+                  description: Specify whether the Secret or it's key must be defined
+                  type: boolean
+              required:
+              - key
+            additionalScrapeConfigs:
+              description: SecretKeySelector selects a key of a Secret.
+              properties:
+                key:
+                  description: The key of the secret to select from.  Must be a valid
+                    secret key.
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                optional:
+                  description: Specify whether the Secret or it's key must be defined
+                  type: boolean
+              required:
+              - key
+            affinity:
+              description: Affinity is a group of affinity scheduling rules.
+              properties:
+                nodeAffinity:
+                  description: Node affinity is a group of node affinity scheduling
+                    rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node matches the corresponding matchExpressions; the
+                        node(s) with the highest sum are the most preferred.
+                      items:
+                        description: An empty preferred scheduling term matches all
+                          objects with implicit weight 0 (i.e. it's a no-op). A null
+                          preferred scheduling term matches no objects (i.e. is also
+                          a no-op).
+                        properties:
+                          preference:
+                            description: A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The
+                              TopologySelectorTerm type implements a subset of the
+                              NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                          weight:
+                            description: Weight associated with matching the corresponding
+                              nodeSelectorTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - preference
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: A node selector represents the union of the results
+                        of one or more label queries over a set of nodes; that is,
+                        it represents the OR of the selectors represented by the node
+                        selector terms.
+                      properties:
+                        nodeSelectorTerms:
+                          description: Required. A list of node selector terms. The
+                            terms are ORed.
+                          items:
+                            description: A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The
+                              TopologySelectorTerm type implements a subset of the
+                              NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                          type: array
+                      required:
+                      - nodeSelectorTerms
+                podAffinity:
+                  description: Pod affinity is a group of inter pod affinity scheduling
+                    rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node has pods which matches the corresponding podAffinityTerm;
+                        the node(s) with the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label selector is a label query over
+                                  a set of resources. The result of matchLabels and
+                                  matchExpressions are ANDed. An empty label selector
+                                  matches all objects. A null label selector matches
+                                  no objects.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                    type: array
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - podAffinityTerm
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to a pod label update), the system may or may not
+                        try to eventually evict the pod from its node. When there
+                        are multiple elements, the lists of nodes corresponding to
+                        each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label selector is a label query over a
+                              set of resources. The result of matchLabels and matchExpressions
+                              are ANDed. An empty label selector matches all objects.
+                              A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchLabels:
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                      type: array
+                podAntiAffinity:
+                  description: Pod anti affinity is a group of inter pod anti affinity
+                    scheduling rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the anti-affinity expressions specified by this
+                        field, but it may choose a node that violates one or more
+                        of the expressions. The node that is most preferred is the
+                        one with the greatest sum of weights, i.e. for each node that
+                        meets all of the scheduling requirements (resource request,
+                        requiredDuringScheduling anti-affinity expressions, etc.),
+                        compute a sum by iterating through the elements of this field
+                        and adding "weight" to the sum if the node has pods which
+                        matches the corresponding podAffinityTerm; the node(s) with
+                        the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label selector is a label query over
+                                  a set of resources. The result of matchLabels and
+                                  matchExpressions are ANDed. An empty label selector
+                                  matches all objects. A null label selector matches
+                                  no objects.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                    type: array
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - podAffinityTerm
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the anti-affinity requirements specified by
+                        this field are not met at scheduling time, the pod will not
+                        be scheduled onto the node. If the anti-affinity requirements
+                        specified by this field cease to be met at some point during
+                        pod execution (e.g. due to a pod label update), the system
+                        may or may not try to eventually evict the pod from its node.
+                        When there are multiple elements, the lists of nodes corresponding
+                        to each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label selector is a label query over a
+                              set of resources. The result of matchLabels and matchExpressions
+                              are ANDed. An empty label selector matches all objects.
+                              A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchLabels:
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                      type: array
+            alerting:
+              description: AlertingSpec defines parameters for alerting configuration
+                of Prometheus servers.
+              properties:
+                alertmanagers:
+                  description: AlertmanagerEndpoints Prometheus should fire alerts
+                    against.
+                  items:
+                    description: AlertmanagerEndpoints defines a selection of a single
+                      Endpoints object containing alertmanager IPs to fire alerts
+                      against.
+                    properties:
+                      bearerTokenFile:
+                        description: BearerTokenFile to read from filesystem to use
+                          when authenticating to Alertmanager.
+                        type: string
+                      name:
+                        description: Name of Endpoints object in Namespace.
+                        type: string
+                      namespace:
+                        description: Namespace of Endpoints object.
+                        type: string
+                      pathPrefix:
+                        description: Prefix for the HTTP path alerts are pushed to.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: string
+                        - type: integer
+                      scheme:
+                        description: Scheme to use when firing alerts.
+                        type: string
+                      tlsConfig:
+                        description: TLSConfig specifies TLS configuration parameters.
+                        properties:
+                          caFile:
+                            description: The CA cert to use for the targets.
+                            type: string
+                          certFile:
+                            description: The client cert file for the targets.
+                            type: string
+                          insecureSkipVerify:
+                            description: Disable target certificate validation.
+                            type: boolean
+                          keyFile:
+                            description: The client key file for the targets.
+                            type: string
+                          serverName:
+                            description: Used to verify the hostname for the targets.
+                            type: string
+                    required:
+                    - namespace
+                    - name
+                    - port
+                  type: array
+              required:
+              - alertmanagers
+            baseImage:
+              description: Base image to use for a Prometheus deployment.
+              type: string
+            containers:
+              description: Containers allows injecting additional containers. This
+                is meant to allow adding an authentication proxy to a Prometheus pod.
+              items:
+                description: A single application container that you want to run within
+                  a pod.
+                properties:
+                  args:
+                    description: 'Arguments to the entrypoint. The docker image''s
+                      CMD is used if this is not provided. Variable references $(VAR_NAME)
+                      are expanded using the container''s environment. If a variable
+                      cannot be resolved, the reference in the input string will be
+                      unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                      $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                      regardless of whether the variable exists or not. Cannot be
+                      updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    description: 'Entrypoint array. Not executed within a shell. The
+                      docker image''s ENTRYPOINT is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container''s
+                      environment. If a variable cannot be resolved, the reference
+                      in the input string will be unchanged. The $(VAR_NAME) syntax
+                      can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                      will never be expanded, regardless of whether the variable exists
+                      or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: List of environment variables to set in the container.
+                      Cannot be updated.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: EnvVarSource represents a source for the value
+                            of an EnvVar.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key from a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or it's
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                            fieldRef:
+                              description: ObjectFieldSelector selects an APIVersioned
+                                field of an object.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                            resourceFieldRef:
+                              description: ResourceFieldSelector represents container
+                                resources (cpu, memory) and their output format
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor: {}
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                            secretKeyRef:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or it's
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                      required:
+                      - name
+                    type: array
+                  envFrom:
+                    description: List of sources to populate environment variables
+                      in the container. The keys defined within a source must be a
+                      C_IDENTIFIER. All invalid keys will be reported as an event
+                      when the container is starting. When a key exists in multiple
+                      sources, the value associated with the last source will take
+                      precedence. Values defined by an Env with a duplicate key will
+                      take precedence. Cannot be updated.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: |-
+                            ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+                            The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: |-
+                            SecretEnvSource selects a Secret to populate the environment variables with.
+                            The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                    type: array
+                  image:
+                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                      This field is optional to allow higher level config management
+                      to default or override container images in workload controllers
+                      like Deployments and StatefulSets.'
+                    type: string
+                  imagePullPolicy:
+                    description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                      Defaults to Always if :latest tag is specified, or IfNotPresent
+                      otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                    type: string
+                  lifecycle:
+                    description: Lifecycle describes actions that the management system
+                      should take in response to container lifecycle events. For the
+                      PostStart and PreStop lifecycle handlers, management of the
+                      container blocks until the action is complete, unless the container
+                      process fails, in which case the handler is aborted.
+                    properties:
+                      postStart:
+                        description: Handler defines a specific action that should
+                          be taken
+                        properties:
+                          exec:
+                            description: ExecAction describes a "run in container"
+                              action.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                          httpGet:
+                            description: HTTPGetAction describes an action based on
+                              HTTP Get requests.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                          tcpSocket:
+                            description: TCPSocketAction describes an action based
+                              on opening a socket
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                            required:
+                            - port
+                      preStop:
+                        description: Handler defines a specific action that should
+                          be taken
+                        properties:
+                          exec:
+                            description: ExecAction describes a "run in container"
+                              action.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                          httpGet:
+                            description: HTTPGetAction describes an action based on
+                              HTTP Get requests.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                          tcpSocket:
+                            description: TCPSocketAction describes an action based
+                              on opening a socket
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                            required:
+                            - port
+                  livenessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: ExecAction describes a "run in container" action.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGetAction describes an action based on HTTP
+                          Get requests.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocketAction describes an action based on
+                          opening a socket
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                        required:
+                        - port
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                  name:
+                    description: Name of the container specified as a DNS_LABEL. Each
+                      container in a pod must have a unique name (DNS_LABEL). Cannot
+                      be updated.
+                    type: string
+                  ports:
+                    description: List of ports to expose from the container. Exposing
+                      a port here gives the system additional information about the
+                      network connections a container uses, but is primarily informational.
+                      Not specifying a port here DOES NOT prevent that port from being
+                      exposed. Any port which is listening on the default "0.0.0.0"
+                      address inside a container will be accessible from the network.
+                      Cannot be updated.
+                    items:
+                      description: ContainerPort represents a network port in a single
+                        container.
+                      properties:
+                        containerPort:
+                          description: Number of port to expose on the pod's IP address.
+                            This must be a valid port number, 0 < x < 65536.
+                          format: int32
+                          type: integer
+                        hostIP:
+                          description: What host IP to bind the external port to.
+                          type: string
+                        hostPort:
+                          description: Number of port to expose on the host. If specified,
+                            this must be a valid port number, 0 < x < 65536. If HostNetwork
+                            is specified, this must match ContainerPort. Most containers
+                            do not need this.
+                          format: int32
+                          type: integer
+                        name:
+                          description: If specified, this must be an IANA_SVC_NAME
+                            and unique within the pod. Each named port in a pod must
+                            have a unique name. Name for the port that can be referred
+                            to by services.
+                          type: string
+                        protocol:
+                          description: Protocol for port. Must be UDP or TCP. Defaults
+                            to "TCP".
+                          type: string
+                      required:
+                      - containerPort
+                    type: array
+                  readinessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: ExecAction describes a "run in container" action.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGetAction describes an action based on HTTP
+                          Get requests.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocketAction describes an action based on
+                          opening a socket
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                        required:
+                        - port
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                  securityContext:
+                    description: SecurityContext holds security configuration that
+                      will be applied to a container. Some fields are present in both
+                      SecurityContext and PodSecurityContext.  When both are set,
+                      the values in SecurityContext take precedence.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: Adds and removes POSIX capabilities from running
+                          containers.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              type: string
+                            type: array
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: SELinuxOptions are the labels to be applied to
+                          the container
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                  stdin:
+                    description: Whether this container should allocate a buffer for
+                      stdin in the container runtime. If this is not set, reads from
+                      stdin in the container will always result in EOF. Default is
+                      false.
+                    type: boolean
+                  stdinOnce:
+                    description: Whether the container runtime should close the stdin
+                      channel after it has been opened by a single attach. When stdin
+                      is true the stdin stream will remain open across multiple attach
+                      sessions. If stdinOnce is set to true, stdin is opened on container
+                      start, is empty until the first client attaches to stdin, and
+                      then remains open and accepts data until the client disconnects,
+                      at which time stdin is closed and remains closed until the container
+                      is restarted. If this flag is false, a container processes that
+                      reads from stdin will never receive an EOF. Default is false
+                    type: boolean
+                  terminationMessagePath:
+                    description: 'Optional: Path at which the file to which the container''s
+                      termination message will be written is mounted into the container''s
+                      filesystem. Message written is intended to be brief final status,
+                      such as an assertion failure message. Will be truncated by the
+                      node if greater than 4096 bytes. The total message length across
+                      all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                      Cannot be updated.'
+                    type: string
+                  terminationMessagePolicy:
+                    description: Indicate how the termination message should be populated.
+                      File will use the contents of terminationMessagePath to populate
+                      the container status message on both success and failure. FallbackToLogsOnError
+                      will use the last chunk of container log output if the termination
+                      message file is empty and the container exited with an error.
+                      The log output is limited to 2048 bytes or 80 lines, whichever
+                      is smaller. Defaults to File. Cannot be updated.
+                    type: string
+                  tty:
+                    description: Whether this container should allocate a TTY for
+                      itself, also requires 'stdin' to be true. Default is false.
+                    type: boolean
+                  volumeDevices:
+                    description: volumeDevices is the list of block devices to be
+                      used by the container. This is an alpha feature and may change
+                      in the future.
+                    items:
+                      description: volumeDevice describes a mapping of a raw block
+                        device within a container.
+                      properties:
+                        devicePath:
+                          description: devicePath is the path inside of the container
+                            that the device will be mapped to.
+                          type: string
+                        name:
+                          description: name must match the name of a persistentVolumeClaim
+                            in the pod
+                          type: string
+                      required:
+                      - name
+                      - devicePath
+                    type: array
+                  volumeMounts:
+                    description: Pod volumes to mount into the container's filesystem.
+                      Cannot be updated.
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: Path within the container at which the volume
+                            should be mounted.  Must not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: mountPropagation determines how mounts are
+                            propagated from the host to container and the other way
+                            around. When not set, MountPropagationHostToContainer
+                            is used. This field is beta in 1.10.
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: Mounted read-only if true, read-write otherwise
+                            (false or unspecified). Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: Path within the volume from which the container's
+                            volume should be mounted. Defaults to "" (volume's root).
+                          type: string
+                      required:
+                      - name
+                      - mountPath
+                    type: array
+                  workingDir:
+                    description: Container's working directory. If not specified,
+                      the container runtime's default will be used, which might be
+                      configured in the container image. Cannot be updated.
+                    type: string
+                required:
+                - name
+              type: array
+            evaluationInterval:
+              description: Interval between consecutive evaluations.
+              type: string
+            externalLabels:
+              description: The labels to add to any time series or alerts when communicating
+                with external systems (federation, remote storage, Alertmanager).
+              type: object
+            externalUrl:
+              description: The external URL the Prometheus instances will be available
+                under. This is necessary to generate correct URLs. This is necessary
+                if Prometheus is not served from root of a DNS name.
+              type: string
+            imagePullSecrets:
+              description: An optional list of references to secrets in the same namespace
+                to use for pulling prometheus and alertmanager images from registries
+                see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
+              items:
+                description: LocalObjectReference contains enough information to let
+                  you locate the referenced object inside the same namespace.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+              type: array
+            listenLocal:
+              description: ListenLocal makes the Prometheus server listen on loopback,
+                so that it does not bind against the Pod IP.
+              type: boolean
+            logLevel:
+              description: Log level for Prometheus to be configured with.
+              type: string
+            nodeSelector:
+              description: Define which Nodes the Pods are scheduled on.
+              type: object
+            paused:
+              description: When a Prometheus deployment is paused, no actions except
+                for deletion will be performed on the underlying objects.
+              type: boolean
+            podMetadata:
+              description: ObjectMeta is metadata that all persisted resources must
+                have, which includes all objects users must create.
+              properties:
+                annotations:
+                  description: 'Annotations is an unstructured key value map stored
+                    with a resource that may be set by external tools to store and
+                    retrieve arbitrary metadata. They are not queryable and should
+                    be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                  type: object
+                clusterName:
+                  description: The name of the cluster which the object belongs to.
+                    This is used to distinguish resources with same name and namespace
+                    in different clusters. This field is not set anywhere right now
+                    and apiserver is going to ignore it if set in create or update
+                    request.
+                  type: string
+                creationTimestamp:
+                  description: Time is a wrapper around time.Time which supports correct
+                    marshaling to YAML and JSON.  Wrappers are provided for many of
+                    the factory methods that the time package offers.
+                  format: date-time
+                  type: string
+                deletionGracePeriodSeconds:
+                  description: Number of seconds allowed for this object to gracefully
+                    terminate before it will be removed from the system. Only set
+                    when deletionTimestamp is also set. May only be shortened. Read-only.
+                  format: int64
+                  type: integer
+                deletionTimestamp:
+                  description: Time is a wrapper around time.Time which supports correct
+                    marshaling to YAML and JSON.  Wrappers are provided for many of
+                    the factory methods that the time package offers.
+                  format: date-time
+                  type: string
+                finalizers:
+                  description: Must be empty before the object is deleted from the
+                    registry. Each entry is an identifier for the responsible component
+                    that will remove the entry from the list. If the deletionTimestamp
+                    of the object is non-nil, entries in this list can only be removed.
+                  items:
+                    type: string
+                  type: array
+                generateName:
+                  description: |-
+                    GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+                    If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+                    Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                  type: string
+                generation:
+                  description: A sequence number representing a specific generation
+                    of the desired state. Populated by the system. Read-only.
+                  format: int64
+                  type: integer
+                initializers:
+                  description: Initializers tracks the progress of initialization.
+                  properties:
+                    pending:
+                      description: Pending is a list of initializers that must execute
+                        in order before this object is visible. When the last pending
+                        initializer is removed, and no failing result is set, the
+                        initializers struct will be set to nil and the object is considered
+                        as initialized and visible to all clients.
+                      items:
+                        description: Initializer is information about an initializer
+                          that has not yet completed.
+                        properties:
+                          name:
+                            description: name of the process that is responsible for
+                              initializing this object.
+                            type: string
+                        required:
+                        - name
+                      type: array
+                    result:
+                      description: Status is a return value for calls that don't return
+                        other objects.
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of
+                            this representation of an object. Servers should convert
+                            recognized schemas to the latest internal value, and may
+                            reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                          type: string
+                        code:
+                          description: Suggested HTTP return code for this status,
+                            0 if not set.
+                          format: int32
+                          type: integer
+                        details:
+                          description: StatusDetails is a set of additional properties
+                            that MAY be set by the server to provide additional information
+                            about a response. The Reason field of a Status object
+                            defines what attributes will be set. Clients must ignore
+                            fields that do not match the defined type of each attribute,
+                            and should assume that any attribute may be empty, invalid,
+                            or under defined.
+                          properties:
+                            causes:
+                              description: The Causes array includes more details
+                                associated with the StatusReason failure. Not all
+                                StatusReasons may provide detailed causes.
+                              items:
+                                description: StatusCause provides more information
+                                  about an api.Status failure, including cases when
+                                  multiple errors are encountered.
+                                properties:
+                                  field:
+                                    description: |-
+                                      The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+                                      Examples:
+                                        "name" - the field "name" on the current resource
+                                        "items[0].name" - the field "name" on the first array entry in "items"
+                                    type: string
+                                  message:
+                                    description: A human-readable description of the
+                                      cause of the error.  This field may be presented
+                                      as-is to a reader.
+                                    type: string
+                                  reason:
+                                    description: A machine-readable description of
+                                      the cause of the error. If this value is empty
+                                      there is no information available.
+                                    type: string
+                              type: array
+                            group:
+                              description: The group attribute of the resource associated
+                                with the status StatusReason.
+                              type: string
+                            kind:
+                              description: 'The kind attribute of the resource associated
+                                with the status StatusReason. On some operations may
+                                differ from the requested resource Kind. More info:
+                                https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: The name attribute of the resource associated
+                                with the status StatusReason (when there is a single
+                                name which can be described).
+                              type: string
+                            retryAfterSeconds:
+                              description: If specified, the time in seconds before
+                                the operation should be retried. Some errors may indicate
+                                the client must take an alternate action - for those
+                                errors this field may indicate how long to wait before
+                                taking the alternate action.
+                              format: int32
+                              type: integer
+                            uid:
+                              description: 'UID of the resource. (when there is a
+                                single resource which can be described). More info:
+                                http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST
+                            resource this object represents. Servers may infer this
+                            from the endpoint the client submits requests to. Cannot
+                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                          type: string
+                        message:
+                          description: A human-readable description of the status
+                            of this operation.
+                          type: string
+                        metadata:
+                          description: ListMeta describes metadata that synthetic
+                            resources must have, including lists and various status
+                            objects. A resource may have only one of {ObjectMeta,
+                            ListMeta}.
+                          properties:
+                            continue:
+                              description: continue may be set if the user set a limit
+                                on the number of items returned, and indicates that
+                                the server has more data available. The value is opaque
+                                and may be used to issue another request to the endpoint
+                                that served this list to retrieve the next set of
+                                available objects. Continuing a list may not be possible
+                                if the server configuration has changed or more than
+                                a few minutes have passed. The resourceVersion field
+                                returned when using this continue value will be identical
+                                to the value in the first response.
+                              type: string
+                            resourceVersion:
+                              description: 'String that identifies the server''s internal
+                                version of this object that can be used by clients
+                                to determine when objects have changed. Value must
+                                be treated as opaque by clients and passed unmodified
+                                back to the server. Populated by the system. Read-only.
+                                More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            selfLink:
+                              description: selfLink is a URL representing this object.
+                                Populated by the system. Read-only.
+                              type: string
+                        reason:
+                          description: A machine-readable description of why this
+                            operation is in the "Failure" status. If this value is
+                            empty there is no information available. A Reason clarifies
+                            an HTTP status code but does not override it.
+                          type: string
+                        status:
+                          description: 'Status of the operation. One of: "Success"
+                            or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                          type: string
+                  required:
+                  - pending
+                labels:
+                  description: 'Map of string keys and values that can be used to
+                    organize and categorize (scope and select) objects. May match
+                    selectors of replication controllers and services. More info:
+                    http://kubernetes.io/docs/user-guide/labels'
+                  type: object
+                name:
+                  description: 'Name must be unique within a namespace. Is required
+                    when creating resources, although some resources may allow a client
+                    to request the generation of an appropriate name automatically.
+                    Name is primarily intended for creation idempotence and configuration
+                    definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+                    Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                  type: string
+                ownerReferences:
+                  description: List of objects depended by this object. If ALL objects
+                    in the list have been deleted, this object will be garbage collected.
+                    If this object is managed by a controller, then an entry in this
+                    list will point to this controller, with the controller field
+                    set to true. There cannot be more than one managing controller.
+                  items:
+                    description: OwnerReference contains enough information to let
+                      you identify an owning object. Currently, an owning object must
+                      be in the same namespace, so there is no namespace field.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      blockOwnerDeletion:
+                        description: If true, AND if the owner has the "foregroundDeletion"
+                          finalizer, then the owner cannot be deleted from the key-value
+                          store until this reference is removed. Defaults to false.
+                          To set this field, a user needs "delete" permission of the
+                          owner, otherwise 422 (Unprocessable Entity) will be returned.
+                        type: boolean
+                      controller:
+                        description: If true, this reference points to the managing
+                          controller.
+                        type: boolean
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                  type: array
+                resourceVersion:
+                  description: |-
+                    An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+                    Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                  type: string
+                selfLink:
+                  description: SelfLink is a URL representing this object. Populated
+                    by the system. Read-only.
+                  type: string
+                uid:
+                  description: |-
+                    UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+                    Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                  type: string
+            remoteRead:
+              description: If specified, the remote_read spec. This is an experimental
+                feature, it may change in any upcoming release in a breaking way.
+              items:
+                description: RemoteReadSpec defines the remote_read configuration
+                  for prometheus.
+                properties:
+                  basicAuth:
+                    description: 'BasicAuth allow an endpoint to authenticate over
+                      basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                    properties:
+                      password:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or it's key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                      username:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or it's key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                  bearerToken:
+                    description: bearer token for remote read.
+                    type: string
+                  bearerTokenFile:
+                    description: File to read bearer token for remote read.
+                    type: string
+                  proxyUrl:
+                    description: Optional ProxyURL
+                    type: string
+                  readRecent:
+                    description: Whether reads should be made for queries for time
+                      ranges that the local storage should have complete data for.
+                    type: boolean
+                  remoteTimeout:
+                    description: Timeout for requests to the remote read endpoint.
+                    type: string
+                  requiredMatchers:
+                    description: An optional list of equality matchers which have
+                      to be present in a selector to query the remote read endpoint.
+                    type: object
+                  tlsConfig:
+                    description: TLSConfig specifies TLS configuration parameters.
+                    properties:
+                      caFile:
+                        description: The CA cert to use for the targets.
+                        type: string
+                      certFile:
+                        description: The client cert file for the targets.
+                        type: string
+                      insecureSkipVerify:
+                        description: Disable target certificate validation.
+                        type: boolean
+                      keyFile:
+                        description: The client key file for the targets.
+                        type: string
+                      serverName:
+                        description: Used to verify the hostname for the targets.
+                        type: string
+                  url:
+                    description: The URL of the endpoint to send samples to.
+                    type: string
+                required:
+                - url
+              type: array
+            remoteWrite:
+              description: If specified, the remote_write spec. This is an experimental
+                feature, it may change in any upcoming release in a breaking way.
+              items:
+                description: RemoteWriteSpec defines the remote_write configuration
+                  for prometheus.
+                properties:
+                  basicAuth:
+                    description: 'BasicAuth allow an endpoint to authenticate over
+                      basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                    properties:
+                      password:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or it's key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                      username:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or it's key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                  bearerToken:
+                    description: File to read bearer token for remote write.
+                    type: string
+                  bearerTokenFile:
+                    description: File to read bearer token for remote write.
+                    type: string
+                  proxyUrl:
+                    description: Optional ProxyURL
+                    type: string
+                  queueConfig:
+                    description: QueueConfig allows the tuning of remote_write queue_config
+                      parameters. This object is referenced in the RemoteWriteSpec
+                      object.
+                    properties:
+                      batchSendDeadline:
+                        description: BatchSendDeadline is the maximum time a sample
+                          will wait in buffer.
+                        type: string
+                      capacity:
+                        description: Capacity is the number of samples to buffer per
+                          shard before we start dropping them.
+                        format: int32
+                        type: integer
+                      maxBackoff:
+                        description: MaxBackoff is the maximum retry delay.
+                        type: string
+                      maxRetries:
+                        description: MaxRetries is the maximum number of times to
+                          retry a batch on recoverable errors.
+                        format: int32
+                        type: integer
+                      maxSamplesPerSend:
+                        description: MaxSamplesPerSend is the maximum number of samples
+                          per send.
+                        format: int32
+                        type: integer
+                      maxShards:
+                        description: MaxShards is the maximum number of shards, i.e.
+                          amount of concurrency.
+                        format: int32
+                        type: integer
+                      minBackoff:
+                        description: MinBackoff is the initial retry delay. Gets doubled
+                          for every retry.
+                        type: string
+                  remoteTimeout:
+                    description: Timeout for requests to the remote write endpoint.
+                    type: string
+                  tlsConfig:
+                    description: TLSConfig specifies TLS configuration parameters.
+                    properties:
+                      caFile:
+                        description: The CA cert to use for the targets.
+                        type: string
+                      certFile:
+                        description: The client cert file for the targets.
+                        type: string
+                      insecureSkipVerify:
+                        description: Disable target certificate validation.
+                        type: boolean
+                      keyFile:
+                        description: The client key file for the targets.
+                        type: string
+                      serverName:
+                        description: Used to verify the hostname for the targets.
+                        type: string
+                  url:
+                    description: The URL of the endpoint to send samples to.
+                    type: string
+                  writeRelabelConfigs:
+                    description: The list of remote write relabel configurations.
+                    items:
+                      description: 'RelabelConfig allows dynamic rewriting of the
+                        label set, being applied to samples before ingestion. It defines
+                        `<metric_relabel_configs>`-section of Prometheus configuration.
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                      properties:
+                        action:
+                          description: Action to perform based on regex matching.
+                            Default is 'replace'
+                          type: string
+                        modulus:
+                          description: Modulus to take of the hash of the source label
+                            values.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched. defailt is '(.*)'
+                          type: string
+                        replacement:
+                          description: Replacement value against which a regex replace
+                            is performed if the regular expression matches. Regex
+                            capture groups are available. Default is '$1'
+                          type: string
+                        separator:
+                          description: Separator placed between concatenated source
+                            label values. default is ';'.
+                          type: string
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            separator and matched against the configured regular expression
+                            for the replace, keep, and drop actions.
+                          items:
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: Label to which the resulting value is written
+                            in a replace action. It is mandatory for replace actions.
+                            Regex capture groups are available.
+                          type: string
+                    type: array
+                required:
+                - url
+              type: array
+            replicas:
+              description: Number of instances to deploy for a Prometheus deployment.
+              format: int32
+              type: integer
+            resources:
+              description: ResourceRequirements describes the compute resource requirements.
+              properties:
+                limits:
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+            retention:
+              description: Time duration Prometheus shall retain data for.
+              type: string
+            routePrefix:
+              description: The route prefix Prometheus registers HTTP handlers for.
+                This is useful, if using ExternalURL and a proxy is rewriting HTTP
+                routes of a request, and the actual ExternalURL is still true, but
+                the server serves requests under a different route prefix. For example
+                for use with `kubectl proxy`.
+              type: string
+            ruleNamespaceSelector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                                 of matchExpressions, whose key field is "key", the operator is
+                                 "In", and the values array contains only "value". The requirements
+                                 are ANDed.
+                  type: object
+            ruleSelector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                                 of matchExpressions, whose key field is "key", the operator is
+                                 "In", and the values array contains only "value". The requirements
+                                 are ANDed.
+                  type: object
+            scrapeInterval:
+              description: Interval between consecutive scrapes.
+              type: string
+            secrets:
+              description: Secrets is a list of Secrets in the same namespace as the
+                Prometheus object, which shall be mounted into the Prometheus Pods.
+                The Secrets are mounted into /etc/prometheus/secrets/<secret-name>.
+                Secrets changes after initial creation of a Prometheus object are
+                not reflected in the running Pods. To change the secrets mounted into
+                the Prometheus Pods, the object must be deleted and recreated with
+                the new list of secrets.
+              items:
+                type: string
+              type: array
+            securityContext:
+              description: PodSecurityContext holds pod-level security attributes
+                and common container settings. Some fields are also present in container.securityContext.  Field
+                values of container.securityContext take precedence over field values
+                of PodSecurityContext.
+              properties:
+                fsGroup:
+                  description: |-
+                    A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+                    1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                    If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                  format: int64
+                  type: integer
+                runAsGroup:
+                  description: The GID to run the entrypoint of the container process.
+                    Uses runtime default if unset. May also be set in SecurityContext.  If
+                    set in both SecurityContext and PodSecurityContext, the value
+                    specified in SecurityContext takes precedence for that container.
+                  format: int64
+                  type: integer
+                runAsNonRoot:
+                  description: Indicates that the container must run as a non-root
+                    user. If true, the Kubelet will validate the image at runtime
+                    to ensure that it does not run as UID 0 (root) and fail to start
+                    the container if it does. If unset or false, no such validation
+                    will be performed. May also be set in SecurityContext.  If set
+                    in both SecurityContext and PodSecurityContext, the value specified
+                    in SecurityContext takes precedence.
+                  type: boolean
+                runAsUser:
+                  description: The UID to run the entrypoint of the container process.
+                    Defaults to user specified in image metadata if unspecified. May
+                    also be set in SecurityContext.  If set in both SecurityContext
+                    and PodSecurityContext, the value specified in SecurityContext
+                    takes precedence for that container.
+                  format: int64
+                  type: integer
+                seLinuxOptions:
+                  description: SELinuxOptions are the labels to be applied to the
+                    container
+                  properties:
+                    level:
+                      description: Level is SELinux level label that applies to the
+                        container.
+                      type: string
+                    role:
+                      description: Role is a SELinux role label that applies to the
+                        container.
+                      type: string
+                    type:
+                      description: Type is a SELinux type label that applies to the
+                        container.
+                      type: string
+                    user:
+                      description: User is a SELinux user label that applies to the
+                        container.
+                      type: string
+                supplementalGroups:
+                  description: A list of groups applied to the first process run in
+                    each container, in addition to the container's primary GID.  If
+                    unspecified, no groups will be added to any container.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                sysctls:
+                  description: Sysctls hold a list of namespaced sysctls used for
+                    the pod. Pods with unsupported sysctls (by the container runtime)
+                    might fail to launch.
+                  items:
+                    description: Sysctl defines a kernel parameter to be set
+                    properties:
+                      name:
+                        description: Name of a property to set
+                        type: string
+                      value:
+                        description: Value of a property to set
+                        type: string
+                    required:
+                    - name
+                    - value
+                  type: array
+            serviceAccountName:
+              description: ServiceAccountName is the name of the ServiceAccount to
+                use to run the Prometheus Pods.
+              type: string
+            serviceMonitorNamespaceSelector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                                 of matchExpressions, whose key field is "key", the operator is
+                                 "In", and the values array contains only "value". The requirements
+                                 are ANDed.
+                  type: object
+            serviceMonitorSelector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                                 of matchExpressions, whose key field is "key", the operator is
+                                 "In", and the values array contains only "value". The requirements
+                                 are ANDed.
+                  type: object
+            storage:
+              description: StorageSpec defines the configured storage for a group
+                Prometheus servers.
+              properties:
+                class:
+                  description: 'Name of the StorageClass to use when requesting storage
+                    provisioning. More info: https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses
+                    DEPRECATED'
+                  type: string
+                emptyDir:
+                  description: Represents an empty directory for a pod. Empty directory
+                    volumes support ownership management and SELinux relabeling.
+                  properties:
+                    medium:
+                      description: 'What type of storage medium should back this directory.
+                        The default is "" which means to use the node''s default medium.
+                        Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                      type: string
+                    sizeLimit: {}
+                resources:
+                  description: ResourceRequirements describes the compute resource
+                    requirements.
+                  properties:
+                    limits:
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                selector:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                      type: array
+                    matchLabels:
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                                     of matchExpressions, whose key field is "key", the operator
+                                     is "In", and the values array contains only "value". The requirements
+                                     are ANDed.
+                      type: object
+                volumeClaimTemplate:
+                  description: PersistentVolumeClaim is a user's request for and claim
+                    to a persistent volume
+                  properties:
+                    apiVersion:
+                      description: 'APIVersion defines the versioned schema of this
+                        representation of an object. Servers should convert recognized
+                        schemas to the latest internal value, and may reject unrecognized
+                        values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                      type: string
+                    kind:
+                      description: 'Kind is a string value representing the REST resource
+                        this object represents. Servers may infer this from the endpoint
+                        the client submits requests to. Cannot be updated. In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                      type: string
+                    metadata:
+                      description: ObjectMeta is metadata that all persisted resources
+                        must have, which includes all objects users must create.
+                      properties:
+                        annotations:
+                          description: 'Annotations is an unstructured key value map
+                            stored with a resource that may be set by external tools
+                            to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: http://kubernetes.io/docs/user-guide/annotations'
+                          type: object
+                        clusterName:
+                          description: The name of the cluster which the object belongs
+                            to. This is used to distinguish resources with same name
+                            and namespace in different clusters. This field is not
+                            set anywhere right now and apiserver is going to ignore
+                            it if set in create or update request.
+                          type: string
+                        creationTimestamp:
+                          description: Time is a wrapper around time.Time which supports
+                            correct marshaling to YAML and JSON.  Wrappers are provided
+                            for many of the factory methods that the time package
+                            offers.
+                          format: date-time
+                          type: string
+                        deletionGracePeriodSeconds:
+                          description: Number of seconds allowed for this object to
+                            gracefully terminate before it will be removed from the
+                            system. Only set when deletionTimestamp is also set. May
+                            only be shortened. Read-only.
+                          format: int64
+                          type: integer
+                        deletionTimestamp:
+                          description: Time is a wrapper around time.Time which supports
+                            correct marshaling to YAML and JSON.  Wrappers are provided
+                            for many of the factory methods that the time package
+                            offers.
+                          format: date-time
+                          type: string
+                        finalizers:
+                          description: Must be empty before the object is deleted
+                            from the registry. Each entry is an identifier for the
+                            responsible component that will remove the entry from
+                            the list. If the deletionTimestamp of the object is non-nil,
+                            entries in this list can only be removed.
+                          items:
+                            type: string
+                          type: array
+                        generateName:
+                          description: |-
+                            GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+                            If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+                            Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                          type: string
+                        generation:
+                          description: A sequence number representing a specific generation
+                            of the desired state. Populated by the system. Read-only.
+                          format: int64
+                          type: integer
+                        initializers:
+                          description: Initializers tracks the progress of initialization.
+                          properties:
+                            pending:
+                              description: Pending is a list of initializers that
+                                must execute in order before this object is visible.
+                                When the last pending initializer is removed, and
+                                no failing result is set, the initializers struct
+                                will be set to nil and the object is considered as
+                                initialized and visible to all clients.
+                              items:
+                                description: Initializer is information about an initializer
+                                  that has not yet completed.
+                                properties:
+                                  name:
+                                    description: name of the process that is responsible
+                                      for initializing this object.
+                                    type: string
+                                required:
+                                - name
+                              type: array
+                            result:
+                              description: Status is a return value for calls that
+                                don't return other objects.
+                              properties:
+                                apiVersion:
+                                  description: 'APIVersion defines the versioned schema
+                                    of this representation of an object. Servers should
+                                    convert recognized schemas to the latest internal
+                                    value, and may reject unrecognized values. More
+                                    info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                                  type: string
+                                code:
+                                  description: Suggested HTTP return code for this
+                                    status, 0 if not set.
+                                  format: int32
+                                  type: integer
+                                details:
+                                  description: StatusDetails is a set of additional
+                                    properties that MAY be set by the server to provide
+                                    additional information about a response. The Reason
+                                    field of a Status object defines what attributes
+                                    will be set. Clients must ignore fields that do
+                                    not match the defined type of each attribute,
+                                    and should assume that any attribute may be empty,
+                                    invalid, or under defined.
+                                  properties:
+                                    causes:
+                                      description: The Causes array includes more
+                                        details associated with the StatusReason failure.
+                                        Not all StatusReasons may provide detailed
+                                        causes.
+                                      items:
+                                        description: StatusCause provides more information
+                                          about an api.Status failure, including cases
+                                          when multiple errors are encountered.
+                                        properties:
+                                          field:
+                                            description: |-
+                                              The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+                                              Examples:
+                                                "name" - the field "name" on the current resource
+                                                "items[0].name" - the field "name" on the first array entry in "items"
+                                            type: string
+                                          message:
+                                            description: A human-readable description
+                                              of the cause of the error.  This field
+                                              may be presented as-is to a reader.
+                                            type: string
+                                          reason:
+                                            description: A machine-readable description
+                                              of the cause of the error. If this value
+                                              is empty there is no information available.
+                                            type: string
+                                      type: array
+                                    group:
+                                      description: The group attribute of the resource
+                                        associated with the status StatusReason.
+                                      type: string
+                                    kind:
+                                      description: 'The kind attribute of the resource
+                                        associated with the status StatusReason. On
+                                        some operations may differ from the requested
+                                        resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: The name attribute of the resource
+                                        associated with the status StatusReason (when
+                                        there is a single name which can be described).
+                                      type: string
+                                    retryAfterSeconds:
+                                      description: If specified, the time in seconds
+                                        before the operation should be retried. Some
+                                        errors may indicate the client must take an
+                                        alternate action - for those errors this field
+                                        may indicate how long to wait before taking
+                                        the alternate action.
+                                      format: int32
+                                      type: integer
+                                    uid:
+                                      description: 'UID of the resource. (when there
+                                        is a single resource which can be described).
+                                        More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                      type: string
+                                kind:
+                                  description: 'Kind is a string value representing
+                                    the REST resource this object represents. Servers
+                                    may infer this from the endpoint the client submits
+                                    requests to. Cannot be updated. In CamelCase.
+                                    More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                  type: string
+                                message:
+                                  description: A human-readable description of the
+                                    status of this operation.
+                                  type: string
+                                metadata:
+                                  description: ListMeta describes metadata that synthetic
+                                                 resources must have, including lists and various
+                                                 status objects. A resource may have only one of
+                                    {ObjectMeta, ListMeta}.
+                                  properties:
+                                    continue:
+                                      description: continue may be set if the user
+                                        set a limit on the number of items returned,
+                                        and indicates that the server has more data
+                                        available. The value is opaque and may be
+                                        used to issue another request to the endpoint
+                                        that served this list to retrieve the next
+                                        set of available objects. Continuing a list
+                                        may not be possible if the server configuration
+                                        has changed or more than a few minutes have
+                                        passed. The resourceVersion field returned
+                                        when using this continue value will be identical
+                                        to the value in the first response.
+                                      type: string
+                                    resourceVersion:
+                                      description: 'String that identifies the server''s
+                                        internal version of this object that can be
+                                        used by clients to determine when objects
+                                        have changed. Value must be treated as opaque
+                                        by clients and passed unmodified back to the
+                                        server. Populated by the system. Read-only.
+                                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                                      type: string
+                                    selfLink:
+                                      description: selfLink is a URL representing
+                                        this object. Populated by the system. Read-only.
+                                      type: string
+                                reason:
+                                  description: A machine-readable description of why
+                                    this operation is in the "Failure" status. If
+                                    this value is empty there is no information available.
+                                    A Reason clarifies an HTTP status code but does
+                                    not override it.
+                                  type: string
+                                status:
+                                  description: 'Status of the operation. One of: "Success"
+                                    or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                                  type: string
+                          required:
+                          - pending
+                        labels:
+                          description: 'Map of string keys and values that can be
+                            used to organize and categorize (scope and select) objects.
+                            May match selectors of replication controllers and services.
+                            More info: http://kubernetes.io/docs/user-guide/labels'
+                          type: object
+                        name:
+                          description: 'Name must be unique within a namespace. Is
+                            required when creating resources, although some resources
+                            may allow a client to request the generation of an appropriate
+                            name automatically. Name is primarily intended for creation
+                            idempotence and configuration definition. Cannot be updated.
+                            More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+                            Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                          type: string
+                        ownerReferences:
+                          description: List of objects depended by this object. If
+                            ALL objects in the list have been deleted, this object
+                            will be garbage collected. If this object is managed by
+                            a controller, then an entry in this list will point to
+                            this controller, with the controller field set to true.
+                            There cannot be more than one managing controller.
+                          items:
+                            description: OwnerReference contains enough information
+                              to let you identify an owning object. Currently, an
+                              owning object must be in the same namespace, so there
+                              is no namespace field.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              blockOwnerDeletion:
+                                description: If true, AND if the owner has the "foregroundDeletion"
+                                               finalizer, then the owner cannot be deleted from
+                                               the key-value store until this reference is removed.
+                                               Defaults to false. To set this field, a user needs
+                                               "delete" permission of the owner, otherwise 422
+                                               (Unprocessable Entity) will be returned.
+                                type: boolean
+                              controller:
+                                description: If true, this reference points to the
+                                  managing controller.
+                                type: boolean
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                type: string
+                            required:
+                            - apiVersion
+                            - kind
+                            - name
+                            - uid
+                          type: array
+                        resourceVersion:
+                          description: |-
+                            An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+                            Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                          type: string
+                        selfLink:
+                          description: SelfLink is a URL representing this object.
+                            Populated by the system. Read-only.
+                          type: string
+                        uid:
+                          description: |-
+                            UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+                            Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                          type: string
+                    spec:
+                      description: PersistentVolumeClaimSpec describes the common
+                        attributes of storage devices and allows a Source for provider-specific
+                        attributes
+                      properties:
+                        accessModes:
+                          description: 'AccessModes contains the desired access modes
+                            the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          items:
+                            type: string
+                          type: array
+                        resources:
+                          description: ResourceRequirements describes the compute
+                            resource requirements.
+                          properties:
+                            limits:
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                        selector:
+                          description: A label selector is a label query over a set
+                            of resources. The result of matchLabels and matchExpressions
+                            are ANDed. An empty label selector matches all objects.
+                            A null label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                              type: array
+                            matchLabels:
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                        storageClassName:
+                          description: 'Name of the StorageClass required by the claim.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                          type: string
+                        volumeMode:
+                          description: volumeMode defines what type of volume is required
+                            by the claim. Value of Filesystem is implied when not
+                            included in claim spec. This is an alpha feature and may
+                            change in the future.
+                          type: string
+                        volumeName:
+                          description: VolumeName is the binding reference to the
+                            PersistentVolume backing this claim.
+                          type: string
+                    status:
+                      description: PersistentVolumeClaimStatus is the current status
+                        of a persistent volume claim.
+                      properties:
+                        accessModes:
+                          description: 'AccessModes contains the actual access modes
+                            the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          items:
+                            type: string
+                          type: array
+                        capacity:
+                          description: Represents the actual resources of the underlying
+                            volume.
+                          type: object
+                        conditions:
+                          description: Current Condition of persistent volume claim.
+                            If underlying persistent volume is being resized then
+                            the Condition will be set to 'ResizeStarted'.
+                          items:
+                            description: PersistentVolumeClaimCondition contails details
+                              about state of pvc
+                            properties:
+                              lastProbeTime:
+                                description: Time is a wrapper around time.Time which
+                                  supports correct marshaling to YAML and JSON.  Wrappers
+                                  are provided for many of the factory methods that
+                                  the time package offers.
+                                format: date-time
+                                type: string
+                              lastTransitionTime:
+                                description: Time is a wrapper around time.Time which
+                                  supports correct marshaling to YAML and JSON.  Wrappers
+                                  are provided for many of the factory methods that
+                                  the time package offers.
+                                format: date-time
+                                type: string
+                              message:
+                                description: Human-readable message indicating details
+                                  about last transition.
+                                type: string
+                              reason:
+                                description: Unique, this should be a short, machine
+                                  understandable string that gives the reason for
+                                  condition's last transition. If it reports "ResizeStarted"
+                                  that means the underlying persistent volume is being
+                                  resized.
+                                type: string
+                              status:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - type
+                            - status
+                          type: array
+                        phase:
+                          description: Phase represents the current phase of PersistentVolumeClaim.
+                          type: string
+            tag:
+              description: Tag of Prometheus container image to be deployed. Defaults
+                to the value of `version`.
+              type: string
+            thanos:
+              description: ThanosSpec defines parameters for a Prometheus server within
+                a Thanos deployment.
+              properties:
+                baseImage:
+                  description: Thanos base image if other than default.
+                  type: string
+                gcs:
+                  description: ThanosGCSSpec defines parameters for use of Google
+                    Cloud Storage (GCS) with Thanos.
+                  properties:
+                    bucket:
+                      description: Google Cloud Storage bucket name for stored blocks.
+                        If empty it won't store any block inside Google Cloud Storage.
+                      type: string
+                peers:
+                  description: Peers is a DNS name for Thanos to discover peers through.
+                  type: string
+                s3:
+                  description: ThanosSpec defines parameters for of AWS Simple Storage
+                    Service (S3) with Thanos. (S3 compatible services apply as well)
+                  properties:
+                    accessKey:
+                      description: SecretKeySelector selects a key of a Secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or it's key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                    bucket:
+                      description: S3-Compatible API bucket name for stored blocks.
+                      type: string
+                    endpoint:
+                      description: S3-Compatible API endpoint for stored blocks.
+                      type: string
+                    insecure:
+                      description: Whether to use an insecure connection with an S3-Compatible
+                        API.
+                      type: boolean
+                    secretKey:
+                      description: SecretKeySelector selects a key of a Secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or it's key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                    signatureVersion2:
+                      description: Whether to use S3 Signature Version 2; otherwise
+                        Signature Version 4 will be used.
+                      type: boolean
+                tag:
+                  description: Tag of Thanos sidecar container image to be deployed.
+                    Defaults to the value of `version`.
+                  type: string
+                version:
+                  description: Version describes the version of Thanos to use.
+                  type: string
+            tolerations:
+              description: If specified, the pod's tolerations.
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
+                properties:
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
+                    type: string
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
+                    type: string
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
+                    type: string
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
+                    type: string
+              type: array
+            version:
+              description: Version of Prometheus to be deployed.
+              type: string
+        status:
+          description: 'Most recent observed status of the Prometheus cluster. Read-only.
+            Not included when requesting from the apiserver, only from the Prometheus
+            Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          properties:
+            availableReplicas:
+              description: Total number of available pods (ready for at least minReadySeconds)
+                targeted by this Prometheus deployment.
+              format: int32
+              type: integer
+            paused:
+              description: Represents whether any actions on the underlaying managed
+                objects are being performed. Only delete actions will be performed.
+              type: boolean
+            replicas:
+              description: Total number of non-terminated pods targeted by this Prometheus
+                deployment (their labels match the selector).
+              format: int32
+              type: integer
+            unavailableReplicas:
+              description: Total number of unavailable pods targeted by this Prometheus
+                deployment.
+              format: int32
+              type: integer
+            updatedReplicas:
+              description: Total number of non-terminated pods targeted by this Prometheus
+                deployment that have the desired version spec.
+              format: int32
+              type: integer
+          required:
+          - paused
+          - replicas
+          - updatedReplicas
+          - availableReplicas
+          - unavailableReplicas
+  version: v1

--- a/bundles/prometheus.0.15.0/manifests/prometheusoperator.0.15.0.clusterserviceversion.yaml
+++ b/bundles/prometheus.0.15.0/manifests/prometheusoperator.0.15.0.clusterserviceversion.yaml
@@ -1,0 +1,264 @@
+#! parse-kind: ClusterServiceVersion
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: prometheusoperator.0.15.0
+  namespace: placeholder
+  annotations:
+    tectonic-visibility: ocs
+    alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v1.7.0","serviceAccountName":"prometheus-k8s","serviceMonitorSelector":{"matchExpressions":[{"key":"k8s-app","operator":"Exists"}]},"ruleSelector":{"matchLabels":{"role":"prometheus-rulefiles","prometheus":"k8s"}},"resources":{"requests":{"memory":"400Mi"}},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus","prometheus":"k8s"}},"namespaceSelector":{"matchNames":["monitoring"]},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3}}]'
+spec:
+  replaces: prometheusoperator.0.14.0
+  displayName: Prometheus
+  description: |
+    An open-source monitoring system with a dimensional data model, flexible query language, efficient time series database and modern alerting approach.
+
+    _The Prometheus Open Cloud Service is Public Alpha. The goal before Beta is for additional user testing and minor bug fixes._
+
+    ### Monitoring applications
+
+    Prometheus scrapes your application metrics based on targets maintained in a ServiceMonitor object. When alerts need to be sent, they are processsed by an AlertManager.
+
+    [Read the complete guide to monitoring applications with the Prometheus Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/prometheus-ocs.html)
+
+    ### Supported Features
+
+
+    **High availability**
+
+
+    Multiple instances are run across failure zones and data is replicated. This keeps your monitoring available during an outage, when you need it most.
+
+
+    **Updates via automated operations**
+
+
+    New Prometheus versions are deployed using a rolling update with no downtime, making it easy to stay up to date.
+
+
+    **Handles the dynamic nature of containers**
+
+
+    Alerting rules are attached to groups of containers instead of individual instances, which is ideal for the highly dynamic nature of container deployment.
+
+  keywords: ['prometheus', 'monitoring', 'tsdb', 'alerting']
+
+  maintainers:
+  - name: CoreOS, Inc
+    email: support@coreos.com
+
+  provider:
+    name: CoreOS, Inc
+
+  links:
+  - name: Prometheus
+    url: https://www.prometheus.io/
+  - name: Documentation
+    url: https://coreos.com/operators/prometheus/docs/latest/
+  - name: Prometheus Operator Source Code
+    url: https://github.com/coreos/prometheus-operator
+
+  labels:
+    alm-status-descriptors: prometheusoperator.0.15.0
+    alm-owner-prometheus: prometheusoperator
+
+  selector:
+    matchLabels:
+      alm-owner-prometheus: prometheusoperator
+
+  icon:
+  - base64data: PHN2ZyB3aWR0aD0iMjQ5MCIgaGVpZ2h0PSIyNTAwIiB2aWV3Qm94PSIwIDAgMjU2IDI1NyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCI+PHBhdGggZD0iTTEyOC4wMDEuNjY3QzU3LjMxMS42NjcgMCA1Ny45NzEgMCAxMjguNjY0YzAgNzAuNjkgNTcuMzExIDEyNy45OTggMTI4LjAwMSAxMjcuOTk4UzI1NiAxOTkuMzU0IDI1NiAxMjguNjY0QzI1NiA1Ny45NyAxOTguNjg5LjY2NyAxMjguMDAxLjY2N3ptMCAyMzkuNTZjLTIwLjExMiAwLTM2LjQxOS0xMy40MzUtMzYuNDE5LTMwLjAwNGg3Mi44MzhjMCAxNi41NjYtMTYuMzA2IDMwLjAwNC0zNi40MTkgMzAuMDA0em02MC4xNTMtMzkuOTRINjcuODQyVjE3OC40N2gxMjAuMzE0djIxLjgxNmgtLjAwMnptLS40MzItMzMuMDQ1SDY4LjE4NWMtLjM5OC0uNDU4LS44MDQtLjkxLTEuMTg4LTEuMzc1LTEyLjMxNS0xNC45NTQtMTUuMjE2LTIyLjc2LTE4LjAzMi0zMC43MTYtLjA0OC0uMjYyIDE0LjkzMyAzLjA2IDI1LjU1NiA1LjQ1IDAgMCA1LjQ2NiAxLjI2NSAxMy40NTggMi43MjItNy42NzMtOC45OTQtMTIuMjMtMjAuNDI4LTEyLjIzLTMyLjExNiAwLTI1LjY1OCAxOS42OC00OC4wNzkgMTIuNTgtNjYuMjAxIDYuOTEuNTYyIDE0LjMgMTQuNTgzIDE0LjggMzYuNTA1IDcuMzQ2LTEwLjE1MiAxMC40Mi0yOC42OSAxMC40Mi00MC4wNTYgMC0xMS43NjkgNy43NTUtMjUuNDQgMTUuNTEyLTI1LjkwNy02LjkxNSAxMS4zOTYgMS43OSAyMS4xNjUgOS41MyA0NS40IDIuOTAyIDkuMTAzIDIuNTMyIDI0LjQyMyA0Ljc3MiAzNC4xMzguNzQ0LTIwLjE3OCA0LjIxMy00OS42MiAxNy4wMTQtNTkuNzg0LTUuNjQ3IDEyLjguODM2IDI4LjgxOCA1LjI3IDM2LjUxOCA3LjE1NCAxMi40MjQgMTEuNDkgMjEuODM2IDExLjQ5IDM5LjYzOCAwIDExLjkzNi00LjQwNyAyMy4xNzMtMTEuODQgMzEuOTU4IDguNDUyLTEuNTg2IDE0LjI4OS0zLjAxNiAxNC4yODktMy4wMTZsMjcuNDUtNS4zNTVjLjAwMi0uMDAyLTMuOTg3IDE2LjQwMS0xOS4zMTQgMzIuMTk3eiIgZmlsbD0iI0RBNEUzMSIvPjwvc3ZnPg==
+    mediatype: image/svg+xml
+
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+      - serviceAccountName: prometheus-k8s
+        rules:
+        - apiGroups: [""]
+          resources:
+          - nodes
+          - services
+          - endpoints
+          - pods
+          verbs: ["get", "list", "watch"]
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          verbs: ["get"]
+      - serviceAccountName: prometheus-operator-0-14-0
+        rules:
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs: ["get", "list"]
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - alertmanagers
+          - prometheuses
+          - servicemonitors
+          verbs:
+          - "*"
+        - apiGroups:
+          - apps
+          resources:
+          - statefulsets
+          verbs: ["*"]
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - secrets
+          verbs: ["*"]
+        - apiGroups: [""]
+          resources:
+          - pods
+          verbs: ["list", "delete"]
+        - apiGroups: [""]
+          resources:
+          - services
+          - endpoints
+          verbs: ["get", "create", "update"]
+        - apiGroups: [""]
+          resources:
+          - nodes
+          verbs: ["list", "watch"]
+        - apiGroups: [""]
+          resources:
+          - namespaces
+          verbs: ['list']
+      deployments:
+      - name: prometheus-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              k8s-app: prometheus-operator
+          template:
+            metadata:
+              labels:
+                k8s-app: prometheus-operator
+            spec:
+              serviceAccount: prometheus-operator-0-14-0
+              containers:
+              - name: prometheus-operator
+                image: quay.io/coreos/prometheus-operator@sha256:0e92dd9b5789c4b13d53e1319d0a6375bcca4caaf0d698af61198061222a576d
+                command:
+                  - sh
+                  - -c
+                  - >
+                    /bin/operator --namespace=$K8S_NAMESPACE --crd-apigroup monitoring.coreos.com
+                    --labels alm-status-descriptors=prometheusoperator.0.15.0,alm-owner-prometheus=prometheusoperator
+                    --kubelet-service=kube-system/kubelet
+                    --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+                env:
+                  - name: K8S_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.namespace
+                ports:
+                - containerPort: 8080
+                  name: http
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 100Mi
+                  requests:
+                    cpu: 100m
+                    memory: 50Mi
+  maturity: alpha
+  version: 0.15.0
+  customresourcedefinitions:
+    owned:
+    - name: prometheuses.monitoring.coreos.com
+      version: v1
+      kind: Prometheus
+      displayName: Prometheus
+      description: A running Prometheus instance
+      resources:
+        - kind: StatefulSet
+          version: v1beta2
+        - kind: Pod
+          version: v1
+      specDescriptors:
+      - description: Desired number of Pods for the cluster
+        displayName: Size
+        path: replicas
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      - description: A selector for the ConfigMaps from which to load rule files
+        displayName: Rule Config Map Selector
+        path: ruleSelector
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:ConfigMap'
+      - description: ServiceMonitors to be selected for target discovery
+        displayName: Service Monitor Selector
+        path: serviceMonitorSelector
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:selector:monitoring.coreos.com:v1:ServiceMonitor'
+      - description: The ServiceAccount to use to run the Prometheus pods
+        displayName: Service Account
+        path: serviceAccountName
+        x-descriptors:
+          - 'urn:alm:descriptor:io.kubernetes:ServiceAccount'
+      - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+        displayName: Resource Requirements
+        path: resources
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      statusDescriptors:
+        - description: The current number of Pods for the cluster
+          displayName: Cluster Size
+          path: replicas
+        - path: prometheusSelector
+          displayName: Prometheus Service Selector
+          description: Label selector to find the service that routes to this prometheus
+          x-descriptors:
+          - 'urn:alm:descriptor:label:selector'
+    - name: servicemonitors.monitoring.coreos.com
+      version: v1
+      kind: ServiceMonitor
+      displayName: Service Monitor
+      description: Configures prometheus to monitor a particular k8s service
+      resources:
+        - kind: Pod
+          version: v1
+      specDescriptors:
+      - description: Selector to select which namespaces the Endpoints objects are discovered from
+        displayName: Monitoring Namespaces
+        path: namespaceSelector
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:namespaceSelector'
+      - description: The label to use to retrieve the job name from
+        displayName: Job Label
+        path: jobLabel
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - description: A list of endpoints allowed as part of this ServiceMonitor
+        displayName: Endpoints
+        path: endpoints
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:endpointList'
+    - name: alertmanagers.monitoring.coreos.com
+      version: v1
+      kind: Alertmanager
+      displayName: Alert Manager
+      description: Configures an Alert Manager for the namespace
+      resources:
+        - kind: StatefulSet
+          version: v1beta2
+        - kind: Pod
+          version: v1
+      specDescriptors:
+      - description: Desired number of Pods for the cluster
+        displayName: Size
+        path: replicas
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+        displayName: Resource Requirements
+        path: resources
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'

--- a/bundles/prometheus.0.15.0/manifests/prometheusrule.crd.yaml
+++ b/bundles/prometheus.0.15.0/manifests/prometheusrule.crd.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: prometheusrules.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    kind: PrometheusRule
+    plural: prometheusrules
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: PrometheusRuleSpec contains specification parameters for a
+            Rule.
+          properties:
+            groups:
+              description: Content of Prometheus rule file
+              items:
+                description: RuleGroup is a list of sequentially evaluated recording
+                  and alerting rules.
+                properties:
+                  interval:
+                    type: string
+                  name:
+                    type: string
+                  rules:
+                    items:
+                      description: Rule describes an alerting or recording rule.
+                      properties:
+                        alert:
+                          type: string
+                        annotations:
+                          type: object
+                        expr:
+                          type: string
+                        for:
+                          type: string
+                        labels:
+                          type: object
+                        record:
+                          type: string
+                      required:
+                      - expr
+                    type: array
+                required:
+                - name
+                - rules
+              type: array
+  version: v1

--- a/bundles/prometheus.0.15.0/manifests/servicemonitor.crd.yaml
+++ b/bundles/prometheus.0.15.0/manifests/servicemonitor.crd.yaml
@@ -1,0 +1,224 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: servicemonitors.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    kind: ServiceMonitor
+    plural: servicemonitors
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: ServiceMonitorSpec contains specification parameters for a
+            ServiceMonitor.
+          properties:
+            endpoints:
+              description: A list of endpoints allowed as part of this ServiceMonitor.
+              items:
+                description: Endpoint defines a scrapeable endpoint serving Prometheus
+                  metrics.
+                properties:
+                  basicAuth:
+                    description: 'BasicAuth allow an endpoint to authenticate over
+                      basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                    properties:
+                      password:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or it's key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                      username:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or it's key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                  bearerTokenFile:
+                    description: File to read bearer token for scraping targets.
+                    type: string
+                  honorLabels:
+                    description: HonorLabels chooses the metric's labels on collisions
+                      with target labels.
+                    type: boolean
+                  interval:
+                    description: Interval at which metrics should be scraped
+                    type: string
+                  metricRelabelings:
+                    description: MetricRelabelConfigs to apply to samples before ingestion.
+                    items:
+                      description: 'RelabelConfig allows dynamic rewriting of the
+                        label set, being applied to samples before ingestion. It defines
+                        `<metric_relabel_configs>`-section of Prometheus configuration.
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                      properties:
+                        action:
+                          description: Action to perform based on regex matching.
+                            Default is 'replace'
+                          type: string
+                        modulus:
+                          description: Modulus to take of the hash of the source label
+                            values.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched. defailt is '(.*)'
+                          type: string
+                        replacement:
+                          description: Replacement value against which a regex replace
+                            is performed if the regular expression matches. Regex
+                            capture groups are available. Default is '$1'
+                          type: string
+                        separator:
+                          description: Separator placed between concatenated source
+                            label values. default is ';'.
+                          type: string
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            separator and matched against the configured regular expression
+                            for the replace, keep, and drop actions.
+                          items:
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: Label to which the resulting value is written
+                            in a replace action. It is mandatory for replace actions.
+                            Regex capture groups are available.
+                          type: string
+                    type: array
+                  params:
+                    description: Optional HTTP URL parameters
+                    type: object
+                  path:
+                    description: HTTP path to scrape for metrics.
+                    type: string
+                  port:
+                    description: Name of the service port this endpoint refers to.
+                      Mutually exclusive with targetPort.
+                    type: string
+                  proxyUrl:
+                    description: ProxyURL eg http://proxyserver:2195 Directs scrapes
+                      to proxy through this endpoint.
+                    type: string
+                  scheme:
+                    description: HTTP scheme to use for scraping.
+                    type: string
+                  scrapeTimeout:
+                    description: Timeout after which the scrape is ended
+                    type: string
+                  targetPort:
+                    anyOf:
+                    - type: string
+                    - type: integer
+                  tlsConfig:
+                    description: TLSConfig specifies TLS configuration parameters.
+                    properties:
+                      caFile:
+                        description: The CA cert to use for the targets.
+                        type: string
+                      certFile:
+                        description: The client cert file for the targets.
+                        type: string
+                      insecureSkipVerify:
+                        description: Disable target certificate validation.
+                        type: boolean
+                      keyFile:
+                        description: The client key file for the targets.
+                        type: string
+                      serverName:
+                        description: Used to verify the hostname for the targets.
+                        type: string
+              type: array
+            jobLabel:
+              description: The label to use to retrieve the job name from.
+              type: string
+            namespaceSelector:
+              description: A selector for selecting namespaces either selecting all
+                namespaces or a list of namespaces.
+              properties:
+                any:
+                  description: Boolean describing whether all namespaces are selected
+                    in contrast to a list restricting them.
+                  type: boolean
+                matchNames:
+                  description: List of namespace names.
+                  items:
+                    type: string
+                  type: array
+            selector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                                 of matchExpressions, whose key field is "key", the operator is
+                                 "In", and the values array contains only "value". The requirements
+                                 are ANDed.
+                  type: object
+            targetLabels:
+              description: TargetLabels transfers labels on the Kubernetes Service
+                onto the target.
+              items:
+                type: string
+              type: array
+          required:
+          - endpoints
+          - selector
+  version: v1

--- a/bundles/prometheus.0.15.0/metadata/annotations.yaml
+++ b/bundles/prometheus.0.15.0/metadata/annotations.yaml
@@ -1,0 +1,4 @@
+annotations:
+  operators.operatorframework.io.bundle.package.v1: "prometheus"
+  operators.operatorframework.io.bundle.channels.v1: "preview"
+  operators.operatorframework.io.bundle.channel.default.v1: "preview"

--- a/bundles/prometheus.0.22.2/manifests/alertmanager.crd.yaml
+++ b/bundles/prometheus.0.22.2/manifests/alertmanager.crd.yaml
@@ -1,0 +1,2398 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: alertmanagers.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    kind: Alertmanager
+    plural: alertmanagers
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: 'Specification of the desired behavior of the Alertmanager
+            cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          properties:
+            affinity:
+              description: Affinity is a group of affinity scheduling rules.
+              properties:
+                nodeAffinity:
+                  description: Node affinity is a group of node affinity scheduling
+                    rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node matches the corresponding matchExpressions; the
+                        node(s) with the highest sum are the most preferred.
+                      items:
+                        description: An empty preferred scheduling term matches all
+                          objects with implicit weight 0 (i.e. it's a no-op). A null
+                          preferred scheduling term matches no objects (i.e. is also
+                          a no-op).
+                        properties:
+                          preference:
+                            description: A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The
+                              TopologySelectorTerm type implements a subset of the
+                              NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                          weight:
+                            description: Weight associated with matching the corresponding
+                              nodeSelectorTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - preference
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: A node selector represents the union of the results
+                        of one or more label queries over a set of nodes; that is,
+                        it represents the OR of the selectors represented by the node
+                        selector terms.
+                      properties:
+                        nodeSelectorTerms:
+                          description: Required. A list of node selector terms. The
+                            terms are ORed.
+                          items:
+                            description: A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The
+                              TopologySelectorTerm type implements a subset of the
+                              NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                          type: array
+                      required:
+                      - nodeSelectorTerms
+                podAffinity:
+                  description: Pod affinity is a group of inter pod affinity scheduling
+                    rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node has pods which matches the corresponding podAffinityTerm;
+                        the node(s) with the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label selector is a label query over
+                                  a set of resources. The result of matchLabels and
+                                  matchExpressions are ANDed. An empty label selector
+                                  matches all objects. A null label selector matches
+                                  no objects.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                    type: array
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - podAffinityTerm
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to a pod label update), the system may or may not
+                        try to eventually evict the pod from its node. When there
+                        are multiple elements, the lists of nodes corresponding to
+                        each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label selector is a label query over a
+                              set of resources. The result of matchLabels and matchExpressions
+                              are ANDed. An empty label selector matches all objects.
+                              A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchLabels:
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                      type: array
+                podAntiAffinity:
+                  description: Pod anti affinity is a group of inter pod anti affinity
+                    scheduling rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the anti-affinity expressions specified by this
+                        field, but it may choose a node that violates one or more
+                        of the expressions. The node that is most preferred is the
+                        one with the greatest sum of weights, i.e. for each node that
+                        meets all of the scheduling requirements (resource request,
+                        requiredDuringScheduling anti-affinity expressions, etc.),
+                        compute a sum by iterating through the elements of this field
+                        and adding "weight" to the sum if the node has pods which
+                        matches the corresponding podAffinityTerm; the node(s) with
+                        the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label selector is a label query over
+                                  a set of resources. The result of matchLabels and
+                                  matchExpressions are ANDed. An empty label selector
+                                  matches all objects. A null label selector matches
+                                  no objects.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                    type: array
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - podAffinityTerm
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the anti-affinity requirements specified by
+                        this field are not met at scheduling time, the pod will not
+                        be scheduled onto the node. If the anti-affinity requirements
+                        specified by this field cease to be met at some point during
+                        pod execution (e.g. due to a pod label update), the system
+                        may or may not try to eventually evict the pod from its node.
+                        When there are multiple elements, the lists of nodes corresponding
+                        to each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label selector is a label query over a
+                              set of resources. The result of matchLabels and matchExpressions
+                              are ANDed. An empty label selector matches all objects.
+                              A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchLabels:
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                      type: array
+            baseImage:
+              description: Base image that is used to deploy pods, without tag.
+              type: string
+            containers:
+              description: Containers allows injecting additional containers. This
+                is meant to allow adding an authentication proxy to an Alertmanager
+                pod.
+              items:
+                description: A single application container that you want to run within
+                  a pod.
+                properties:
+                  args:
+                    description: 'Arguments to the entrypoint. The docker image''s
+                      CMD is used if this is not provided. Variable references $(VAR_NAME)
+                      are expanded using the container''s environment. If a variable
+                      cannot be resolved, the reference in the input string will be
+                      unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                      $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                      regardless of whether the variable exists or not. Cannot be
+                      updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    description: 'Entrypoint array. Not executed within a shell. The
+                      docker image''s ENTRYPOINT is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container''s
+                      environment. If a variable cannot be resolved, the reference
+                      in the input string will be unchanged. The $(VAR_NAME) syntax
+                      can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                      will never be expanded, regardless of whether the variable exists
+                      or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: List of environment variables to set in the container.
+                      Cannot be updated.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: EnvVarSource represents a source for the value
+                            of an EnvVar.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key from a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or it's
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                            fieldRef:
+                              description: ObjectFieldSelector selects an APIVersioned
+                                field of an object.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                            resourceFieldRef:
+                              description: ResourceFieldSelector represents container
+                                resources (cpu, memory) and their output format
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor: {}
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                            secretKeyRef:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or it's
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                      required:
+                      - name
+                    type: array
+                  envFrom:
+                    description: List of sources to populate environment variables
+                      in the container. The keys defined within a source must be a
+                      C_IDENTIFIER. All invalid keys will be reported as an event
+                      when the container is starting. When a key exists in multiple
+                      sources, the value associated with the last source will take
+                      precedence. Values defined by an Env with a duplicate key will
+                      take precedence. Cannot be updated.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: |-
+                            ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+
+                            The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: |-
+                            SecretEnvSource selects a Secret to populate the environment variables with.
+
+                            The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                    type: array
+                  image:
+                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                      This field is optional to allow higher level config management
+                      to default or override container images in workload controllers
+                      like Deployments and StatefulSets.'
+                    type: string
+                  imagePullPolicy:
+                    description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                      Defaults to Always if :latest tag is specified, or IfNotPresent
+                      otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                    type: string
+                  lifecycle:
+                    description: Lifecycle describes actions that the management system
+                      should take in response to container lifecycle events. For the
+                      PostStart and PreStop lifecycle handlers, management of the
+                      container blocks until the action is complete, unless the container
+                      process fails, in which case the handler is aborted.
+                    properties:
+                      postStart:
+                        description: Handler defines a specific action that should
+                          be taken
+                        properties:
+                          exec:
+                            description: ExecAction describes a "run in container"
+                              action.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                          httpGet:
+                            description: HTTPGetAction describes an action based on
+                              HTTP Get requests.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                          tcpSocket:
+                            description: TCPSocketAction describes an action based
+                              on opening a socket
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                            required:
+                            - port
+                      preStop:
+                        description: Handler defines a specific action that should
+                          be taken
+                        properties:
+                          exec:
+                            description: ExecAction describes a "run in container"
+                              action.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                          httpGet:
+                            description: HTTPGetAction describes an action based on
+                              HTTP Get requests.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                          tcpSocket:
+                            description: TCPSocketAction describes an action based
+                              on opening a socket
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                            required:
+                            - port
+                  livenessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: ExecAction describes a "run in container" action.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGetAction describes an action based on HTTP
+                          Get requests.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocketAction describes an action based on
+                          opening a socket
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                        required:
+                        - port
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                  name:
+                    description: Name of the container specified as a DNS_LABEL. Each
+                      container in a pod must have a unique name (DNS_LABEL). Cannot
+                      be updated.
+                    type: string
+                  ports:
+                    description: List of ports to expose from the container. Exposing
+                      a port here gives the system additional information about the
+                      network connections a container uses, but is primarily informational.
+                      Not specifying a port here DOES NOT prevent that port from being
+                      exposed. Any port which is listening on the default "0.0.0.0"
+                      address inside a container will be accessible from the network.
+                      Cannot be updated.
+                    items:
+                      description: ContainerPort represents a network port in a single
+                        container.
+                      properties:
+                        containerPort:
+                          description: Number of port to expose on the pod's IP address.
+                            This must be a valid port number, 0 < x < 65536.
+                          format: int32
+                          type: integer
+                        hostIP:
+                          description: What host IP to bind the external port to.
+                          type: string
+                        hostPort:
+                          description: Number of port to expose on the host. If specified,
+                            this must be a valid port number, 0 < x < 65536. If HostNetwork
+                            is specified, this must match ContainerPort. Most containers
+                            do not need this.
+                          format: int32
+                          type: integer
+                        name:
+                          description: If specified, this must be an IANA_SVC_NAME
+                            and unique within the pod. Each named port in a pod must
+                            have a unique name. Name for the port that can be referred
+                            to by services.
+                          type: string
+                        protocol:
+                          description: Protocol for port. Must be UDP or TCP. Defaults
+                            to "TCP".
+                          type: string
+                      required:
+                      - containerPort
+                    type: array
+                  readinessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: ExecAction describes a "run in container" action.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGetAction describes an action based on HTTP
+                          Get requests.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocketAction describes an action based on
+                          opening a socket
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                        required:
+                        - port
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                  securityContext:
+                    description: SecurityContext holds security configuration that
+                      will be applied to a container. Some fields are present in both
+                      SecurityContext and PodSecurityContext.  When both are set,
+                      the values in SecurityContext take precedence.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: Adds and removes POSIX capabilities from running
+                          containers.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              type: string
+                            type: array
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: SELinuxOptions are the labels to be applied to
+                          the container
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                  stdin:
+                    description: Whether this container should allocate a buffer for
+                      stdin in the container runtime. If this is not set, reads from
+                      stdin in the container will always result in EOF. Default is
+                      false.
+                    type: boolean
+                  stdinOnce:
+                    description: Whether the container runtime should close the stdin
+                      channel after it has been opened by a single attach. When stdin
+                      is true the stdin stream will remain open across multiple attach
+                      sessions. If stdinOnce is set to true, stdin is opened on container
+                      start, is empty until the first client attaches to stdin, and
+                      then remains open and accepts data until the client disconnects,
+                      at which time stdin is closed and remains closed until the container
+                      is restarted. If this flag is false, a container processes that
+                      reads from stdin will never receive an EOF. Default is false
+                    type: boolean
+                  terminationMessagePath:
+                    description: 'Optional: Path at which the file to which the container''s
+                      termination message will be written is mounted into the container''s
+                      filesystem. Message written is intended to be brief final status,
+                      such as an assertion failure message. Will be truncated by the
+                      node if greater than 4096 bytes. The total message length across
+                      all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                      Cannot be updated.'
+                    type: string
+                  terminationMessagePolicy:
+                    description: Indicate how the termination message should be populated.
+                      File will use the contents of terminationMessagePath to populate
+                      the container status message on both success and failure. FallbackToLogsOnError
+                      will use the last chunk of container log output if the termination
+                      message file is empty and the container exited with an error.
+                      The log output is limited to 2048 bytes or 80 lines, whichever
+                      is smaller. Defaults to File. Cannot be updated.
+                    type: string
+                  tty:
+                    description: Whether this container should allocate a TTY for
+                      itself, also requires 'stdin' to be true. Default is false.
+                    type: boolean
+                  volumeDevices:
+                    description: volumeDevices is the list of block devices to be
+                      used by the container. This is an alpha feature and may change
+                      in the future.
+                    items:
+                      description: volumeDevice describes a mapping of a raw block
+                        device within a container.
+                      properties:
+                        devicePath:
+                          description: devicePath is the path inside of the container
+                            that the device will be mapped to.
+                          type: string
+                        name:
+                          description: name must match the name of a persistentVolumeClaim
+                            in the pod
+                          type: string
+                      required:
+                      - name
+                      - devicePath
+                    type: array
+                  volumeMounts:
+                    description: Pod volumes to mount into the container's filesystem.
+                      Cannot be updated.
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: Path within the container at which the volume
+                            should be mounted.  Must not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: mountPropagation determines how mounts are
+                            propagated from the host to container and the other way
+                            around. When not set, MountPropagationHostToContainer
+                            is used. This field is beta in 1.10.
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: Mounted read-only if true, read-write otherwise
+                            (false or unspecified). Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: Path within the volume from which the container's
+                            volume should be mounted. Defaults to "" (volume's root).
+                          type: string
+                      required:
+                      - name
+                      - mountPath
+                    type: array
+                  workingDir:
+                    description: Container's working directory. If not specified,
+                      the container runtime's default will be used, which might be
+                      configured in the container image. Cannot be updated.
+                    type: string
+                required:
+                - name
+              type: array
+            externalUrl:
+              description: The external URL the Alertmanager instances will be available
+                under. This is necessary to generate correct URLs. This is necessary
+                if Alertmanager is not served from root of a DNS name.
+              type: string
+            imagePullSecrets:
+              description: An optional list of references to secrets in the same namespace
+                to use for pulling prometheus and alertmanager images from registries
+                see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
+              items:
+                description: LocalObjectReference contains enough information to let
+                  you locate the referenced object inside the same namespace.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+              type: array
+            listenLocal:
+              description: ListenLocal makes the Alertmanager server listen on loopback,
+                so that it does not bind against the Pod IP. Note this is only for
+                the Alertmanager UI, not the gossip communication.
+              type: boolean
+            logLevel:
+              description: Log level for Alertmanager to be configured with.
+              type: string
+            nodeSelector:
+              description: Define which Nodes the Pods are scheduled on.
+              type: object
+            paused:
+              description: If set to true all actions on the underlaying managed objects
+                are not goint to be performed, except for delete actions.
+              type: boolean
+            podMetadata:
+              description: ObjectMeta is metadata that all persisted resources must
+                have, which includes all objects users must create.
+              properties:
+                annotations:
+                  description: 'Annotations is an unstructured key value map stored
+                    with a resource that may be set by external tools to store and
+                    retrieve arbitrary metadata. They are not queryable and should
+                    be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                  type: object
+                clusterName:
+                  description: The name of the cluster which the object belongs to.
+                    This is used to distinguish resources with same name and namespace
+                    in different clusters. This field is not set anywhere right now
+                    and apiserver is going to ignore it if set in create or update
+                    request.
+                  type: string
+                creationTimestamp:
+                  description: Time is a wrapper around time.Time which supports correct
+                    marshaling to YAML and JSON.  Wrappers are provided for many of
+                    the factory methods that the time package offers.
+                  format: date-time
+                  type: string
+                deletionGracePeriodSeconds:
+                  description: Number of seconds allowed for this object to gracefully
+                    terminate before it will be removed from the system. Only set
+                    when deletionTimestamp is also set. May only be shortened. Read-only.
+                  format: int64
+                  type: integer
+                deletionTimestamp:
+                  description: Time is a wrapper around time.Time which supports correct
+                    marshaling to YAML and JSON.  Wrappers are provided for many of
+                    the factory methods that the time package offers.
+                  format: date-time
+                  type: string
+                finalizers:
+                  description: Must be empty before the object is deleted from the
+                    registry. Each entry is an identifier for the responsible component
+                    that will remove the entry from the list. If the deletionTimestamp
+                    of the object is non-nil, entries in this list can only be removed.
+                  items:
+                    type: string
+                  type: array
+                generateName:
+                  description: |-
+                    GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+                    If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
+                    Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                  type: string
+                generation:
+                  description: A sequence number representing a specific generation
+                    of the desired state. Populated by the system. Read-only.
+                  format: int64
+                  type: integer
+                initializers:
+                  description: Initializers tracks the progress of initialization.
+                  properties:
+                    pending:
+                      description: Pending is a list of initializers that must execute
+                        in order before this object is visible. When the last pending
+                        initializer is removed, and no failing result is set, the
+                        initializers struct will be set to nil and the object is considered
+                        as initialized and visible to all clients.
+                      items:
+                        description: Initializer is information about an initializer
+                          that has not yet completed.
+                        properties:
+                          name:
+                            description: name of the process that is responsible for
+                              initializing this object.
+                            type: string
+                        required:
+                        - name
+                      type: array
+                    result:
+                      description: Status is a return value for calls that don't return
+                        other objects.
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of
+                            this representation of an object. Servers should convert
+                            recognized schemas to the latest internal value, and may
+                            reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                          type: string
+                        code:
+                          description: Suggested HTTP return code for this status,
+                            0 if not set.
+                          format: int32
+                          type: integer
+                        details:
+                          description: StatusDetails is a set of additional properties
+                            that MAY be set by the server to provide additional information
+                            about a response. The Reason field of a Status object
+                            defines what attributes will be set. Clients must ignore
+                            fields that do not match the defined type of each attribute,
+                            and should assume that any attribute may be empty, invalid,
+                            or under defined.
+                          properties:
+                            causes:
+                              description: The Causes array includes more details
+                                associated with the StatusReason failure. Not all
+                                StatusReasons may provide detailed causes.
+                              items:
+                                description: StatusCause provides more information
+                                  about an api.Status failure, including cases when
+                                  multiple errors are encountered.
+                                properties:
+                                  field:
+                                    description: |-
+                                      The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
+                                      Examples:
+                                        "name" - the field "name" on the current resource
+                                        "items[0].name" - the field "name" on the first array entry in "items"
+                                    type: string
+                                  message:
+                                    description: A human-readable description of the
+                                      cause of the error.  This field may be presented
+                                      as-is to a reader.
+                                    type: string
+                                  reason:
+                                    description: A machine-readable description of
+                                      the cause of the error. If this value is empty
+                                      there is no information available.
+                                    type: string
+                              type: array
+                            group:
+                              description: The group attribute of the resource associated
+                                with the status StatusReason.
+                              type: string
+                            kind:
+                              description: 'The kind attribute of the resource associated
+                                with the status StatusReason. On some operations may
+                                differ from the requested resource Kind. More info:
+                                https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: The name attribute of the resource associated
+                                with the status StatusReason (when there is a single
+                                name which can be described).
+                              type: string
+                            retryAfterSeconds:
+                              description: If specified, the time in seconds before
+                                the operation should be retried. Some errors may indicate
+                                the client must take an alternate action - for those
+                                errors this field may indicate how long to wait before
+                                taking the alternate action.
+                              format: int32
+                              type: integer
+                            uid:
+                              description: 'UID of the resource. (when there is a
+                                single resource which can be described). More info:
+                                http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST
+                            resource this object represents. Servers may infer this
+                            from the endpoint the client submits requests to. Cannot
+                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                          type: string
+                        message:
+                          description: A human-readable description of the status
+                            of this operation.
+                          type: string
+                        metadata:
+                          description: ListMeta describes metadata that synthetic
+                            resources must have, including lists and various status
+                            objects. A resource may have only one of {ObjectMeta,
+                            ListMeta}.
+                          properties:
+                            continue:
+                              description: continue may be set if the user set a limit
+                                on the number of items returned, and indicates that
+                                the server has more data available. The value is opaque
+                                and may be used to issue another request to the endpoint
+                                that served this list to retrieve the next set of
+                                available objects. Continuing a list may not be possible
+                                if the server configuration has changed or more than
+                                a few minutes have passed. The resourceVersion field
+                                returned when using this continue value will be identical
+                                to the value in the first response.
+                              type: string
+                            resourceVersion:
+                              description: 'String that identifies the server''s internal
+                                version of this object that can be used by clients
+                                to determine when objects have changed. Value must
+                                be treated as opaque by clients and passed unmodified
+                                back to the server. Populated by the system. Read-only.
+                                More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            selfLink:
+                              description: selfLink is a URL representing this object.
+                                Populated by the system. Read-only.
+                              type: string
+                        reason:
+                          description: A machine-readable description of why this
+                            operation is in the "Failure" status. If this value is
+                            empty there is no information available. A Reason clarifies
+                            an HTTP status code but does not override it.
+                          type: string
+                        status:
+                          description: 'Status of the operation. One of: "Success"
+                            or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                          type: string
+                  required:
+                  - pending
+                labels:
+                  description: 'Map of string keys and values that can be used to
+                    organize and categorize (scope and select) objects. May match
+                    selectors of replication controllers and services. More info:
+                    http://kubernetes.io/docs/user-guide/labels'
+                  type: object
+                name:
+                  description: 'Name must be unique within a namespace. Is required
+                    when creating resources, although some resources may allow a client
+                    to request the generation of an appropriate name automatically.
+                    Name is primarily intended for creation idempotence and configuration
+                    definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+                    Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                  type: string
+                ownerReferences:
+                  description: List of objects depended by this object. If ALL objects
+                    in the list have been deleted, this object will be garbage collected.
+                    If this object is managed by a controller, then an entry in this
+                    list will point to this controller, with the controller field
+                    set to true. There cannot be more than one managing controller.
+                  items:
+                    description: OwnerReference contains enough information to let
+                      you identify an owning object. Currently, an owning object must
+                      be in the same namespace, so there is no namespace field.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      blockOwnerDeletion:
+                        description: If true, AND if the owner has the "foregroundDeletion"
+                          finalizer, then the owner cannot be deleted from the key-value
+                          store until this reference is removed. Defaults to false.
+                          To set this field, a user needs "delete" permission of the
+                          owner, otherwise 422 (Unprocessable Entity) will be returned.
+                        type: boolean
+                      controller:
+                        description: If true, this reference points to the managing
+                          controller.
+                        type: boolean
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                  type: array
+                resourceVersion:
+                  description: |-
+                    An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+                    Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                  type: string
+                selfLink:
+                  description: SelfLink is a URL representing this object. Populated
+                    by the system. Read-only.
+                  type: string
+                uid:
+                  description: |-
+                    UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+                    Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                  type: string
+            replicas:
+              description: Size is the expected size of the alertmanager cluster.
+                The controller will eventually make the size of the running cluster
+                equal to the expected size.
+              format: int32
+              type: integer
+            resources:
+              description: ResourceRequirements describes the compute resource requirements.
+              properties:
+                limits:
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+            routePrefix:
+              description: The route prefix Alertmanager registers HTTP handlers for.
+                This is useful, if using ExternalURL and a proxy is rewriting HTTP
+                routes of a request, and the actual ExternalURL is still true, but
+                the server serves requests under a different route prefix. For example
+                for use with `kubectl proxy`.
+              type: string
+            secrets:
+              description: Secrets is a list of Secrets in the same namespace as the
+                Alertmanager object, which shall be mounted into the Alertmanager
+                Pods. The Secrets are mounted into /etc/alertmanager/secrets/<secret-name>.
+              items:
+                type: string
+              type: array
+            securityContext:
+              description: PodSecurityContext holds pod-level security attributes
+                and common container settings. Some fields are also present in container.securityContext.  Field
+                values of container.securityContext take precedence over field values
+                of PodSecurityContext.
+              properties:
+                fsGroup:
+                  description: |-
+                    A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                    1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                    If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                  format: int64
+                  type: integer
+                runAsGroup:
+                  description: The GID to run the entrypoint of the container process.
+                    Uses runtime default if unset. May also be set in SecurityContext.  If
+                    set in both SecurityContext and PodSecurityContext, the value
+                    specified in SecurityContext takes precedence for that container.
+                  format: int64
+                  type: integer
+                runAsNonRoot:
+                  description: Indicates that the container must run as a non-root
+                    user. If true, the Kubelet will validate the image at runtime
+                    to ensure that it does not run as UID 0 (root) and fail to start
+                    the container if it does. If unset or false, no such validation
+                    will be performed. May also be set in SecurityContext.  If set
+                    in both SecurityContext and PodSecurityContext, the value specified
+                    in SecurityContext takes precedence.
+                  type: boolean
+                runAsUser:
+                  description: The UID to run the entrypoint of the container process.
+                    Defaults to user specified in image metadata if unspecified. May
+                    also be set in SecurityContext.  If set in both SecurityContext
+                    and PodSecurityContext, the value specified in SecurityContext
+                    takes precedence for that container.
+                  format: int64
+                  type: integer
+                seLinuxOptions:
+                  description: SELinuxOptions are the labels to be applied to the
+                    container
+                  properties:
+                    level:
+                      description: Level is SELinux level label that applies to the
+                        container.
+                      type: string
+                    role:
+                      description: Role is a SELinux role label that applies to the
+                        container.
+                      type: string
+                    type:
+                      description: Type is a SELinux type label that applies to the
+                        container.
+                      type: string
+                    user:
+                      description: User is a SELinux user label that applies to the
+                        container.
+                      type: string
+                supplementalGroups:
+                  description: A list of groups applied to the first process run in
+                    each container, in addition to the container's primary GID.  If
+                    unspecified, no groups will be added to any container.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                sysctls:
+                  description: Sysctls hold a list of namespaced sysctls used for
+                    the pod. Pods with unsupported sysctls (by the container runtime)
+                    might fail to launch.
+                  items:
+                    description: Sysctl defines a kernel parameter to be set
+                    properties:
+                      name:
+                        description: Name of a property to set
+                        type: string
+                      value:
+                        description: Value of a property to set
+                        type: string
+                    required:
+                    - name
+                    - value
+                  type: array
+            serviceAccountName:
+              description: ServiceAccountName is the name of the ServiceAccount to
+                use to run the Prometheus Pods.
+              type: string
+            storage:
+              description: StorageSpec defines the configured storage for a group
+                Prometheus servers.
+              properties:
+                class:
+                  description: 'Name of the StorageClass to use when requesting storage
+                    provisioning. More info: https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses
+                    DEPRECATED'
+                  type: string
+                emptyDir:
+                  description: Represents an empty directory for a pod. Empty directory
+                    volumes support ownership management and SELinux relabeling.
+                  properties:
+                    medium:
+                      description: 'What type of storage medium should back this directory.
+                        The default is "" which means to use the node''s default medium.
+                        Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                      type: string
+                    sizeLimit: {}
+                resources:
+                  description: ResourceRequirements describes the compute resource
+                    requirements.
+                  properties:
+                    limits:
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                selector:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                      type: array
+                    matchLabels:
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                                     of matchExpressions, whose key field is "key", the operator
+                                     is "In", and the values array contains only "value". The requirements
+                                     are ANDed.
+                      type: object
+                volumeClaimTemplate:
+                  description: PersistentVolumeClaim is a user's request for and claim
+                    to a persistent volume
+                  properties:
+                    apiVersion:
+                      description: 'APIVersion defines the versioned schema of this
+                        representation of an object. Servers should convert recognized
+                        schemas to the latest internal value, and may reject unrecognized
+                        values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                      type: string
+                    kind:
+                      description: 'Kind is a string value representing the REST resource
+                        this object represents. Servers may infer this from the endpoint
+                        the client submits requests to. Cannot be updated. In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                      type: string
+                    metadata:
+                      description: ObjectMeta is metadata that all persisted resources
+                        must have, which includes all objects users must create.
+                      properties:
+                        annotations:
+                          description: 'Annotations is an unstructured key value map
+                            stored with a resource that may be set by external tools
+                            to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: http://kubernetes.io/docs/user-guide/annotations'
+                          type: object
+                        clusterName:
+                          description: The name of the cluster which the object belongs
+                            to. This is used to distinguish resources with same name
+                            and namespace in different clusters. This field is not
+                            set anywhere right now and apiserver is going to ignore
+                            it if set in create or update request.
+                          type: string
+                        creationTimestamp:
+                          description: Time is a wrapper around time.Time which supports
+                            correct marshaling to YAML and JSON.  Wrappers are provided
+                            for many of the factory methods that the time package
+                            offers.
+                          format: date-time
+                          type: string
+                        deletionGracePeriodSeconds:
+                          description: Number of seconds allowed for this object to
+                            gracefully terminate before it will be removed from the
+                            system. Only set when deletionTimestamp is also set. May
+                            only be shortened. Read-only.
+                          format: int64
+                          type: integer
+                        deletionTimestamp:
+                          description: Time is a wrapper around time.Time which supports
+                            correct marshaling to YAML and JSON.  Wrappers are provided
+                            for many of the factory methods that the time package
+                            offers.
+                          format: date-time
+                          type: string
+                        finalizers:
+                          description: Must be empty before the object is deleted
+                            from the registry. Each entry is an identifier for the
+                            responsible component that will remove the entry from
+                            the list. If the deletionTimestamp of the object is non-nil,
+                            entries in this list can only be removed.
+                          items:
+                            type: string
+                          type: array
+                        generateName:
+                          description: |-
+                            GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+                            If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
+                            Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                          type: string
+                        generation:
+                          description: A sequence number representing a specific generation
+                            of the desired state. Populated by the system. Read-only.
+                          format: int64
+                          type: integer
+                        initializers:
+                          description: Initializers tracks the progress of initialization.
+                          properties:
+                            pending:
+                              description: Pending is a list of initializers that
+                                must execute in order before this object is visible.
+                                When the last pending initializer is removed, and
+                                no failing result is set, the initializers struct
+                                will be set to nil and the object is considered as
+                                initialized and visible to all clients.
+                              items:
+                                description: Initializer is information about an initializer
+                                  that has not yet completed.
+                                properties:
+                                  name:
+                                    description: name of the process that is responsible
+                                      for initializing this object.
+                                    type: string
+                                required:
+                                - name
+                              type: array
+                            result:
+                              description: Status is a return value for calls that
+                                don't return other objects.
+                              properties:
+                                apiVersion:
+                                  description: 'APIVersion defines the versioned schema
+                                    of this representation of an object. Servers should
+                                    convert recognized schemas to the latest internal
+                                    value, and may reject unrecognized values. More
+                                    info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                                  type: string
+                                code:
+                                  description: Suggested HTTP return code for this
+                                    status, 0 if not set.
+                                  format: int32
+                                  type: integer
+                                details:
+                                  description: StatusDetails is a set of additional
+                                    properties that MAY be set by the server to provide
+                                    additional information about a response. The Reason
+                                    field of a Status object defines what attributes
+                                    will be set. Clients must ignore fields that do
+                                    not match the defined type of each attribute,
+                                    and should assume that any attribute may be empty,
+                                    invalid, or under defined.
+                                  properties:
+                                    causes:
+                                      description: The Causes array includes more
+                                        details associated with the StatusReason failure.
+                                        Not all StatusReasons may provide detailed
+                                        causes.
+                                      items:
+                                        description: StatusCause provides more information
+                                          about an api.Status failure, including cases
+                                          when multiple errors are encountered.
+                                        properties:
+                                          field:
+                                            description: |-
+                                              The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
+                                              Examples:
+                                                "name" - the field "name" on the current resource
+                                                "items[0].name" - the field "name" on the first array entry in "items"
+                                            type: string
+                                          message:
+                                            description: A human-readable description
+                                              of the cause of the error.  This field
+                                              may be presented as-is to a reader.
+                                            type: string
+                                          reason:
+                                            description: A machine-readable description
+                                              of the cause of the error. If this value
+                                              is empty there is no information available.
+                                            type: string
+                                      type: array
+                                    group:
+                                      description: The group attribute of the resource
+                                        associated with the status StatusReason.
+                                      type: string
+                                    kind:
+                                      description: 'The kind attribute of the resource
+                                        associated with the status StatusReason. On
+                                        some operations may differ from the requested
+                                        resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: The name attribute of the resource
+                                        associated with the status StatusReason (when
+                                        there is a single name which can be described).
+                                      type: string
+                                    retryAfterSeconds:
+                                      description: If specified, the time in seconds
+                                        before the operation should be retried. Some
+                                        errors may indicate the client must take an
+                                        alternate action - for those errors this field
+                                        may indicate how long to wait before taking
+                                        the alternate action.
+                                      format: int32
+                                      type: integer
+                                    uid:
+                                      description: 'UID of the resource. (when there
+                                        is a single resource which can be described).
+                                        More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                      type: string
+                                kind:
+                                  description: 'Kind is a string value representing
+                                    the REST resource this object represents. Servers
+                                    may infer this from the endpoint the client submits
+                                    requests to. Cannot be updated. In CamelCase.
+                                    More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                  type: string
+                                message:
+                                  description: A human-readable description of the
+                                    status of this operation.
+                                  type: string
+                                metadata:
+                                  description: ListMeta describes metadata that synthetic
+                                                 resources must have, including lists and various
+                                                 status objects. A resource may have only one of
+                                    {ObjectMeta, ListMeta}.
+                                  properties:
+                                    continue:
+                                      description: continue may be set if the user
+                                        set a limit on the number of items returned,
+                                        and indicates that the server has more data
+                                        available. The value is opaque and may be
+                                        used to issue another request to the endpoint
+                                        that served this list to retrieve the next
+                                        set of available objects. Continuing a list
+                                        may not be possible if the server configuration
+                                        has changed or more than a few minutes have
+                                        passed. The resourceVersion field returned
+                                        when using this continue value will be identical
+                                        to the value in the first response.
+                                      type: string
+                                    resourceVersion:
+                                      description: 'String that identifies the server''s
+                                        internal version of this object that can be
+                                        used by clients to determine when objects
+                                        have changed. Value must be treated as opaque
+                                        by clients and passed unmodified back to the
+                                        server. Populated by the system. Read-only.
+                                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                                      type: string
+                                    selfLink:
+                                      description: selfLink is a URL representing
+                                        this object. Populated by the system. Read-only.
+                                      type: string
+                                reason:
+                                  description: A machine-readable description of why
+                                    this operation is in the "Failure" status. If
+                                    this value is empty there is no information available.
+                                    A Reason clarifies an HTTP status code but does
+                                    not override it.
+                                  type: string
+                                status:
+                                  description: 'Status of the operation. One of: "Success"
+                                    or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                                  type: string
+                          required:
+                          - pending
+                        labels:
+                          description: 'Map of string keys and values that can be
+                            used to organize and categorize (scope and select) objects.
+                            May match selectors of replication controllers and services.
+                            More info: http://kubernetes.io/docs/user-guide/labels'
+                          type: object
+                        name:
+                          description: 'Name must be unique within a namespace. Is
+                            required when creating resources, although some resources
+                            may allow a client to request the generation of an appropriate
+                            name automatically. Name is primarily intended for creation
+                            idempotence and configuration definition. Cannot be updated.
+                            More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+                            Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                          type: string
+                        ownerReferences:
+                          description: List of objects depended by this object. If
+                            ALL objects in the list have been deleted, this object
+                            will be garbage collected. If this object is managed by
+                            a controller, then an entry in this list will point to
+                            this controller, with the controller field set to true.
+                            There cannot be more than one managing controller.
+                          items:
+                            description: OwnerReference contains enough information
+                              to let you identify an owning object. Currently, an
+                              owning object must be in the same namespace, so there
+                              is no namespace field.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              blockOwnerDeletion:
+                                description: If true, AND if the owner has the "foregroundDeletion"
+                                               finalizer, then the owner cannot be deleted from
+                                               the key-value store until this reference is removed.
+                                               Defaults to false. To set this field, a user needs
+                                               "delete" permission of the owner, otherwise 422
+                                               (Unprocessable Entity) will be returned.
+                                type: boolean
+                              controller:
+                                description: If true, this reference points to the
+                                  managing controller.
+                                type: boolean
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                type: string
+                            required:
+                            - apiVersion
+                            - kind
+                            - name
+                            - uid
+                          type: array
+                        resourceVersion:
+                          description: |-
+                            An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+                            Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                          type: string
+                        selfLink:
+                          description: SelfLink is a URL representing this object.
+                            Populated by the system. Read-only.
+                          type: string
+                        uid:
+                          description: |-
+                            UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+                            Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                          type: string
+                    spec:
+                      description: PersistentVolumeClaimSpec describes the common
+                        attributes of storage devices and allows a Source for provider-specific
+                        attributes
+                      properties:
+                        accessModes:
+                          description: 'AccessModes contains the desired access modes
+                            the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          items:
+                            type: string
+                          type: array
+                        resources:
+                          description: ResourceRequirements describes the compute
+                            resource requirements.
+                          properties:
+                            limits:
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                        selector:
+                          description: A label selector is a label query over a set
+                            of resources. The result of matchLabels and matchExpressions
+                            are ANDed. An empty label selector matches all objects.
+                            A null label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                              type: array
+                            matchLabels:
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                        storageClassName:
+                          description: 'Name of the StorageClass required by the claim.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                          type: string
+                        volumeMode:
+                          description: volumeMode defines what type of volume is required
+                            by the claim. Value of Filesystem is implied when not
+                            included in claim spec. This is an alpha feature and may
+                            change in the future.
+                          type: string
+                        volumeName:
+                          description: VolumeName is the binding reference to the
+                            PersistentVolume backing this claim.
+                          type: string
+                    status:
+                      description: PersistentVolumeClaimStatus is the current status
+                        of a persistent volume claim.
+                      properties:
+                        accessModes:
+                          description: 'AccessModes contains the actual access modes
+                            the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          items:
+                            type: string
+                          type: array
+                        capacity:
+                          description: Represents the actual resources of the underlying
+                            volume.
+                          type: object
+                        conditions:
+                          description: Current Condition of persistent volume claim.
+                            If underlying persistent volume is being resized then
+                            the Condition will be set to 'ResizeStarted'.
+                          items:
+                            description: PersistentVolumeClaimCondition contails details
+                              about state of pvc
+                            properties:
+                              lastProbeTime:
+                                description: Time is a wrapper around time.Time which
+                                  supports correct marshaling to YAML and JSON.  Wrappers
+                                  are provided for many of the factory methods that
+                                  the time package offers.
+                                format: date-time
+                                type: string
+                              lastTransitionTime:
+                                description: Time is a wrapper around time.Time which
+                                  supports correct marshaling to YAML and JSON.  Wrappers
+                                  are provided for many of the factory methods that
+                                  the time package offers.
+                                format: date-time
+                                type: string
+                              message:
+                                description: Human-readable message indicating details
+                                  about last transition.
+                                type: string
+                              reason:
+                                description: Unique, this should be a short, machine
+                                  understandable string that gives the reason for
+                                  condition's last transition. If it reports "ResizeStarted"
+                                  that means the underlying persistent volume is being
+                                  resized.
+                                type: string
+                              status:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - type
+                            - status
+                          type: array
+                        phase:
+                          description: Phase represents the current phase of PersistentVolumeClaim.
+                          type: string
+            tag:
+              description: Tag of Alertmanager container image to be deployed. Defaults
+                to the value of `version`.
+              type: string
+            tolerations:
+              description: If specified, the pod's tolerations.
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
+                properties:
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
+                    type: string
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
+                    type: string
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
+                    type: string
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
+                    type: string
+              type: array
+            version:
+              description: Version the cluster should be on.
+              type: string
+        status:
+          description: 'Most recent observed status of the Alertmanager cluster. Read-only.
+            Not included when requesting from the apiserver, only from the Prometheus
+            Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          properties:
+            availableReplicas:
+              description: Total number of available pods (ready for at least minReadySeconds)
+                targeted by this Alertmanager cluster.
+              format: int32
+              type: integer
+            paused:
+              description: Represents whether any actions on the underlaying managed
+                objects are being performed. Only delete actions will be performed.
+              type: boolean
+            replicas:
+              description: Total number of non-terminated pods targeted by this Alertmanager
+                cluster (their labels match the selector).
+              format: int32
+              type: integer
+            unavailableReplicas:
+              description: Total number of unavailable pods targeted by this Alertmanager
+                cluster.
+              format: int32
+              type: integer
+            updatedReplicas:
+              description: Total number of non-terminated pods targeted by this Alertmanager
+                cluster that have the desired version spec.
+              format: int32
+              type: integer
+          required:
+          - paused
+          - replicas
+          - updatedReplicas
+          - availableReplicas
+          - unavailableReplicas
+  version: v1

--- a/bundles/prometheus.0.22.2/manifests/prometheus.crd.yaml
+++ b/bundles/prometheus.0.22.2/manifests/prometheus.crd.yaml
@@ -1,0 +1,2971 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: prometheuses.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    kind: Prometheus
+    plural: prometheuses
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: 'Specification of the desired behavior of the Prometheus cluster.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          properties:
+            additionalAlertManagerConfigs:
+              description: SecretKeySelector selects a key of a Secret.
+              properties:
+                key:
+                  description: The key of the secret to select from.  Must be a valid
+                    secret key.
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                optional:
+                  description: Specify whether the Secret or it's key must be defined
+                  type: boolean
+              required:
+              - key
+            additionalScrapeConfigs:
+              description: SecretKeySelector selects a key of a Secret.
+              properties:
+                key:
+                  description: The key of the secret to select from.  Must be a valid
+                    secret key.
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                optional:
+                  description: Specify whether the Secret or it's key must be defined
+                  type: boolean
+              required:
+              - key
+            affinity:
+              description: Affinity is a group of affinity scheduling rules.
+              properties:
+                nodeAffinity:
+                  description: Node affinity is a group of node affinity scheduling
+                    rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node matches the corresponding matchExpressions; the
+                        node(s) with the highest sum are the most preferred.
+                      items:
+                        description: An empty preferred scheduling term matches all
+                          objects with implicit weight 0 (i.e. it's a no-op). A null
+                          preferred scheduling term matches no objects (i.e. is also
+                          a no-op).
+                        properties:
+                          preference:
+                            description: A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The
+                              TopologySelectorTerm type implements a subset of the
+                              NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                          weight:
+                            description: Weight associated with matching the corresponding
+                              nodeSelectorTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - preference
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: A node selector represents the union of the results
+                        of one or more label queries over a set of nodes; that is,
+                        it represents the OR of the selectors represented by the node
+                        selector terms.
+                      properties:
+                        nodeSelectorTerms:
+                          description: Required. A list of node selector terms. The
+                            terms are ORed.
+                          items:
+                            description: A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The
+                              TopologySelectorTerm type implements a subset of the
+                              NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                          type: array
+                      required:
+                      - nodeSelectorTerms
+                podAffinity:
+                  description: Pod affinity is a group of inter pod affinity scheduling
+                    rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node has pods which matches the corresponding podAffinityTerm;
+                        the node(s) with the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label selector is a label query over
+                                  a set of resources. The result of matchLabels and
+                                  matchExpressions are ANDed. An empty label selector
+                                  matches all objects. A null label selector matches
+                                  no objects.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                    type: array
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - podAffinityTerm
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to a pod label update), the system may or may not
+                        try to eventually evict the pod from its node. When there
+                        are multiple elements, the lists of nodes corresponding to
+                        each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label selector is a label query over a
+                              set of resources. The result of matchLabels and matchExpressions
+                              are ANDed. An empty label selector matches all objects.
+                              A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchLabels:
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                      type: array
+                podAntiAffinity:
+                  description: Pod anti affinity is a group of inter pod anti affinity
+                    scheduling rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the anti-affinity expressions specified by this
+                        field, but it may choose a node that violates one or more
+                        of the expressions. The node that is most preferred is the
+                        one with the greatest sum of weights, i.e. for each node that
+                        meets all of the scheduling requirements (resource request,
+                        requiredDuringScheduling anti-affinity expressions, etc.),
+                        compute a sum by iterating through the elements of this field
+                        and adding "weight" to the sum if the node has pods which
+                        matches the corresponding podAffinityTerm; the node(s) with
+                        the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label selector is a label query over
+                                  a set of resources. The result of matchLabels and
+                                  matchExpressions are ANDed. An empty label selector
+                                  matches all objects. A null label selector matches
+                                  no objects.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                    type: array
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - podAffinityTerm
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the anti-affinity requirements specified by
+                        this field are not met at scheduling time, the pod will not
+                        be scheduled onto the node. If the anti-affinity requirements
+                        specified by this field cease to be met at some point during
+                        pod execution (e.g. due to a pod label update), the system
+                        may or may not try to eventually evict the pod from its node.
+                        When there are multiple elements, the lists of nodes corresponding
+                        to each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label selector is a label query over a
+                              set of resources. The result of matchLabels and matchExpressions
+                              are ANDed. An empty label selector matches all objects.
+                              A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                type: array
+                              matchLabels:
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                      type: array
+            alerting:
+              description: AlertingSpec defines parameters for alerting configuration
+                of Prometheus servers.
+              properties:
+                alertmanagers:
+                  description: AlertmanagerEndpoints Prometheus should fire alerts
+                    against.
+                  items:
+                    description: AlertmanagerEndpoints defines a selection of a single
+                      Endpoints object containing alertmanager IPs to fire alerts
+                      against.
+                    properties:
+                      bearerTokenFile:
+                        description: BearerTokenFile to read from filesystem to use
+                          when authenticating to Alertmanager.
+                        type: string
+                      name:
+                        description: Name of Endpoints object in Namespace.
+                        type: string
+                      namespace:
+                        description: Namespace of Endpoints object.
+                        type: string
+                      pathPrefix:
+                        description: Prefix for the HTTP path alerts are pushed to.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: string
+                        - type: integer
+                      scheme:
+                        description: Scheme to use when firing alerts.
+                        type: string
+                      tlsConfig:
+                        description: TLSConfig specifies TLS configuration parameters.
+                        properties:
+                          caFile:
+                            description: The CA cert to use for the targets.
+                            type: string
+                          certFile:
+                            description: The client cert file for the targets.
+                            type: string
+                          insecureSkipVerify:
+                            description: Disable target certificate validation.
+                            type: boolean
+                          keyFile:
+                            description: The client key file for the targets.
+                            type: string
+                          serverName:
+                            description: Used to verify the hostname for the targets.
+                            type: string
+                    required:
+                    - namespace
+                    - name
+                    - port
+                  type: array
+              required:
+              - alertmanagers
+            baseImage:
+              description: Base image to use for a Prometheus deployment.
+              type: string
+            containers:
+              description: Containers allows injecting additional containers. This
+                is meant to allow adding an authentication proxy to a Prometheus pod.
+              items:
+                description: A single application container that you want to run within
+                  a pod.
+                properties:
+                  args:
+                    description: 'Arguments to the entrypoint. The docker image''s
+                      CMD is used if this is not provided. Variable references $(VAR_NAME)
+                      are expanded using the container''s environment. If a variable
+                      cannot be resolved, the reference in the input string will be
+                      unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                      $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                      regardless of whether the variable exists or not. Cannot be
+                      updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    description: 'Entrypoint array. Not executed within a shell. The
+                      docker image''s ENTRYPOINT is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container''s
+                      environment. If a variable cannot be resolved, the reference
+                      in the input string will be unchanged. The $(VAR_NAME) syntax
+                      can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                      will never be expanded, regardless of whether the variable exists
+                      or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: List of environment variables to set in the container.
+                      Cannot be updated.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: EnvVarSource represents a source for the value
+                            of an EnvVar.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key from a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or it's
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                            fieldRef:
+                              description: ObjectFieldSelector selects an APIVersioned
+                                field of an object.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                            resourceFieldRef:
+                              description: ResourceFieldSelector represents container
+                                resources (cpu, memory) and their output format
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor: {}
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                            secretKeyRef:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or it's
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                      required:
+                      - name
+                    type: array
+                  envFrom:
+                    description: List of sources to populate environment variables
+                      in the container. The keys defined within a source must be a
+                      C_IDENTIFIER. All invalid keys will be reported as an event
+                      when the container is starting. When a key exists in multiple
+                      sources, the value associated with the last source will take
+                      precedence. Values defined by an Env with a duplicate key will
+                      take precedence. Cannot be updated.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: |-
+                            ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+                            The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: |-
+                            SecretEnvSource selects a Secret to populate the environment variables with.
+                            The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                    type: array
+                  image:
+                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                      This field is optional to allow higher level config management
+                      to default or override container images in workload controllers
+                      like Deployments and StatefulSets.'
+                    type: string
+                  imagePullPolicy:
+                    description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                      Defaults to Always if :latest tag is specified, or IfNotPresent
+                      otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                    type: string
+                  lifecycle:
+                    description: Lifecycle describes actions that the management system
+                      should take in response to container lifecycle events. For the
+                      PostStart and PreStop lifecycle handlers, management of the
+                      container blocks until the action is complete, unless the container
+                      process fails, in which case the handler is aborted.
+                    properties:
+                      postStart:
+                        description: Handler defines a specific action that should
+                          be taken
+                        properties:
+                          exec:
+                            description: ExecAction describes a "run in container"
+                              action.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                          httpGet:
+                            description: HTTPGetAction describes an action based on
+                              HTTP Get requests.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                          tcpSocket:
+                            description: TCPSocketAction describes an action based
+                              on opening a socket
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                            required:
+                            - port
+                      preStop:
+                        description: Handler defines a specific action that should
+                          be taken
+                        properties:
+                          exec:
+                            description: ExecAction describes a "run in container"
+                              action.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                          httpGet:
+                            description: HTTPGetAction describes an action based on
+                              HTTP Get requests.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                          tcpSocket:
+                            description: TCPSocketAction describes an action based
+                              on opening a socket
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                            required:
+                            - port
+                  livenessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: ExecAction describes a "run in container" action.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGetAction describes an action based on HTTP
+                          Get requests.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocketAction describes an action based on
+                          opening a socket
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                        required:
+                        - port
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                  name:
+                    description: Name of the container specified as a DNS_LABEL. Each
+                      container in a pod must have a unique name (DNS_LABEL). Cannot
+                      be updated.
+                    type: string
+                  ports:
+                    description: List of ports to expose from the container. Exposing
+                      a port here gives the system additional information about the
+                      network connections a container uses, but is primarily informational.
+                      Not specifying a port here DOES NOT prevent that port from being
+                      exposed. Any port which is listening on the default "0.0.0.0"
+                      address inside a container will be accessible from the network.
+                      Cannot be updated.
+                    items:
+                      description: ContainerPort represents a network port in a single
+                        container.
+                      properties:
+                        containerPort:
+                          description: Number of port to expose on the pod's IP address.
+                            This must be a valid port number, 0 < x < 65536.
+                          format: int32
+                          type: integer
+                        hostIP:
+                          description: What host IP to bind the external port to.
+                          type: string
+                        hostPort:
+                          description: Number of port to expose on the host. If specified,
+                            this must be a valid port number, 0 < x < 65536. If HostNetwork
+                            is specified, this must match ContainerPort. Most containers
+                            do not need this.
+                          format: int32
+                          type: integer
+                        name:
+                          description: If specified, this must be an IANA_SVC_NAME
+                            and unique within the pod. Each named port in a pod must
+                            have a unique name. Name for the port that can be referred
+                            to by services.
+                          type: string
+                        protocol:
+                          description: Protocol for port. Must be UDP or TCP. Defaults
+                            to "TCP".
+                          type: string
+                      required:
+                      - containerPort
+                    type: array
+                  readinessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: ExecAction describes a "run in container" action.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGetAction describes an action based on HTTP
+                          Get requests.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocketAction describes an action based on
+                          opening a socket
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                        required:
+                        - port
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                  securityContext:
+                    description: SecurityContext holds security configuration that
+                      will be applied to a container. Some fields are present in both
+                      SecurityContext and PodSecurityContext.  When both are set,
+                      the values in SecurityContext take precedence.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: Adds and removes POSIX capabilities from running
+                          containers.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              type: string
+                            type: array
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: SELinuxOptions are the labels to be applied to
+                          the container
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                  stdin:
+                    description: Whether this container should allocate a buffer for
+                      stdin in the container runtime. If this is not set, reads from
+                      stdin in the container will always result in EOF. Default is
+                      false.
+                    type: boolean
+                  stdinOnce:
+                    description: Whether the container runtime should close the stdin
+                      channel after it has been opened by a single attach. When stdin
+                      is true the stdin stream will remain open across multiple attach
+                      sessions. If stdinOnce is set to true, stdin is opened on container
+                      start, is empty until the first client attaches to stdin, and
+                      then remains open and accepts data until the client disconnects,
+                      at which time stdin is closed and remains closed until the container
+                      is restarted. If this flag is false, a container processes that
+                      reads from stdin will never receive an EOF. Default is false
+                    type: boolean
+                  terminationMessagePath:
+                    description: 'Optional: Path at which the file to which the container''s
+                      termination message will be written is mounted into the container''s
+                      filesystem. Message written is intended to be brief final status,
+                      such as an assertion failure message. Will be truncated by the
+                      node if greater than 4096 bytes. The total message length across
+                      all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                      Cannot be updated.'
+                    type: string
+                  terminationMessagePolicy:
+                    description: Indicate how the termination message should be populated.
+                      File will use the contents of terminationMessagePath to populate
+                      the container status message on both success and failure. FallbackToLogsOnError
+                      will use the last chunk of container log output if the termination
+                      message file is empty and the container exited with an error.
+                      The log output is limited to 2048 bytes or 80 lines, whichever
+                      is smaller. Defaults to File. Cannot be updated.
+                    type: string
+                  tty:
+                    description: Whether this container should allocate a TTY for
+                      itself, also requires 'stdin' to be true. Default is false.
+                    type: boolean
+                  volumeDevices:
+                    description: volumeDevices is the list of block devices to be
+                      used by the container. This is an alpha feature and may change
+                      in the future.
+                    items:
+                      description: volumeDevice describes a mapping of a raw block
+                        device within a container.
+                      properties:
+                        devicePath:
+                          description: devicePath is the path inside of the container
+                            that the device will be mapped to.
+                          type: string
+                        name:
+                          description: name must match the name of a persistentVolumeClaim
+                            in the pod
+                          type: string
+                      required:
+                      - name
+                      - devicePath
+                    type: array
+                  volumeMounts:
+                    description: Pod volumes to mount into the container's filesystem.
+                      Cannot be updated.
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: Path within the container at which the volume
+                            should be mounted.  Must not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: mountPropagation determines how mounts are
+                            propagated from the host to container and the other way
+                            around. When not set, MountPropagationHostToContainer
+                            is used. This field is beta in 1.10.
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: Mounted read-only if true, read-write otherwise
+                            (false or unspecified). Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: Path within the volume from which the container's
+                            volume should be mounted. Defaults to "" (volume's root).
+                          type: string
+                      required:
+                      - name
+                      - mountPath
+                    type: array
+                  workingDir:
+                    description: Container's working directory. If not specified,
+                      the container runtime's default will be used, which might be
+                      configured in the container image. Cannot be updated.
+                    type: string
+                required:
+                - name
+              type: array
+            evaluationInterval:
+              description: Interval between consecutive evaluations.
+              type: string
+            externalLabels:
+              description: The labels to add to any time series or alerts when communicating
+                with external systems (federation, remote storage, Alertmanager).
+              type: object
+            externalUrl:
+              description: The external URL the Prometheus instances will be available
+                under. This is necessary to generate correct URLs. This is necessary
+                if Prometheus is not served from root of a DNS name.
+              type: string
+            imagePullSecrets:
+              description: An optional list of references to secrets in the same namespace
+                to use for pulling prometheus and alertmanager images from registries
+                see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
+              items:
+                description: LocalObjectReference contains enough information to let
+                  you locate the referenced object inside the same namespace.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+              type: array
+            listenLocal:
+              description: ListenLocal makes the Prometheus server listen on loopback,
+                so that it does not bind against the Pod IP.
+              type: boolean
+            logLevel:
+              description: Log level for Prometheus to be configured with.
+              type: string
+            nodeSelector:
+              description: Define which Nodes the Pods are scheduled on.
+              type: object
+            paused:
+              description: When a Prometheus deployment is paused, no actions except
+                for deletion will be performed on the underlying objects.
+              type: boolean
+            podMetadata:
+              description: ObjectMeta is metadata that all persisted resources must
+                have, which includes all objects users must create.
+              properties:
+                annotations:
+                  description: 'Annotations is an unstructured key value map stored
+                    with a resource that may be set by external tools to store and
+                    retrieve arbitrary metadata. They are not queryable and should
+                    be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                  type: object
+                clusterName:
+                  description: The name of the cluster which the object belongs to.
+                    This is used to distinguish resources with same name and namespace
+                    in different clusters. This field is not set anywhere right now
+                    and apiserver is going to ignore it if set in create or update
+                    request.
+                  type: string
+                creationTimestamp:
+                  description: Time is a wrapper around time.Time which supports correct
+                    marshaling to YAML and JSON.  Wrappers are provided for many of
+                    the factory methods that the time package offers.
+                  format: date-time
+                  type: string
+                deletionGracePeriodSeconds:
+                  description: Number of seconds allowed for this object to gracefully
+                    terminate before it will be removed from the system. Only set
+                    when deletionTimestamp is also set. May only be shortened. Read-only.
+                  format: int64
+                  type: integer
+                deletionTimestamp:
+                  description: Time is a wrapper around time.Time which supports correct
+                    marshaling to YAML and JSON.  Wrappers are provided for many of
+                    the factory methods that the time package offers.
+                  format: date-time
+                  type: string
+                finalizers:
+                  description: Must be empty before the object is deleted from the
+                    registry. Each entry is an identifier for the responsible component
+                    that will remove the entry from the list. If the deletionTimestamp
+                    of the object is non-nil, entries in this list can only be removed.
+                  items:
+                    type: string
+                  type: array
+                generateName:
+                  description: |-
+                    GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+                    If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+                    Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                  type: string
+                generation:
+                  description: A sequence number representing a specific generation
+                    of the desired state. Populated by the system. Read-only.
+                  format: int64
+                  type: integer
+                initializers:
+                  description: Initializers tracks the progress of initialization.
+                  properties:
+                    pending:
+                      description: Pending is a list of initializers that must execute
+                        in order before this object is visible. When the last pending
+                        initializer is removed, and no failing result is set, the
+                        initializers struct will be set to nil and the object is considered
+                        as initialized and visible to all clients.
+                      items:
+                        description: Initializer is information about an initializer
+                          that has not yet completed.
+                        properties:
+                          name:
+                            description: name of the process that is responsible for
+                              initializing this object.
+                            type: string
+                        required:
+                        - name
+                      type: array
+                    result:
+                      description: Status is a return value for calls that don't return
+                        other objects.
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of
+                            this representation of an object. Servers should convert
+                            recognized schemas to the latest internal value, and may
+                            reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                          type: string
+                        code:
+                          description: Suggested HTTP return code for this status,
+                            0 if not set.
+                          format: int32
+                          type: integer
+                        details:
+                          description: StatusDetails is a set of additional properties
+                            that MAY be set by the server to provide additional information
+                            about a response. The Reason field of a Status object
+                            defines what attributes will be set. Clients must ignore
+                            fields that do not match the defined type of each attribute,
+                            and should assume that any attribute may be empty, invalid,
+                            or under defined.
+                          properties:
+                            causes:
+                              description: The Causes array includes more details
+                                associated with the StatusReason failure. Not all
+                                StatusReasons may provide detailed causes.
+                              items:
+                                description: StatusCause provides more information
+                                  about an api.Status failure, including cases when
+                                  multiple errors are encountered.
+                                properties:
+                                  field:
+                                    description: |-
+                                      The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+                                      Examples:
+                                        "name" - the field "name" on the current resource
+                                        "items[0].name" - the field "name" on the first array entry in "items"
+                                    type: string
+                                  message:
+                                    description: A human-readable description of the
+                                      cause of the error.  This field may be presented
+                                      as-is to a reader.
+                                    type: string
+                                  reason:
+                                    description: A machine-readable description of
+                                      the cause of the error. If this value is empty
+                                      there is no information available.
+                                    type: string
+                              type: array
+                            group:
+                              description: The group attribute of the resource associated
+                                with the status StatusReason.
+                              type: string
+                            kind:
+                              description: 'The kind attribute of the resource associated
+                                with the status StatusReason. On some operations may
+                                differ from the requested resource Kind. More info:
+                                https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: The name attribute of the resource associated
+                                with the status StatusReason (when there is a single
+                                name which can be described).
+                              type: string
+                            retryAfterSeconds:
+                              description: If specified, the time in seconds before
+                                the operation should be retried. Some errors may indicate
+                                the client must take an alternate action - for those
+                                errors this field may indicate how long to wait before
+                                taking the alternate action.
+                              format: int32
+                              type: integer
+                            uid:
+                              description: 'UID of the resource. (when there is a
+                                single resource which can be described). More info:
+                                http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST
+                            resource this object represents. Servers may infer this
+                            from the endpoint the client submits requests to. Cannot
+                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                          type: string
+                        message:
+                          description: A human-readable description of the status
+                            of this operation.
+                          type: string
+                        metadata:
+                          description: ListMeta describes metadata that synthetic
+                            resources must have, including lists and various status
+                            objects. A resource may have only one of {ObjectMeta,
+                            ListMeta}.
+                          properties:
+                            continue:
+                              description: continue may be set if the user set a limit
+                                on the number of items returned, and indicates that
+                                the server has more data available. The value is opaque
+                                and may be used to issue another request to the endpoint
+                                that served this list to retrieve the next set of
+                                available objects. Continuing a list may not be possible
+                                if the server configuration has changed or more than
+                                a few minutes have passed. The resourceVersion field
+                                returned when using this continue value will be identical
+                                to the value in the first response.
+                              type: string
+                            resourceVersion:
+                              description: 'String that identifies the server''s internal
+                                version of this object that can be used by clients
+                                to determine when objects have changed. Value must
+                                be treated as opaque by clients and passed unmodified
+                                back to the server. Populated by the system. Read-only.
+                                More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            selfLink:
+                              description: selfLink is a URL representing this object.
+                                Populated by the system. Read-only.
+                              type: string
+                        reason:
+                          description: A machine-readable description of why this
+                            operation is in the "Failure" status. If this value is
+                            empty there is no information available. A Reason clarifies
+                            an HTTP status code but does not override it.
+                          type: string
+                        status:
+                          description: 'Status of the operation. One of: "Success"
+                            or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                          type: string
+                  required:
+                  - pending
+                labels:
+                  description: 'Map of string keys and values that can be used to
+                    organize and categorize (scope and select) objects. May match
+                    selectors of replication controllers and services. More info:
+                    http://kubernetes.io/docs/user-guide/labels'
+                  type: object
+                name:
+                  description: 'Name must be unique within a namespace. Is required
+                    when creating resources, although some resources may allow a client
+                    to request the generation of an appropriate name automatically.
+                    Name is primarily intended for creation idempotence and configuration
+                    definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+                    Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                  type: string
+                ownerReferences:
+                  description: List of objects depended by this object. If ALL objects
+                    in the list have been deleted, this object will be garbage collected.
+                    If this object is managed by a controller, then an entry in this
+                    list will point to this controller, with the controller field
+                    set to true. There cannot be more than one managing controller.
+                  items:
+                    description: OwnerReference contains enough information to let
+                      you identify an owning object. Currently, an owning object must
+                      be in the same namespace, so there is no namespace field.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      blockOwnerDeletion:
+                        description: If true, AND if the owner has the "foregroundDeletion"
+                          finalizer, then the owner cannot be deleted from the key-value
+                          store until this reference is removed. Defaults to false.
+                          To set this field, a user needs "delete" permission of the
+                          owner, otherwise 422 (Unprocessable Entity) will be returned.
+                        type: boolean
+                      controller:
+                        description: If true, this reference points to the managing
+                          controller.
+                        type: boolean
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                  type: array
+                resourceVersion:
+                  description: |-
+                    An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+                    Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                  type: string
+                selfLink:
+                  description: SelfLink is a URL representing this object. Populated
+                    by the system. Read-only.
+                  type: string
+                uid:
+                  description: |-
+                    UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+                    Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                  type: string
+            remoteRead:
+              description: If specified, the remote_read spec. This is an experimental
+                feature, it may change in any upcoming release in a breaking way.
+              items:
+                description: RemoteReadSpec defines the remote_read configuration
+                  for prometheus.
+                properties:
+                  basicAuth:
+                    description: 'BasicAuth allow an endpoint to authenticate over
+                      basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                    properties:
+                      password:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or it's key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                      username:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or it's key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                  bearerToken:
+                    description: bearer token for remote read.
+                    type: string
+                  bearerTokenFile:
+                    description: File to read bearer token for remote read.
+                    type: string
+                  proxyUrl:
+                    description: Optional ProxyURL
+                    type: string
+                  readRecent:
+                    description: Whether reads should be made for queries for time
+                      ranges that the local storage should have complete data for.
+                    type: boolean
+                  remoteTimeout:
+                    description: Timeout for requests to the remote read endpoint.
+                    type: string
+                  requiredMatchers:
+                    description: An optional list of equality matchers which have
+                      to be present in a selector to query the remote read endpoint.
+                    type: object
+                  tlsConfig:
+                    description: TLSConfig specifies TLS configuration parameters.
+                    properties:
+                      caFile:
+                        description: The CA cert to use for the targets.
+                        type: string
+                      certFile:
+                        description: The client cert file for the targets.
+                        type: string
+                      insecureSkipVerify:
+                        description: Disable target certificate validation.
+                        type: boolean
+                      keyFile:
+                        description: The client key file for the targets.
+                        type: string
+                      serverName:
+                        description: Used to verify the hostname for the targets.
+                        type: string
+                  url:
+                    description: The URL of the endpoint to send samples to.
+                    type: string
+                required:
+                - url
+              type: array
+            remoteWrite:
+              description: If specified, the remote_write spec. This is an experimental
+                feature, it may change in any upcoming release in a breaking way.
+              items:
+                description: RemoteWriteSpec defines the remote_write configuration
+                  for prometheus.
+                properties:
+                  basicAuth:
+                    description: 'BasicAuth allow an endpoint to authenticate over
+                      basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                    properties:
+                      password:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or it's key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                      username:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or it's key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                  bearerToken:
+                    description: File to read bearer token for remote write.
+                    type: string
+                  bearerTokenFile:
+                    description: File to read bearer token for remote write.
+                    type: string
+                  proxyUrl:
+                    description: Optional ProxyURL
+                    type: string
+                  queueConfig:
+                    description: QueueConfig allows the tuning of remote_write queue_config
+                      parameters. This object is referenced in the RemoteWriteSpec
+                      object.
+                    properties:
+                      batchSendDeadline:
+                        description: BatchSendDeadline is the maximum time a sample
+                          will wait in buffer.
+                        type: string
+                      capacity:
+                        description: Capacity is the number of samples to buffer per
+                          shard before we start dropping them.
+                        format: int32
+                        type: integer
+                      maxBackoff:
+                        description: MaxBackoff is the maximum retry delay.
+                        type: string
+                      maxRetries:
+                        description: MaxRetries is the maximum number of times to
+                          retry a batch on recoverable errors.
+                        format: int32
+                        type: integer
+                      maxSamplesPerSend:
+                        description: MaxSamplesPerSend is the maximum number of samples
+                          per send.
+                        format: int32
+                        type: integer
+                      maxShards:
+                        description: MaxShards is the maximum number of shards, i.e.
+                          amount of concurrency.
+                        format: int32
+                        type: integer
+                      minBackoff:
+                        description: MinBackoff is the initial retry delay. Gets doubled
+                          for every retry.
+                        type: string
+                  remoteTimeout:
+                    description: Timeout for requests to the remote write endpoint.
+                    type: string
+                  tlsConfig:
+                    description: TLSConfig specifies TLS configuration parameters.
+                    properties:
+                      caFile:
+                        description: The CA cert to use for the targets.
+                        type: string
+                      certFile:
+                        description: The client cert file for the targets.
+                        type: string
+                      insecureSkipVerify:
+                        description: Disable target certificate validation.
+                        type: boolean
+                      keyFile:
+                        description: The client key file for the targets.
+                        type: string
+                      serverName:
+                        description: Used to verify the hostname for the targets.
+                        type: string
+                  url:
+                    description: The URL of the endpoint to send samples to.
+                    type: string
+                  writeRelabelConfigs:
+                    description: The list of remote write relabel configurations.
+                    items:
+                      description: 'RelabelConfig allows dynamic rewriting of the
+                        label set, being applied to samples before ingestion. It defines
+                        `<metric_relabel_configs>`-section of Prometheus configuration.
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                      properties:
+                        action:
+                          description: Action to perform based on regex matching.
+                            Default is 'replace'
+                          type: string
+                        modulus:
+                          description: Modulus to take of the hash of the source label
+                            values.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched. defailt is '(.*)'
+                          type: string
+                        replacement:
+                          description: Replacement value against which a regex replace
+                            is performed if the regular expression matches. Regex
+                            capture groups are available. Default is '$1'
+                          type: string
+                        separator:
+                          description: Separator placed between concatenated source
+                            label values. default is ';'.
+                          type: string
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            separator and matched against the configured regular expression
+                            for the replace, keep, and drop actions.
+                          items:
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: Label to which the resulting value is written
+                            in a replace action. It is mandatory for replace actions.
+                            Regex capture groups are available.
+                          type: string
+                    type: array
+                required:
+                - url
+              type: array
+            replicas:
+              description: Number of instances to deploy for a Prometheus deployment.
+              format: int32
+              type: integer
+            resources:
+              description: ResourceRequirements describes the compute resource requirements.
+              properties:
+                limits:
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+            retention:
+              description: Time duration Prometheus shall retain data for.
+              type: string
+            routePrefix:
+              description: The route prefix Prometheus registers HTTP handlers for.
+                This is useful, if using ExternalURL and a proxy is rewriting HTTP
+                routes of a request, and the actual ExternalURL is still true, but
+                the server serves requests under a different route prefix. For example
+                for use with `kubectl proxy`.
+              type: string
+            ruleNamespaceSelector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                                 of matchExpressions, whose key field is "key", the operator is
+                                 "In", and the values array contains only "value". The requirements
+                                 are ANDed.
+                  type: object
+            ruleSelector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                                 of matchExpressions, whose key field is "key", the operator is
+                                 "In", and the values array contains only "value". The requirements
+                                 are ANDed.
+                  type: object
+            scrapeInterval:
+              description: Interval between consecutive scrapes.
+              type: string
+            secrets:
+              description: Secrets is a list of Secrets in the same namespace as the
+                Prometheus object, which shall be mounted into the Prometheus Pods.
+                The Secrets are mounted into /etc/prometheus/secrets/<secret-name>.
+                Secrets changes after initial creation of a Prometheus object are
+                not reflected in the running Pods. To change the secrets mounted into
+                the Prometheus Pods, the object must be deleted and recreated with
+                the new list of secrets.
+              items:
+                type: string
+              type: array
+            securityContext:
+              description: PodSecurityContext holds pod-level security attributes
+                and common container settings. Some fields are also present in container.securityContext.  Field
+                values of container.securityContext take precedence over field values
+                of PodSecurityContext.
+              properties:
+                fsGroup:
+                  description: |-
+                    A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+                    1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                    If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                  format: int64
+                  type: integer
+                runAsGroup:
+                  description: The GID to run the entrypoint of the container process.
+                    Uses runtime default if unset. May also be set in SecurityContext.  If
+                    set in both SecurityContext and PodSecurityContext, the value
+                    specified in SecurityContext takes precedence for that container.
+                  format: int64
+                  type: integer
+                runAsNonRoot:
+                  description: Indicates that the container must run as a non-root
+                    user. If true, the Kubelet will validate the image at runtime
+                    to ensure that it does not run as UID 0 (root) and fail to start
+                    the container if it does. If unset or false, no such validation
+                    will be performed. May also be set in SecurityContext.  If set
+                    in both SecurityContext and PodSecurityContext, the value specified
+                    in SecurityContext takes precedence.
+                  type: boolean
+                runAsUser:
+                  description: The UID to run the entrypoint of the container process.
+                    Defaults to user specified in image metadata if unspecified. May
+                    also be set in SecurityContext.  If set in both SecurityContext
+                    and PodSecurityContext, the value specified in SecurityContext
+                    takes precedence for that container.
+                  format: int64
+                  type: integer
+                seLinuxOptions:
+                  description: SELinuxOptions are the labels to be applied to the
+                    container
+                  properties:
+                    level:
+                      description: Level is SELinux level label that applies to the
+                        container.
+                      type: string
+                    role:
+                      description: Role is a SELinux role label that applies to the
+                        container.
+                      type: string
+                    type:
+                      description: Type is a SELinux type label that applies to the
+                        container.
+                      type: string
+                    user:
+                      description: User is a SELinux user label that applies to the
+                        container.
+                      type: string
+                supplementalGroups:
+                  description: A list of groups applied to the first process run in
+                    each container, in addition to the container's primary GID.  If
+                    unspecified, no groups will be added to any container.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                sysctls:
+                  description: Sysctls hold a list of namespaced sysctls used for
+                    the pod. Pods with unsupported sysctls (by the container runtime)
+                    might fail to launch.
+                  items:
+                    description: Sysctl defines a kernel parameter to be set
+                    properties:
+                      name:
+                        description: Name of a property to set
+                        type: string
+                      value:
+                        description: Value of a property to set
+                        type: string
+                    required:
+                    - name
+                    - value
+                  type: array
+            serviceAccountName:
+              description: ServiceAccountName is the name of the ServiceAccount to
+                use to run the Prometheus Pods.
+              type: string
+            serviceMonitorNamespaceSelector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                                 of matchExpressions, whose key field is "key", the operator is
+                                 "In", and the values array contains only "value". The requirements
+                                 are ANDed.
+                  type: object
+            serviceMonitorSelector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                                 of matchExpressions, whose key field is "key", the operator is
+                                 "In", and the values array contains only "value". The requirements
+                                 are ANDed.
+                  type: object
+            storage:
+              description: StorageSpec defines the configured storage for a group
+                Prometheus servers.
+              properties:
+                class:
+                  description: 'Name of the StorageClass to use when requesting storage
+                    provisioning. More info: https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses
+                    DEPRECATED'
+                  type: string
+                emptyDir:
+                  description: Represents an empty directory for a pod. Empty directory
+                    volumes support ownership management and SELinux relabeling.
+                  properties:
+                    medium:
+                      description: 'What type of storage medium should back this directory.
+                        The default is "" which means to use the node''s default medium.
+                        Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                      type: string
+                    sizeLimit: {}
+                resources:
+                  description: ResourceRequirements describes the compute resource
+                    requirements.
+                  properties:
+                    limits:
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                selector:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                      type: array
+                    matchLabels:
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                                     of matchExpressions, whose key field is "key", the operator
+                                     is "In", and the values array contains only "value". The requirements
+                                     are ANDed.
+                      type: object
+                volumeClaimTemplate:
+                  description: PersistentVolumeClaim is a user's request for and claim
+                    to a persistent volume
+                  properties:
+                    apiVersion:
+                      description: 'APIVersion defines the versioned schema of this
+                        representation of an object. Servers should convert recognized
+                        schemas to the latest internal value, and may reject unrecognized
+                        values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                      type: string
+                    kind:
+                      description: 'Kind is a string value representing the REST resource
+                        this object represents. Servers may infer this from the endpoint
+                        the client submits requests to. Cannot be updated. In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                      type: string
+                    metadata:
+                      description: ObjectMeta is metadata that all persisted resources
+                        must have, which includes all objects users must create.
+                      properties:
+                        annotations:
+                          description: 'Annotations is an unstructured key value map
+                            stored with a resource that may be set by external tools
+                            to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: http://kubernetes.io/docs/user-guide/annotations'
+                          type: object
+                        clusterName:
+                          description: The name of the cluster which the object belongs
+                            to. This is used to distinguish resources with same name
+                            and namespace in different clusters. This field is not
+                            set anywhere right now and apiserver is going to ignore
+                            it if set in create or update request.
+                          type: string
+                        creationTimestamp:
+                          description: Time is a wrapper around time.Time which supports
+                            correct marshaling to YAML and JSON.  Wrappers are provided
+                            for many of the factory methods that the time package
+                            offers.
+                          format: date-time
+                          type: string
+                        deletionGracePeriodSeconds:
+                          description: Number of seconds allowed for this object to
+                            gracefully terminate before it will be removed from the
+                            system. Only set when deletionTimestamp is also set. May
+                            only be shortened. Read-only.
+                          format: int64
+                          type: integer
+                        deletionTimestamp:
+                          description: Time is a wrapper around time.Time which supports
+                            correct marshaling to YAML and JSON.  Wrappers are provided
+                            for many of the factory methods that the time package
+                            offers.
+                          format: date-time
+                          type: string
+                        finalizers:
+                          description: Must be empty before the object is deleted
+                            from the registry. Each entry is an identifier for the
+                            responsible component that will remove the entry from
+                            the list. If the deletionTimestamp of the object is non-nil,
+                            entries in this list can only be removed.
+                          items:
+                            type: string
+                          type: array
+                        generateName:
+                          description: |-
+                            GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+                            If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+                            Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                          type: string
+                        generation:
+                          description: A sequence number representing a specific generation
+                            of the desired state. Populated by the system. Read-only.
+                          format: int64
+                          type: integer
+                        initializers:
+                          description: Initializers tracks the progress of initialization.
+                          properties:
+                            pending:
+                              description: Pending is a list of initializers that
+                                must execute in order before this object is visible.
+                                When the last pending initializer is removed, and
+                                no failing result is set, the initializers struct
+                                will be set to nil and the object is considered as
+                                initialized and visible to all clients.
+                              items:
+                                description: Initializer is information about an initializer
+                                  that has not yet completed.
+                                properties:
+                                  name:
+                                    description: name of the process that is responsible
+                                      for initializing this object.
+                                    type: string
+                                required:
+                                - name
+                              type: array
+                            result:
+                              description: Status is a return value for calls that
+                                don't return other objects.
+                              properties:
+                                apiVersion:
+                                  description: 'APIVersion defines the versioned schema
+                                    of this representation of an object. Servers should
+                                    convert recognized schemas to the latest internal
+                                    value, and may reject unrecognized values. More
+                                    info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                                  type: string
+                                code:
+                                  description: Suggested HTTP return code for this
+                                    status, 0 if not set.
+                                  format: int32
+                                  type: integer
+                                details:
+                                  description: StatusDetails is a set of additional
+                                    properties that MAY be set by the server to provide
+                                    additional information about a response. The Reason
+                                    field of a Status object defines what attributes
+                                    will be set. Clients must ignore fields that do
+                                    not match the defined type of each attribute,
+                                    and should assume that any attribute may be empty,
+                                    invalid, or under defined.
+                                  properties:
+                                    causes:
+                                      description: The Causes array includes more
+                                        details associated with the StatusReason failure.
+                                        Not all StatusReasons may provide detailed
+                                        causes.
+                                      items:
+                                        description: StatusCause provides more information
+                                          about an api.Status failure, including cases
+                                          when multiple errors are encountered.
+                                        properties:
+                                          field:
+                                            description: |-
+                                              The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+                                              Examples:
+                                                "name" - the field "name" on the current resource
+                                                "items[0].name" - the field "name" on the first array entry in "items"
+                                            type: string
+                                          message:
+                                            description: A human-readable description
+                                              of the cause of the error.  This field
+                                              may be presented as-is to a reader.
+                                            type: string
+                                          reason:
+                                            description: A machine-readable description
+                                              of the cause of the error. If this value
+                                              is empty there is no information available.
+                                            type: string
+                                      type: array
+                                    group:
+                                      description: The group attribute of the resource
+                                        associated with the status StatusReason.
+                                      type: string
+                                    kind:
+                                      description: 'The kind attribute of the resource
+                                        associated with the status StatusReason. On
+                                        some operations may differ from the requested
+                                        resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: The name attribute of the resource
+                                        associated with the status StatusReason (when
+                                        there is a single name which can be described).
+                                      type: string
+                                    retryAfterSeconds:
+                                      description: If specified, the time in seconds
+                                        before the operation should be retried. Some
+                                        errors may indicate the client must take an
+                                        alternate action - for those errors this field
+                                        may indicate how long to wait before taking
+                                        the alternate action.
+                                      format: int32
+                                      type: integer
+                                    uid:
+                                      description: 'UID of the resource. (when there
+                                        is a single resource which can be described).
+                                        More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                      type: string
+                                kind:
+                                  description: 'Kind is a string value representing
+                                    the REST resource this object represents. Servers
+                                    may infer this from the endpoint the client submits
+                                    requests to. Cannot be updated. In CamelCase.
+                                    More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                  type: string
+                                message:
+                                  description: A human-readable description of the
+                                    status of this operation.
+                                  type: string
+                                metadata:
+                                  description: ListMeta describes metadata that synthetic
+                                                 resources must have, including lists and various
+                                                 status objects. A resource may have only one of
+                                    {ObjectMeta, ListMeta}.
+                                  properties:
+                                    continue:
+                                      description: continue may be set if the user
+                                        set a limit on the number of items returned,
+                                        and indicates that the server has more data
+                                        available. The value is opaque and may be
+                                        used to issue another request to the endpoint
+                                        that served this list to retrieve the next
+                                        set of available objects. Continuing a list
+                                        may not be possible if the server configuration
+                                        has changed or more than a few minutes have
+                                        passed. The resourceVersion field returned
+                                        when using this continue value will be identical
+                                        to the value in the first response.
+                                      type: string
+                                    resourceVersion:
+                                      description: 'String that identifies the server''s
+                                        internal version of this object that can be
+                                        used by clients to determine when objects
+                                        have changed. Value must be treated as opaque
+                                        by clients and passed unmodified back to the
+                                        server. Populated by the system. Read-only.
+                                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                                      type: string
+                                    selfLink:
+                                      description: selfLink is a URL representing
+                                        this object. Populated by the system. Read-only.
+                                      type: string
+                                reason:
+                                  description: A machine-readable description of why
+                                    this operation is in the "Failure" status. If
+                                    this value is empty there is no information available.
+                                    A Reason clarifies an HTTP status code but does
+                                    not override it.
+                                  type: string
+                                status:
+                                  description: 'Status of the operation. One of: "Success"
+                                    or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                                  type: string
+                          required:
+                          - pending
+                        labels:
+                          description: 'Map of string keys and values that can be
+                            used to organize and categorize (scope and select) objects.
+                            May match selectors of replication controllers and services.
+                            More info: http://kubernetes.io/docs/user-guide/labels'
+                          type: object
+                        name:
+                          description: 'Name must be unique within a namespace. Is
+                            required when creating resources, although some resources
+                            may allow a client to request the generation of an appropriate
+                            name automatically. Name is primarily intended for creation
+                            idempotence and configuration definition. Cannot be updated.
+                            More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+                            Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                          type: string
+                        ownerReferences:
+                          description: List of objects depended by this object. If
+                            ALL objects in the list have been deleted, this object
+                            will be garbage collected. If this object is managed by
+                            a controller, then an entry in this list will point to
+                            this controller, with the controller field set to true.
+                            There cannot be more than one managing controller.
+                          items:
+                            description: OwnerReference contains enough information
+                              to let you identify an owning object. Currently, an
+                              owning object must be in the same namespace, so there
+                              is no namespace field.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              blockOwnerDeletion:
+                                description: If true, AND if the owner has the "foregroundDeletion"
+                                               finalizer, then the owner cannot be deleted from
+                                               the key-value store until this reference is removed.
+                                               Defaults to false. To set this field, a user needs
+                                               "delete" permission of the owner, otherwise 422
+                                               (Unprocessable Entity) will be returned.
+                                type: boolean
+                              controller:
+                                description: If true, this reference points to the
+                                  managing controller.
+                                type: boolean
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                type: string
+                            required:
+                            - apiVersion
+                            - kind
+                            - name
+                            - uid
+                          type: array
+                        resourceVersion:
+                          description: |-
+                            An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+                            Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                          type: string
+                        selfLink:
+                          description: SelfLink is a URL representing this object.
+                            Populated by the system. Read-only.
+                          type: string
+                        uid:
+                          description: |-
+                            UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+                            Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                          type: string
+                    spec:
+                      description: PersistentVolumeClaimSpec describes the common
+                        attributes of storage devices and allows a Source for provider-specific
+                        attributes
+                      properties:
+                        accessModes:
+                          description: 'AccessModes contains the desired access modes
+                            the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          items:
+                            type: string
+                          type: array
+                        resources:
+                          description: ResourceRequirements describes the compute
+                            resource requirements.
+                          properties:
+                            limits:
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                        selector:
+                          description: A label selector is a label query over a set
+                            of resources. The result of matchLabels and matchExpressions
+                            are ANDed. An empty label selector matches all objects.
+                            A null label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                              type: array
+                            matchLabels:
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                        storageClassName:
+                          description: 'Name of the StorageClass required by the claim.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                          type: string
+                        volumeMode:
+                          description: volumeMode defines what type of volume is required
+                            by the claim. Value of Filesystem is implied when not
+                            included in claim spec. This is an alpha feature and may
+                            change in the future.
+                          type: string
+                        volumeName:
+                          description: VolumeName is the binding reference to the
+                            PersistentVolume backing this claim.
+                          type: string
+                    status:
+                      description: PersistentVolumeClaimStatus is the current status
+                        of a persistent volume claim.
+                      properties:
+                        accessModes:
+                          description: 'AccessModes contains the actual access modes
+                            the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          items:
+                            type: string
+                          type: array
+                        capacity:
+                          description: Represents the actual resources of the underlying
+                            volume.
+                          type: object
+                        conditions:
+                          description: Current Condition of persistent volume claim.
+                            If underlying persistent volume is being resized then
+                            the Condition will be set to 'ResizeStarted'.
+                          items:
+                            description: PersistentVolumeClaimCondition contails details
+                              about state of pvc
+                            properties:
+                              lastProbeTime:
+                                description: Time is a wrapper around time.Time which
+                                  supports correct marshaling to YAML and JSON.  Wrappers
+                                  are provided for many of the factory methods that
+                                  the time package offers.
+                                format: date-time
+                                type: string
+                              lastTransitionTime:
+                                description: Time is a wrapper around time.Time which
+                                  supports correct marshaling to YAML and JSON.  Wrappers
+                                  are provided for many of the factory methods that
+                                  the time package offers.
+                                format: date-time
+                                type: string
+                              message:
+                                description: Human-readable message indicating details
+                                  about last transition.
+                                type: string
+                              reason:
+                                description: Unique, this should be a short, machine
+                                  understandable string that gives the reason for
+                                  condition's last transition. If it reports "ResizeStarted"
+                                  that means the underlying persistent volume is being
+                                  resized.
+                                type: string
+                              status:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - type
+                            - status
+                          type: array
+                        phase:
+                          description: Phase represents the current phase of PersistentVolumeClaim.
+                          type: string
+            tag:
+              description: Tag of Prometheus container image to be deployed. Defaults
+                to the value of `version`.
+              type: string
+            thanos:
+              description: ThanosSpec defines parameters for a Prometheus server within
+                a Thanos deployment.
+              properties:
+                baseImage:
+                  description: Thanos base image if other than default.
+                  type: string
+                gcs:
+                  description: ThanosGCSSpec defines parameters for use of Google
+                    Cloud Storage (GCS) with Thanos.
+                  properties:
+                    bucket:
+                      description: Google Cloud Storage bucket name for stored blocks.
+                        If empty it won't store any block inside Google Cloud Storage.
+                      type: string
+                peers:
+                  description: Peers is a DNS name for Thanos to discover peers through.
+                  type: string
+                s3:
+                  description: ThanosSpec defines parameters for of AWS Simple Storage
+                    Service (S3) with Thanos. (S3 compatible services apply as well)
+                  properties:
+                    accessKey:
+                      description: SecretKeySelector selects a key of a Secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or it's key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                    bucket:
+                      description: S3-Compatible API bucket name for stored blocks.
+                      type: string
+                    endpoint:
+                      description: S3-Compatible API endpoint for stored blocks.
+                      type: string
+                    insecure:
+                      description: Whether to use an insecure connection with an S3-Compatible
+                        API.
+                      type: boolean
+                    secretKey:
+                      description: SecretKeySelector selects a key of a Secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or it's key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                    signatureVersion2:
+                      description: Whether to use S3 Signature Version 2; otherwise
+                        Signature Version 4 will be used.
+                      type: boolean
+                tag:
+                  description: Tag of Thanos sidecar container image to be deployed.
+                    Defaults to the value of `version`.
+                  type: string
+                version:
+                  description: Version describes the version of Thanos to use.
+                  type: string
+            tolerations:
+              description: If specified, the pod's tolerations.
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
+                properties:
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
+                    type: string
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
+                    type: string
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
+                    type: string
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
+                    type: string
+              type: array
+            version:
+              description: Version of Prometheus to be deployed.
+              type: string
+        status:
+          description: 'Most recent observed status of the Prometheus cluster. Read-only.
+            Not included when requesting from the apiserver, only from the Prometheus
+            Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          properties:
+            availableReplicas:
+              description: Total number of available pods (ready for at least minReadySeconds)
+                targeted by this Prometheus deployment.
+              format: int32
+              type: integer
+            paused:
+              description: Represents whether any actions on the underlaying managed
+                objects are being performed. Only delete actions will be performed.
+              type: boolean
+            replicas:
+              description: Total number of non-terminated pods targeted by this Prometheus
+                deployment (their labels match the selector).
+              format: int32
+              type: integer
+            unavailableReplicas:
+              description: Total number of unavailable pods targeted by this Prometheus
+                deployment.
+              format: int32
+              type: integer
+            updatedReplicas:
+              description: Total number of non-terminated pods targeted by this Prometheus
+                deployment that have the desired version spec.
+              format: int32
+              type: integer
+          required:
+          - paused
+          - replicas
+          - updatedReplicas
+          - availableReplicas
+          - unavailableReplicas
+  version: v1

--- a/bundles/prometheus.0.22.2/manifests/prometheusoperator.0.22.2.clusterserviceversion.yaml
+++ b/bundles/prometheus.0.22.2/manifests/prometheusoperator.0.22.2.clusterserviceversion.yaml
@@ -1,0 +1,271 @@
+#! parse-kind: ClusterServiceVersion
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: prometheusoperator.0.22.2
+  namespace: placeholder
+  annotations:
+    alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v2.3.2","serviceAccountName":"prometheus-k8s","securityContext": {}, "serviceMonitorSelector":{"matchExpressions":[{"key":"k8s-app","operator":"Exists"}]},"ruleSelector":{"matchLabels":{"role":"prometheus-rulefiles","prometheus":"k8s"}},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus"}},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3, "securityContext": {}}}]'
+spec:
+  replaces: prometheusoperator.0.15.0
+  displayName: Prometheus Operator
+  description: |
+    The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
+
+    Once installed, the Prometheus Operator provides the following features:
+
+    * **Create/Destroy**: Easily launch a Prometheus instance for your Kubernetes namespace, a specific application or team easily using the Operator.
+
+    * **Simple Configuration**: Configure the fundamentals of Prometheus like versions, persistence, retention policies, and replicas from a native Kubernetes resource.
+
+    * **Target Services via Labels**: Automatically generate monitoring target configurations based on familiar Kubernetes label queries; no need to learn a Prometheus specific configuration language.
+
+    ### Other Supported Features
+
+    **High availability**
+
+    Multiple instances are run across failure zones and data is replicated. This keeps your monitoring available during an outage, when you need it most.
+
+    **Updates via automated operations**
+
+    New Prometheus versions are deployed using a rolling update with no downtime, making it easy to stay up to date.
+
+    **Handles the dynamic nature of containers**
+
+    Alerting rules are attached to groups of containers instead of individual instances, which is ideal for the highly dynamic nature of container deployment.
+
+  keywords: ['prometheus', 'monitoring', 'tsdb', 'alerting']
+
+  maintainers:
+  - name: Red Hat
+    email: openshift-operators@redhat.com
+
+  provider:
+    name: Red Hat
+
+  links:
+  - name: Prometheus
+    url: https://www.prometheus.io/
+  - name: Documentation
+    url: https://coreos.com/operators/prometheus/docs/latest/
+  - name: Prometheus Operator
+    url: https://github.com/coreos/prometheus-operator
+
+  labels:
+    alm-status-descriptors: prometheusoperator.0.22.2
+    alm-owner-prometheus: prometheusoperator
+
+  selector:
+    matchLabels:
+      alm-owner-prometheus: prometheusoperator
+
+  icon:
+  - base64data: PHN2ZyB3aWR0aD0iMjQ5MCIgaGVpZ2h0PSIyNTAwIiB2aWV3Qm94PSIwIDAgMjU2IDI1NyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCI+PHBhdGggZD0iTTEyOC4wMDEuNjY3QzU3LjMxMS42NjcgMCA1Ny45NzEgMCAxMjguNjY0YzAgNzAuNjkgNTcuMzExIDEyNy45OTggMTI4LjAwMSAxMjcuOTk4UzI1NiAxOTkuMzU0IDI1NiAxMjguNjY0QzI1NiA1Ny45NyAxOTguNjg5LjY2NyAxMjguMDAxLjY2N3ptMCAyMzkuNTZjLTIwLjExMiAwLTM2LjQxOS0xMy40MzUtMzYuNDE5LTMwLjAwNGg3Mi44MzhjMCAxNi41NjYtMTYuMzA2IDMwLjAwNC0zNi40MTkgMzAuMDA0em02MC4xNTMtMzkuOTRINjcuODQyVjE3OC40N2gxMjAuMzE0djIxLjgxNmgtLjAwMnptLS40MzItMzMuMDQ1SDY4LjE4NWMtLjM5OC0uNDU4LS44MDQtLjkxLTEuMTg4LTEuMzc1LTEyLjMxNS0xNC45NTQtMTUuMjE2LTIyLjc2LTE4LjAzMi0zMC43MTYtLjA0OC0uMjYyIDE0LjkzMyAzLjA2IDI1LjU1NiA1LjQ1IDAgMCA1LjQ2NiAxLjI2NSAxMy40NTggMi43MjItNy42NzMtOC45OTQtMTIuMjMtMjAuNDI4LTEyLjIzLTMyLjExNiAwLTI1LjY1OCAxOS42OC00OC4wNzkgMTIuNTgtNjYuMjAxIDYuOTEuNTYyIDE0LjMgMTQuNTgzIDE0LjggMzYuNTA1IDcuMzQ2LTEwLjE1MiAxMC40Mi0yOC42OSAxMC40Mi00MC4wNTYgMC0xMS43NjkgNy43NTUtMjUuNDQgMTUuNTEyLTI1LjkwNy02LjkxNSAxMS4zOTYgMS43OSAyMS4xNjUgOS41MyA0NS40IDIuOTAyIDkuMTAzIDIuNTMyIDI0LjQyMyA0Ljc3MiAzNC4xMzguNzQ0LTIwLjE3OCA0LjIxMy00OS42MiAxNy4wMTQtNTkuNzg0LTUuNjQ3IDEyLjguODM2IDI4LjgxOCA1LjI3IDM2LjUxOCA3LjE1NCAxMi40MjQgMTEuNDkgMjEuODM2IDExLjQ5IDM5LjYzOCAwIDExLjkzNi00LjQwNyAyMy4xNzMtMTEuODQgMzEuOTU4IDguNDUyLTEuNTg2IDE0LjI4OS0zLjAxNiAxNC4yODktMy4wMTZsMjcuNDUtNS4zNTVjLjAwMi0uMDAyLTMuOTg3IDE2LjQwMS0xOS4zMTQgMzIuMTk3eiIgZmlsbD0iI0RBNEUzMSIvPjwvc3ZnPg==
+    mediatype: image/svg+xml
+
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+      - serviceAccountName: prometheus-k8s
+        rules:
+        - apiGroups: [""]
+          resources:
+          - nodes
+          - services
+          - endpoints
+          - pods
+          verbs: ["get", "list", "watch"]
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          verbs: ["get"]
+      - serviceAccountName: prometheus-operator-0-22-2
+        rules:
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - alertmanagers
+          - prometheuses
+          - prometheuses/finalizers
+          - alertmanagers/finalizers
+          - servicemonitors
+          - prometheusrules
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - list
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - endpoints
+          verbs:
+          - get
+          - create
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - list
+          - watch
+      deployments:
+      - name: prometheus-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              k8s-app: prometheus-operator
+          template:
+            metadata:
+              labels:
+                k8s-app: prometheus-operator
+            spec:
+              serviceAccount: prometheus-operator-0-22-2
+              containers:
+              - name: prometheus-operator
+                image: quay.io/coreos/prometheus-operator@sha256:3daa69a8c6c2f1d35dcf1fe48a7cd8b230e55f5229a1ded438f687debade5bcf
+                args:
+                - -namespace=$(K8S_NAMESPACE)
+                - -manage-crds=false
+                - -logtostderr=true
+                - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+                - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.22.2
+                env:
+                - name: K8S_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                ports:
+                - containerPort: 8080
+                  name: http
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 100Mi
+                  requests:
+                    cpu: 100m
+                    memory: 50Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
+              nodeSelector:
+                beta.kubernetes.io/os: linux
+  maturity: beta
+  version: 0.22.2
+  customresourcedefinitions:
+    owned:
+    - name: prometheuses.monitoring.coreos.com
+      version: v1
+      kind: Prometheus
+      displayName: Prometheus
+      description: A running Prometheus instance
+      resources:
+      - kind: StatefulSet
+        version: v1beta2
+      - kind: Pod
+        version: v1
+      specDescriptors:
+      - description: Desired number of Pods for the cluster
+        displayName: Size
+        path: replicas
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      - description: A selector for the ConfigMaps from which to load rule files
+        displayName: Rule Config Map Selector
+        path: ruleSelector
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:ConfigMap'
+      - description: ServiceMonitors to be selected for target discovery
+        displayName: Service Monitor Selector
+        path: serviceMonitorSelector
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:selector:monitoring.coreos.com:v1:ServiceMonitor'
+      - description: The ServiceAccount to use to run the Prometheus pods
+        displayName: Service Account
+        path: serviceAccountName
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes:ServiceAccount'
+      - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+        displayName: Resource Requirements
+        path: resources
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+    - name: prometheusrules.monitoring.coreos.com
+      version: v1
+      kind: PrometheusRule
+      displayName: Prometheus Rule
+      description: A Prometheus Rule configures groups of sequentially evaluated recording and alerting rules.
+    - name: servicemonitors.monitoring.coreos.com
+      version: v1
+      kind: ServiceMonitor
+      displayName: Service Monitor
+      description: Configures prometheus to monitor a particular k8s service
+      resources:
+      - kind: Pod
+        version: v1
+      specDescriptors:
+      - description: The label to use to retrieve the job name from
+        displayName: Job Label
+        path: jobLabel
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - description: A list of endpoints allowed as part of this ServiceMonitor
+        displayName: Endpoints
+        path: endpoints
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:endpointList'
+    - name: alertmanagers.monitoring.coreos.com
+      version: v1
+      kind: Alertmanager
+      displayName: Alertmanager
+      description: Configures an Alertmanager for the namespace
+      resources:
+      - kind: StatefulSet
+        version: v1beta2
+      - kind: Pod
+        version: v1
+      specDescriptors:
+      - description: Desired number of Pods for the cluster
+        displayName: Size
+        path: replicas
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+        displayName: Resource Requirements
+        path: resources
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'

--- a/bundles/prometheus.0.22.2/manifests/prometheusrule.crd.yaml
+++ b/bundles/prometheus.0.22.2/manifests/prometheusrule.crd.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: prometheusrules.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    kind: PrometheusRule
+    plural: prometheusrules
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: PrometheusRuleSpec contains specification parameters for a
+            Rule.
+          properties:
+            groups:
+              description: Content of Prometheus rule file
+              items:
+                description: RuleGroup is a list of sequentially evaluated recording
+                  and alerting rules.
+                properties:
+                  interval:
+                    type: string
+                  name:
+                    type: string
+                  rules:
+                    items:
+                      description: Rule describes an alerting or recording rule.
+                      properties:
+                        alert:
+                          type: string
+                        annotations:
+                          type: object
+                        expr:
+                          type: string
+                        for:
+                          type: string
+                        labels:
+                          type: object
+                        record:
+                          type: string
+                      required:
+                      - expr
+                    type: array
+                required:
+                - name
+                - rules
+              type: array
+  version: v1

--- a/bundles/prometheus.0.22.2/manifests/servicemonitor.crd.yaml
+++ b/bundles/prometheus.0.22.2/manifests/servicemonitor.crd.yaml
@@ -1,0 +1,224 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: servicemonitors.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    kind: ServiceMonitor
+    plural: servicemonitors
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: ServiceMonitorSpec contains specification parameters for a
+            ServiceMonitor.
+          properties:
+            endpoints:
+              description: A list of endpoints allowed as part of this ServiceMonitor.
+              items:
+                description: Endpoint defines a scrapeable endpoint serving Prometheus
+                  metrics.
+                properties:
+                  basicAuth:
+                    description: 'BasicAuth allow an endpoint to authenticate over
+                      basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                    properties:
+                      password:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or it's key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                      username:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or it's key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                  bearerTokenFile:
+                    description: File to read bearer token for scraping targets.
+                    type: string
+                  honorLabels:
+                    description: HonorLabels chooses the metric's labels on collisions
+                      with target labels.
+                    type: boolean
+                  interval:
+                    description: Interval at which metrics should be scraped
+                    type: string
+                  metricRelabelings:
+                    description: MetricRelabelConfigs to apply to samples before ingestion.
+                    items:
+                      description: 'RelabelConfig allows dynamic rewriting of the
+                        label set, being applied to samples before ingestion. It defines
+                        `<metric_relabel_configs>`-section of Prometheus configuration.
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                      properties:
+                        action:
+                          description: Action to perform based on regex matching.
+                            Default is 'replace'
+                          type: string
+                        modulus:
+                          description: Modulus to take of the hash of the source label
+                            values.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched. defailt is '(.*)'
+                          type: string
+                        replacement:
+                          description: Replacement value against which a regex replace
+                            is performed if the regular expression matches. Regex
+                            capture groups are available. Default is '$1'
+                          type: string
+                        separator:
+                          description: Separator placed between concatenated source
+                            label values. default is ';'.
+                          type: string
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            separator and matched against the configured regular expression
+                            for the replace, keep, and drop actions.
+                          items:
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: Label to which the resulting value is written
+                            in a replace action. It is mandatory for replace actions.
+                            Regex capture groups are available.
+                          type: string
+                    type: array
+                  params:
+                    description: Optional HTTP URL parameters
+                    type: object
+                  path:
+                    description: HTTP path to scrape for metrics.
+                    type: string
+                  port:
+                    description: Name of the service port this endpoint refers to.
+                      Mutually exclusive with targetPort.
+                    type: string
+                  proxyUrl:
+                    description: ProxyURL eg http://proxyserver:2195 Directs scrapes
+                      to proxy through this endpoint.
+                    type: string
+                  scheme:
+                    description: HTTP scheme to use for scraping.
+                    type: string
+                  scrapeTimeout:
+                    description: Timeout after which the scrape is ended
+                    type: string
+                  targetPort:
+                    anyOf:
+                    - type: string
+                    - type: integer
+                  tlsConfig:
+                    description: TLSConfig specifies TLS configuration parameters.
+                    properties:
+                      caFile:
+                        description: The CA cert to use for the targets.
+                        type: string
+                      certFile:
+                        description: The client cert file for the targets.
+                        type: string
+                      insecureSkipVerify:
+                        description: Disable target certificate validation.
+                        type: boolean
+                      keyFile:
+                        description: The client key file for the targets.
+                        type: string
+                      serverName:
+                        description: Used to verify the hostname for the targets.
+                        type: string
+              type: array
+            jobLabel:
+              description: The label to use to retrieve the job name from.
+              type: string
+            namespaceSelector:
+              description: A selector for selecting namespaces either selecting all
+                namespaces or a list of namespaces.
+              properties:
+                any:
+                  description: Boolean describing whether all namespaces are selected
+                    in contrast to a list restricting them.
+                  type: boolean
+                matchNames:
+                  description: List of namespace names.
+                  items:
+                    type: string
+                  type: array
+            selector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                                 of matchExpressions, whose key field is "key", the operator is
+                                 "In", and the values array contains only "value". The requirements
+                                 are ANDed.
+                  type: object
+            targetLabels:
+              description: TargetLabels transfers labels on the Kubernetes Service
+                onto the target.
+              items:
+                type: string
+              type: array
+          required:
+          - endpoints
+          - selector
+  version: v1

--- a/bundles/prometheus.0.22.2/metadata/annotations.yaml
+++ b/bundles/prometheus.0.22.2/metadata/annotations.yaml
@@ -1,0 +1,4 @@
+annotations:
+  operators.operatorframework.io.bundle.package.v1: "prometheus"
+  operators.operatorframework.io.bundle.channels.v1: "preview"
+  operators.operatorframework.io.bundle.channel.default.v1: "preview"

--- a/cmd/opm/registry/add.go
+++ b/cmd/opm/registry/add.go
@@ -1,0 +1,81 @@
+package registry
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/operator-framework/operator-registry/pkg/sqlite"
+)
+
+func newRegistryAddCmd() *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:   "add",
+		Short: "add operator bundle to operator registry DB",
+		Long:  `add operator bundle to operator registry DB`,
+
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if debug, _ := cmd.Flags().GetBool("debug"); debug {
+				logrus.SetLevel(logrus.DebugLevel)
+			}
+			return nil
+		},
+
+		RunE: addFunc,
+	}
+
+	rootCmd.Flags().Bool("debug", false, "enable debug logging")
+	rootCmd.Flags().StringP("database", "d", "bundles.db", "relative path to database file")
+	rootCmd.Flags().StringSliceP("bundle-images", "b", []string{}, "comma separated list of links to bundle image")
+	rootCmd.Flags().Bool("permissive", false, "allow registry load errors")
+
+	return rootCmd
+}
+
+func addFunc(cmd *cobra.Command, args []string) error {
+	bundleImages, err := cmd.Flags().GetStringSlice("bundle-images")
+	if err != nil {
+		return err
+	}
+
+	fromFilename, err := cmd.Flags().GetString("database")
+	if err != nil {
+		return err
+	}
+	permissive, err := cmd.Flags().GetBool("permissive")
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+
+	db, err := sql.Open("sqlite3", fromFilename)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	dbLoader, err := sqlite.NewSQLLiteLoader(db)
+	if err != nil {
+		return err
+	}
+	if err := dbLoader.Migrate(context.TODO()); err != nil {
+		return err
+	}
+
+	for _, bundleImage := range bundleImages {
+		loader := sqlite.NewSQLLoaderForImage(dbLoader, bundleImage)
+		if err := loader.Populate(); err != nil {
+			err = fmt.Errorf("error loading bundle from image: %s", err)
+			if !permissive {
+				logrus.WithError(err).Fatal("permissive mode disabled")
+				errs = append(errs, err)
+			}
+			logrus.WithError(err).Warn("permissive mode enabled")
+		}
+	}
+	return nil
+}

--- a/cmd/opm/registry/cmd.go
+++ b/cmd/opm/registry/cmd.go
@@ -21,6 +21,8 @@ func NewOpmRegistryCmd() *cobra.Command {
 	}
 
 	rootCmd.AddCommand(newRegistryServeCmd())
+	rootCmd.AddCommand(newRegistryAddCmd())
+	rootCmd.AddCommand(newRegistryRmCmd())
 
 	return rootCmd
 }

--- a/cmd/opm/registry/rm.go
+++ b/cmd/opm/registry/rm.go
@@ -1,0 +1,79 @@
+package registry
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/operator-framework/operator-registry/pkg/sqlite"
+)
+
+func newRegistryRmCmd() *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:   "rm",
+		Short: "remove operator from operator registry DB",
+		Long:  `Remove operator from operator registry DB`,
+
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if debug, _ := cmd.Flags().GetBool("debug"); debug {
+				logrus.SetLevel(logrus.DebugLevel)
+			}
+			return nil
+		},
+
+		RunE: rmFunc,
+	}
+
+	rootCmd.Flags().Bool("debug", false, "enable debug logging")
+	rootCmd.Flags().StringP("database", "d", "bundles.db", "relative path to database file")
+	rootCmd.Flags().StringSliceP("packages", "o", []string{}, "comma separated list of package names to be deleted")
+	rootCmd.Flags().Bool("permissive", false, "allow registry load errors")
+
+	return rootCmd
+}
+
+func rmFunc(cmd *cobra.Command, args []string) error {
+	fromFilename, err := cmd.Flags().GetString("database")
+	if err != nil {
+		return err
+	}
+	packages, err := cmd.Flags().GetStringSlice("packages")
+	if err != nil {
+		return err
+	}
+	permissive, err := cmd.Flags().GetBool("permissive")
+	if err != nil {
+		return err
+	}
+
+	db, err := sql.Open("sqlite3", fromFilename)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	dbLoader, err := sqlite.NewSQLLiteLoader(db)
+	if err != nil {
+		return err
+	}
+	if err := dbLoader.Migrate(context.TODO()); err != nil {
+		return err
+	}
+
+	for _, pkg := range packages {
+		remover := sqlite.NewSQLRemoverForPackages(dbLoader, pkg)
+		if err := remover.Remove(); err != nil {
+			err = fmt.Errorf("error deleting packages from database: %s", err)
+			if !permissive {
+				logrus.WithError(err).Fatal("permissive mode disabled")
+				return err
+			}
+			logrus.WithError(err).Warn("permissive mode enabled")
+		}
+	}
+
+	return nil
+}

--- a/cmd/opm/registry/serve.go
+++ b/cmd/opm/registry/serve.go
@@ -31,7 +31,7 @@ func newRegistryServeCmd() *cobra.Command {
 			return nil
 		},
 
-		RunE: runRegistryServeCmdFunc,
+		RunE: serveFunc,
 	}
 
 	rootCmd.Flags().Bool("debug", false, "enable debug logging")
@@ -43,7 +43,7 @@ func newRegistryServeCmd() *cobra.Command {
 
 }
 
-func runRegistryServeCmdFunc(cmd *cobra.Command, args []string) error {
+func serveFunc(cmd *cobra.Command, args []string) error {
 	// Immediately set up termination log
 	terminationLogPath, err := cmd.Flags().GetString("termination-log")
 	if err != nil {

--- a/pkg/containertools/bundlereader.go
+++ b/pkg/containertools/bundlereader.go
@@ -1,0 +1,186 @@
+package containertools
+
+import (
+	"archive/tar"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+const (
+	imageManifestName = "manifest.json"
+)
+
+// imageManifest is the object format of container image manifest files
+// use this type to parse manifest.json files inside container image blobs
+type imageManifest struct {
+	Layers []string `json:”Layers”`
+}
+
+type BundleReader struct {
+}
+
+func NewBundleReader() *BundleReader {
+	return &BundleReader{}
+}
+
+func (b *BundleReader) GetBundle(image, outputDir string) error {
+	r := NewCommandRunner(Podman)
+
+	// Create the output directory if it doesn't exist
+	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
+		os.Mkdir(outputDir, 0777)
+	}
+
+	err := r.Pull(image)
+	if err != nil {
+		return err
+	}
+
+	workingDir, err := ioutil.TempDir("./", "bundle_staging_")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(workingDir)
+
+	rootTarfile := filepath.Join(workingDir, "bundle.tar")
+
+	err = r.Save(image, rootTarfile)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Open(rootTarfile)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Read the manifest.json file to find the right embedded tarball
+	layerTarballs, err := getManifestLayers(tar.NewReader(f))
+	if err != nil {
+		return err
+	}
+	
+	// Untar the image layer tarballs and push the bundle manifests to the output directory
+	for _, tarball := range layerTarballs {
+		f, err = os.Open(rootTarfile)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		err = extractBundleManifests(tarball, outputDir, tar.NewReader(f))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getManifestLayers(tarReader *tar.Reader) ([]string, error) {
+	for {
+		header, err := tarReader.Next()
+		if err != nil {
+			if err == io.EOF {
+				return nil, fmt.Errorf("invalid bundle image: unable to find manifest.json")
+			}
+			return nil, err
+		}
+
+		if header.Name == imageManifestName {
+			buf := new(bytes.Buffer)
+			buf.ReadFrom(tarReader)
+			b := buf.Bytes()
+
+			manifests := make([]imageManifest, 0)
+			err := json.Unmarshal(b, &manifests)
+			if err != nil {
+				return nil, err
+			}
+
+			if len(manifests) == 0 {
+				return nil, fmt.Errorf("invalid bundle image: manifest.json missing manifest data")
+			}
+
+			topManifest := manifests[0]
+
+			if len(topManifest.Layers) == 0 {
+				return nil, fmt.Errorf("invalid bundle image: manifest has no layers")
+			}
+
+			return topManifest.Layers, nil
+		}
+	}
+}
+
+func extractBundleManifests(layerTarball, outputDir string, tarReader *tar.Reader) error {
+	for {
+		header, err := tarReader.Next()
+		if err != nil {
+			if err == io.EOF {
+				return fmt.Errorf("Manifest error: Layer tarball does not exist in bundle")
+			}
+			return err
+		}
+
+		if header.Typeflag == tar.TypeReg {
+			if header.Name == layerTarball {
+				// Found the embedded top layer tarball
+				layerReader := tar.NewReader(tarReader)
+
+				err = extractTarballToDir(outputDir, layerReader)
+				if err != nil {
+					return err
+				}
+			}
+
+			continue
+		} else {
+			return nil
+		}
+	}
+}
+
+func extractTarballToDir(outputDir string, tarReader *tar.Reader) error {
+	for {
+		header, err := tarReader.Next()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			// Create the directory if it doesn't exist
+			directoryToWrite := filepath.Join(outputDir, header.Name)
+			if _, err := os.Stat(directoryToWrite); os.IsNotExist(err) {
+				os.Mkdir(directoryToWrite, 0777)
+			}
+		case tar.TypeReg:
+			buf := new(bytes.Buffer)
+			buf.ReadFrom(tarReader)
+			b := buf.Bytes()
+
+			manifestToWrite := filepath.Join(outputDir, header.Name)
+
+			m, err := os.Create(manifestToWrite)
+			if err != nil {
+				return err
+			}
+			defer m.Close()
+
+			_, err = m.Write(b)
+			if err != nil {
+				return err
+			}
+		}
+	}
+}

--- a/pkg/containertools/command.go
+++ b/pkg/containertools/command.go
@@ -1,0 +1,66 @@
+package containertools
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+const (
+	// Podman cli tool
+	Podman = "podman"
+	// Docker cli tool
+	Docker = "docker"
+)
+
+// CommandRunner is configured to select a container cli tool and execute commands with that
+// tooling.
+type CommandRunner struct {
+	containerTool string
+}
+
+// NewCommandRunner takes the containerTool as an input string and returns a CommandRunner to
+// run commands with that cli tool
+func NewCommandRunner(containerTool string) *CommandRunner {
+	r := &CommandRunner{}
+
+	switch containerTool {
+	case Podman:
+		r.containerTool = Podman
+	case Docker:
+		r.containerTool = Docker
+	default:
+		r.containerTool = Podman
+	}
+
+	return r
+}
+
+// Pull takes a container image path hosted on a container registry and runs the pull command to
+// download it onto the local environment
+func (r *CommandRunner) Pull(image string) error {
+	args := []string{"pull", image}
+
+	command := exec.Command(r.containerTool, args...)
+
+	out, err := command.Output()
+	if err != nil {
+		return fmt.Errorf("error with %s %s: %s", command.Args, string(out), err)
+	}
+
+	return nil
+}
+
+// Save takes a local container image and runs the save commmand to convert the image into a specified
+// tarball and push it to the local directory
+func (r *CommandRunner) Save(image, tarFile string) error {
+	args := []string{"save", image, "-o", tarFile}
+
+	command := exec.Command(r.containerTool, args...)
+
+	out, err := command.Output()
+	if err != nil {
+		return fmt.Errorf("error with %s %s: %s", command.Args, string(out), err)
+	}
+
+	return nil
+}

--- a/pkg/registry/bundle.go
+++ b/pkg/registry/bundle.go
@@ -28,13 +28,14 @@ func init() {
 }
 
 type Bundle struct {
-	Name       string
-	Objects    []*unstructured.Unstructured
-	Package    string
-	Channel    string
-	csv        *ClusterServiceVersion
-	crds       []*v1beta1.CustomResourceDefinition
-	cacheStale bool
+	Name        string
+	Objects     []*unstructured.Unstructured
+	Package     string
+	Channel     string
+	BundleImage string
+	csv         *ClusterServiceVersion
+	crds        []*v1beta1.CustomResourceDefinition
+	cacheStale  bool
 }
 
 func NewBundle(name, pkgName, channelName string, objs ...*unstructured.Unstructured) *Bundle {
@@ -170,12 +171,12 @@ func (b *Bundle) AllProvidedAPIsInBundle() error {
 	return nil
 }
 
-func (b *Bundle) Serialize() (csvName string, csvBytes []byte, bundleBytes []byte, err error) {
+func (b *Bundle) Serialize() (csvName, bundleImage string, csvBytes []byte, bundleBytes []byte, err error) {
 	csvCount := 0
 	for _, obj := range b.Objects {
 		objBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
 		if err != nil {
-			return "", nil, nil, err
+			return "", "", nil, nil, err
 		}
 		bundleBytes = append(bundleBytes, objBytes...)
 
@@ -183,16 +184,16 @@ func (b *Bundle) Serialize() (csvName string, csvBytes []byte, bundleBytes []byt
 			csvName = obj.GetName()
 			csvBytes, err = runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
 			if err != nil {
-				return "", nil, nil, err
+				return "", "", nil, nil, err
 			}
 			csvCount += 1
 			if csvCount > 1 {
-				return "", nil, nil, fmt.Errorf("two csvs found in one bundle")
+				return "", "", nil, nil, fmt.Errorf("two csvs found in one bundle")
 			}
 		}
 	}
 
-	return csvName, csvBytes, bundleBytes, nil
+	return csvName, b.BundleImage, csvBytes, bundleBytes, nil
 }
 
 func (b *Bundle) Images() (map[string]struct{}, error) {

--- a/pkg/registry/interface.go
+++ b/pkg/registry/interface.go
@@ -8,7 +8,10 @@ import (
 
 type Load interface {
 	AddOperatorBundle(bundle *Bundle) error
+	AddBundlePackageChannels(manifest PackageManifest, bundle Bundle) error
 	AddPackageChannels(manifest PackageManifest) error
+	RmPackageName(packageName string) error
+	ClearNonDefaultBundles(packageName string) error
 }
 
 type Query interface {

--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"strings"
 )
 
 // APIKey stores GroupVersionKind for use as map keys
@@ -73,4 +74,52 @@ type ChannelEntry struct {
 	ChannelName string
 	BundleName  string
 	Replaces    string
+}
+
+// AnnotationsFile holds annotation information about a bundle
+type AnnotationsFile struct {
+	// annotations is a list of annotations for a given bundle
+	Annotations Annotations `json:"annotations" yaml:"annotations"`
+}
+
+// Annotations is a list of annotations for a given bundle
+type Annotations struct {
+	// PackageName is the name of the overall package, ala `etcd`.
+	PackageName string `json:"operators.operatorframework.io.bundle.package.v1" yaml:"operators.operatorframework.io.bundle.package.v1"`
+
+	// Channels are a comma separated list of the declared channels for the bundle, ala `stable` or `alpha`.
+	Channels string `json:"operators.operatorframework.io.bundle.channels.v1" yaml:"operators.operatorframework.io.bundle.channels.v1"`
+
+	// DefaultChannelName is, if specified, the name of the default channel for the package. The
+	// default channel will be installed if no other channel is explicitly given. If the package
+	// has a single channel, then that channel is implicitly the default.
+	DefaultChannelName string `json:"operators.operatorframework.io.bundle.channel.default.v1" yaml:"operators.operatorframework.io.bundle.channel.default.v1"`
+}
+
+// GetName returns the package name of the bundle
+func (a *AnnotationsFile) GetName() string {
+	if a.Annotations.PackageName != "" {
+		return a.Annotations.PackageName
+	}
+	return ""
+}
+
+// GetChannels returns the channels that this bundle should be added to
+func (a *AnnotationsFile) GetChannels() []string {
+	if a.Annotations.Channels != "" {
+		return strings.Split(a.Annotations.Channels, ",")
+	}
+	return []string{}
+}
+
+// GetDefaultChannelName returns the name of the default channel
+func (a *AnnotationsFile) GetDefaultChannelName() string {
+	if a.Annotations.DefaultChannelName != "" {
+		return a.Annotations.DefaultChannelName
+	}
+	channels := a.GetChannels()
+	if len(channels) == 1 {
+		return channels[0]
+	}
+	return ""
 }

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -1,0 +1,239 @@
+package sqlite
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/yaml"
+
+	"github.com/operator-framework/operator-registry/pkg/containertools"
+	"github.com/operator-framework/operator-registry/pkg/registry"
+)
+
+// ImageLoader loads a bundle image of resources into the database
+type ImageLoader struct {
+	store     registry.Load
+	image     string
+	directory string
+}
+
+func NewSQLLoaderForImage(store registry.Load, image string) *ImageLoader {
+	return &ImageLoader{
+		store:     store,
+		image:     image,
+		directory: "",
+	}
+}
+
+func (i *ImageLoader) Populate() error {
+
+	log := logrus.WithField("img", i.image)
+
+	workingDir, err := ioutil.TempDir("./", "bundle_tmp")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(workingDir)
+
+	// Pull the image and get the manifests
+	reader := containertools.NewBundleReader()
+
+	err = reader.GetBundle(i.image, workingDir)
+	if err != nil {
+		return err
+	}
+
+	i.directory = workingDir
+
+	log.Infof("loading Bundle %s", i.image)
+	errs := make([]error, 0)
+	if err := i.LoadBundleFunc(); err != nil {
+		errs = append(errs, err)
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
+// LoadBundleFunc walks the bundle directory. Looks for the metadata and manifests
+// sub-directories to find the annotations.yaml file that will inform how the
+// manifests of the bundle should be loaded into the database.
+func (i *ImageLoader) LoadBundleFunc() error {
+	path := i.directory
+	manifests := filepath.Join(path, "manifests")
+	metadata := filepath.Join(path, "metadata")
+
+	// Get annotations file
+	log := logrus.WithFields(logrus.Fields{"dir": i.directory, "file": metadata, "load": "annotations"})
+	files, err := ioutil.ReadDir(metadata)
+	if err != nil {
+		return fmt.Errorf("unable to read directory %s: %s", metadata, err)
+	}
+
+	annotationsFile := &registry.AnnotationsFile{}
+	for _, f := range files {
+		fileReader, err := os.Open(filepath.Join(metadata, f.Name()))
+		if err != nil {
+			return fmt.Errorf("unable to read file %s: %s", f.Name(), err)
+		}
+		decoder := yaml.NewYAMLOrJSONDecoder(fileReader, 30)
+		err = decoder.Decode(&annotationsFile)
+		if err != nil || *annotationsFile == (registry.AnnotationsFile{}) {
+			continue
+		} else {
+			log.Info("found annotations file searching for csv")
+		}
+	}
+
+	if *annotationsFile == (registry.AnnotationsFile{}) {
+		return fmt.Errorf("Could not find annotations.yaml file")
+	}
+
+	err = i.loadManifests(manifests, annotationsFile)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (i *ImageLoader) loadManifests(manifests string, annotationsFile *registry.AnnotationsFile) error {
+	log := logrus.WithFields(logrus.Fields{"dir": i.directory, "file": manifests, "load": "bundle"})
+
+	csv, err := i.findCSV(manifests)
+	if err != nil {
+		return err
+	}
+
+	if csv.Object == nil {
+		return fmt.Errorf("csv is empty: %s", err)
+	}
+
+	log.Info("found csv, loading bundle")
+
+	// TODO: Check channels against what's in the database vs in the bundle csv
+
+	bundle, err := loadBundle(csv.GetName(), manifests)
+	if err != nil {
+		return fmt.Errorf("error loading objs in directory: %s", err)
+	}
+
+	if bundle == nil || bundle.Size() == 0 {
+		return fmt.Errorf("no bundle objects found")
+	}
+
+	// set the bundleimage on the bundle
+	bundle.BundleImage = i.image
+
+	if err := bundle.AllProvidedAPIsInBundle(); err != nil {
+		return fmt.Errorf("error checking provided apis in bundle %s: %s", bundle.Name, err)
+	}
+
+	bcsv, err := bundle.ClusterServiceVersion()
+	if err != nil {
+		return fmt.Errorf("error getting csv from bundle %s: %s", bundle.Name, err)
+	}
+
+	packageManifest, err := translateAnnotationsIntoPackage(annotationsFile, bcsv)
+	if err != nil {
+		return fmt.Errorf("Could not translate annotations file into packageManifest %s", err)
+	}
+
+	if err := i.loadOperatorBundle(packageManifest, *bundle); err != nil {
+		return fmt.Errorf("Error adding package %s", err)
+	}
+
+	// Finally let's delete all the old bundles
+	if err = i.store.ClearNonDefaultBundles(packageManifest.PackageName); err != nil {
+		return fmt.Errorf("Error deleting previous bundles: %s", err)
+	}
+
+	return nil
+}
+
+// findCSV looks through the bundle directory to find a csv
+func (i *ImageLoader) findCSV(manifests string) (*unstructured.Unstructured, error) {
+	log := logrus.WithFields(logrus.Fields{"dir": i.directory, "find": "csv"})
+
+	files, err := ioutil.ReadDir(manifests)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read directory %s: %s", manifests, err)
+	}
+
+	var errs []error
+	for _, f := range files {
+		log = log.WithField("file", f.Name())
+		if f.IsDir() {
+			log.Info("skipping directory")
+			continue
+		}
+
+		if strings.HasPrefix(f.Name(), ".") {
+			log.Info("skipping hidden file")
+			continue
+		}
+
+		path := filepath.Join(manifests, f.Name())
+		fileReader, err := os.Open(path)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("unable to read file %s: %s", path, err))
+			continue
+		}
+
+		dec := yaml.NewYAMLOrJSONDecoder(fileReader, 30)
+		unst := &unstructured.Unstructured{}
+		if err := dec.Decode(unst); err != nil {
+			continue
+		}
+
+		if unst.GetKind() != ClusterServiceVersionKind {
+			continue
+		}
+
+		return unst, nil
+
+	}
+
+	errs = append(errs, fmt.Errorf("no csv found in bundle"))
+	return nil, utilerrors.NewAggregate(errs)
+}
+
+// loadOperatorBundle adds the package information to the loader's store
+func (i *ImageLoader) loadOperatorBundle(manifest registry.PackageManifest, bundle registry.Bundle) error {
+	if manifest.PackageName == "" {
+		return nil
+	}
+
+	if err := i.store.AddBundlePackageChannels(manifest, bundle); err != nil {
+		return fmt.Errorf("error loading bundle into db: %s", err)
+	}
+
+	return nil
+}
+
+// translateAnnotationsIntoPackage attempts to translate the channels.yaml file at the given path into a package.yaml
+func translateAnnotationsIntoPackage(annotations *registry.AnnotationsFile, csv *registry.ClusterServiceVersion) (registry.PackageManifest, error) {
+	manifest := registry.PackageManifest{}
+
+	channels := []registry.PackageChannel{}
+	for _, ch := range annotations.GetChannels() {
+		channels = append(channels,
+			registry.PackageChannel{
+				Name:           ch,
+				CurrentCSVName: csv.GetName(),
+			})
+	}
+
+	manifest = registry.PackageManifest{
+		PackageName:        annotations.GetName(),
+		DefaultChannelName: annotations.GetDefaultChannelName(),
+		Channels:           channels,
+	}
+
+	return manifest, nil
+}

--- a/pkg/sqlite/image_test.go
+++ b/pkg/sqlite/image_test.go
@@ -1,0 +1,54 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImageLoader(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+	db, cleanup := CreateTestDb(t)
+	defer cleanup()
+	store, err := NewSQLLiteLoader(db)
+	require.NoError(t, err)
+	require.NoError(t, store.Migrate(context.TODO()))
+
+	image := "quay.io/test/"
+	etcdFirstVersion := &ImageLoader{
+		store:     store,
+		image:     image + "etcd.0.9.0",
+		directory: "../../bundles/etcd.0.9.0",
+	}
+	require.NoError(t, etcdFirstVersion.LoadBundleFunc())
+
+	etcdNextVersion := &ImageLoader{
+		store:     store,
+		image:     image + "etcd.0.9.2",
+		directory: "../../bundles/etcd.0.9.2",
+	}
+	require.NoError(t, etcdNextVersion.LoadBundleFunc())
+
+	prometheusFirstVersion := &ImageLoader{
+		store:     store,
+		image:     image + "prometheus.0.14.0",
+		directory: "../../bundles/prometheus.0.14.0",
+	}
+	require.NoError(t, prometheusFirstVersion.LoadBundleFunc())
+
+	prometheusSecondVersion := &ImageLoader{
+		store:     store,
+		image:     image + "prometheus.0.15.0",
+		directory: "../../bundles/prometheus.0.15.0",
+	}
+	require.NoError(t, prometheusSecondVersion.LoadBundleFunc())
+
+	prometheusThirdVersion := &ImageLoader{
+		store:     store,
+		image:     image + "prometheus.0.22.2",
+		directory: "../../bundles/prometheus.0.22.2",
+	}
+	require.NoError(t, prometheusThirdVersion.LoadBundleFunc())
+}

--- a/pkg/sqlite/load.go
+++ b/pkg/sqlite/load.go
@@ -68,7 +68,7 @@ func (s *SQLLoader) AddOperatorBundle(bundle *registry.Bundle) error {
 	}
 	defer addImage.Close()
 
-	csvName, csvBytes, bundleBytes, err := bundle.Serialize()
+	csvName, bundleImage, csvBytes, bundleBytes, err := bundle.Serialize()
 	if err != nil {
 		return err
 	}
@@ -77,7 +77,7 @@ func (s *SQLLoader) AddOperatorBundle(bundle *registry.Bundle) error {
 		return fmt.Errorf("csv name not found")
 	}
 
-	if _, err := stmt.Exec(csvName, csvBytes, bundleBytes, nil); err != nil {
+	if _, err := stmt.Exec(csvName, csvBytes, bundleBytes, bundleImage); err != nil {
 		return err
 	}
 
@@ -134,13 +134,22 @@ func (s *SQLLoader) AddPackageChannels(manifest registry.PackageManifest) error 
 	}
 	defer addReplaces.Close()
 
+	var errs []error
+
 	if _, err := addPackage.Exec(manifest.PackageName); err != nil {
-		// This should be terminal
-		return err
+		err = s.updatePackageChannels(tx, manifest)
+		if err != nil {
+			errs = append(errs, err)
+		}
+
+		if err := tx.Commit(); err != nil {
+			errs = append(errs, err)
+		}
+
+		return utilerrors.NewAggregate(errs)
 	}
 
 	hasDefault := false
-	var errs []error
 	for _, c := range manifest.Channels {
 		if _, err := addChannel.Exec(c.Name, manifest.PackageName, c.CurrentCSVName); err != nil {
 			errs = append(errs, err)
@@ -274,6 +283,106 @@ func (s *SQLLoader) AddPackageChannels(manifest registry.PackageManifest) error 
 	return utilerrors.NewAggregate(errs)
 }
 
+func (s *SQLLoader) ClearNonDefaultBundles(packageName string) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		tx.Rollback()
+	}()
+
+	// First find the default channel for the package
+	getDefChan, err := tx.Prepare(fmt.Sprintf("select default_channel from package where name='%s'", packageName))
+	if err != nil {
+		return err
+	}
+	defer getDefChan.Close()
+
+	defaultChannelRows, err := getDefChan.Query()
+	if err != nil {
+		return err
+	}
+	defer defaultChannelRows.Close()
+
+	if !defaultChannelRows.Next() {
+		return fmt.Errorf("no default channel found for package %s", packageName)
+	}
+	var defaultChannel sql.NullString
+	if err := defaultChannelRows.Scan(&defaultChannel); err != nil {
+		return err
+	}
+
+	// Then get the head of the default channel
+	getChanHead, err := tx.Prepare(fmt.Sprintf("select head_operatorbundle_name from channel where name='%s'", defaultChannel.String))
+	if err != nil {
+		return err
+	}
+	defer getChanHead.Close()
+
+	chanHeadRows, err := getChanHead.Query()
+	if err != nil {
+		return err
+	}
+	defer chanHeadRows.Close()
+
+	if !chanHeadRows.Next() {
+		return fmt.Errorf("no channel head found for default channel %s", defaultChannel.String)
+	}
+	var defChanHead sql.NullString
+	if err := chanHeadRows.Scan(&defChanHead); err != nil {
+		return err
+	}
+
+	// Now get all the bundles that are not the head of the default channel
+	getChannelBundles, err := tx.Prepare(fmt.Sprintf("SELECT operatorbundle_name FROM channel_entry WHERE package_name='%s' AND operatorbundle_name!='%s'", packageName, defChanHead.String))
+	if err != nil {
+		return err
+	}
+	defer getChanHead.Close()
+
+	chanBundleRows, err := getChannelBundles.Query()
+	if err != nil {
+		return err
+	}
+	defer chanBundleRows.Close()
+
+	bundles := make(map[string]struct{}, 0)
+	for chanBundleRows.Next() {
+		var bundleToUpdate sql.NullString
+		if err := chanBundleRows.Scan(&bundleToUpdate); err != nil {
+			return err
+		}
+		bundles[bundleToUpdate.String] = struct{}{}
+	}
+
+	if len(bundles) > 0 {
+		bundlePredicates := []string{}
+		for bundle := range bundles {
+			bundlePredicates = append(bundlePredicates, fmt.Sprintf("name = '%s'", bundle))
+		}
+
+		var transactionPredicate string
+		if len(bundlePredicates) == 1 {
+			transactionPredicate = fmt.Sprintf("WHERE %s AND bundlepath != \"\"", bundlePredicates[0])
+		} else {
+			transactionPredicate = fmt.Sprintf("WHERE (%s) AND bundlepath != \"\"", strings.Join(bundlePredicates, " OR "))
+		}
+
+		removeOldBundles, err := tx.Prepare(fmt.Sprintf("UPDATE operatorbundle SET bundle = null, csv = null %s", transactionPredicate))
+		if err != nil {
+			return err
+		}
+
+		_, err = removeOldBundles.Exec()
+		if err != nil {
+			return fmt.Errorf("Unable to remove previous bundles: %s", err)
+		}
+	}
+
+	return tx.Commit()
+}
+
 func SplitCRDName(crdName string) (plural, group string, err error) {
 	pluralGroup := strings.SplitN(crdName, ".", 2)
 	if len(pluralGroup) != 2 {
@@ -308,10 +417,14 @@ func (s *SQLLoader) getCSV(tx *sql.Tx, csvName string) (*registry.ClusterService
 		return nil, err
 	}
 
+	if !csvStringSQL.Valid {
+		return nil, fmt.Errorf("csv %s not stored for non-latest versions", csvName)
+	}
+
 	dec := yaml.NewYAMLOrJSONDecoder(strings.NewReader(csvStringSQL.String), 10)
 	unst := &unstructured.Unstructured{}
 	if err := dec.Decode(unst); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("can't decode %s: %s", csvStringSQL.String, err)
 	}
 
 	csv := &registry.ClusterServiceVersion{}
@@ -342,6 +455,9 @@ func (s *SQLLoader) addAPIs(tx *sql.Tx, csv *registry.ClusterServiceVersion, cha
 	defer addApiRequirer.Close()
 
 	ownedCRDs, requiredCRDs, err := csv.GetCustomResourceDefintions()
+	if err != nil {
+		return err
+	}
 	for _, crd := range ownedCRDs {
 		plural, group, err := SplitCRDName(crd.Name)
 		if err != nil {
@@ -368,6 +484,9 @@ func (s *SQLLoader) addAPIs(tx *sql.Tx, csv *registry.ClusterServiceVersion, cha
 	}
 
 	ownedAPIs, requiredAPIs, err := csv.GetApiServiceDefinitions()
+	if err != nil {
+		return err
+	}
 	for _, api := range ownedAPIs {
 		if _, err := addAPI.Exec(api.Group, api.Version, api.Kind, api.Name); err != nil {
 			return err
@@ -380,9 +499,477 @@ func (s *SQLLoader) addAPIs(tx *sql.Tx, csv *registry.ClusterServiceVersion, cha
 		if _, err := addAPI.Exec(api.Group, api.Version, api.Kind, api.Name); err != nil {
 			return err
 		}
-		if _, err := addAPIProvider.Exec(api.Group, api.Version, api.Kind, channelEntryId); err != nil {
+		if _, err := addApiRequirer.Exec(api.Group, api.Version, api.Kind, channelEntryId); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+func (s *SQLLoader) getCSVNames(tx *sql.Tx, packageName string) ([]string, error) {
+	getID, err := tx.Prepare(`
+	  SELECT DISTINCT channel_entry.operatorbundle_name
+	  FROM channel_entry
+	  WHERE channel_entry.package_name=?`)
+
+	if err != nil {
+		return nil, err
+	}
+	defer getID.Close()
+
+	rows, err := getID.Query(packageName)
+	if err != nil {
+		return nil, err
+	}
+
+	var csvName string
+	csvNames := []string{}
+	for rows.Next() {
+		err := rows.Scan(&csvName)
+		if err != nil {
+			return nil, err
+		}
+		csvNames = append(csvNames, csvName)
+	}
+
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+
+	return csvNames, nil
+}
+
+func (s *SQLLoader) rmAPIs(tx *sql.Tx, csv *registry.ClusterServiceVersion) error {
+	rmAPI, err := tx.Prepare("delete from api where group_name=? AND version=? AND kind=?")
+	if err != nil {
+		return err
+	}
+	defer rmAPI.Close()
+
+	ownedCRDs, _, err := csv.GetCustomResourceDefintions()
+	for _, crd := range ownedCRDs {
+		_, group, err := SplitCRDName(crd.Name)
+		if err != nil {
+			return err
+		}
+		if _, err := rmAPI.Exec(group, crd.Version, crd.Kind); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *SQLLoader) RmPackageName(packageName string) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		tx.Rollback()
+	}()
+
+	csvNames, err := s.getCSVNames(tx, packageName)
+	if err != nil {
+		return err
+	}
+	for _, csvName := range csvNames {
+		csv, err := s.getCSV(tx, csvName)
+		if csv != nil {
+			err = s.rmBundle(tx, csvName)
+			if err != nil {
+				return err
+			}
+			err = s.rmAPIs(tx, csv)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = s.rmBundle(tx, csvName)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return tx.Commit()
+}
+
+func (s *SQLLoader) rmBundle(tx *sql.Tx, csvName string) error {
+	stmt, err := tx.Prepare("DELETE FROM operatorbundle WHERE operatorbundle.name=?")
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	if _, err := stmt.Exec(csvName); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *SQLLoader) AddBundlePackageChannels(manifest registry.PackageManifest, bundle registry.Bundle) error {
+	var errs []error
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		tx.Rollback()
+	}()
+
+	stmt, err := tx.Prepare("insert into operatorbundle(name, csv, bundle, bundlepath) values(?, ?, ?, ?)")
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	addImage, err := tx.Prepare("insert into related_image(image, operatorbundle_name) values(?,?)")
+	if err != nil {
+		return err
+	}
+	defer addImage.Close()
+
+	csvName, bundleImage, csvBytes, bundleBytes, err := bundle.Serialize()
+	if err != nil {
+		return err
+	}
+
+	if csvName == "" {
+		return fmt.Errorf("csv name not found")
+	}
+
+	if _, err := stmt.Exec(csvName, csvBytes, bundleBytes, bundleImage); err != nil {
+		return err
+	}
+
+	imgs, err := bundle.Images()
+	if err != nil {
+		return err
+	}
+	// TODO: bulk insert
+	for img := range imgs {
+		if _, err := addImage.Exec(img, csvName); err != nil {
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	if err := s.AddPackageChannels(manifest); err != nil {
+		errs = append(errs, err)
+		tx, err := s.db.Begin()
+		if err != nil {
+			errs = append(errs, err)
+			return utilerrors.NewAggregate(errs)
+		}
+		defer func() {
+			tx.Rollback()
+		}()
+
+		if err := s.rmBundle(tx, csvName); err != nil {
+			errs = append(errs, err)
+			return utilerrors.NewAggregate(errs)
+		}
+
+		if err := tx.Commit(); err != nil {
+			errs = append(errs, err)
+		}
+
+		return utilerrors.NewAggregate(errs)
+	}
+
+	return nil
+}
+
+func (s *SQLLoader) updatePackageChannels(tx *sql.Tx, manifest registry.PackageManifest) error {
+	updateDefaultChannel, err := tx.Prepare("update package set default_channel = ? where name = ?")
+	if err != nil {
+		return err
+	}
+	defer updateDefaultChannel.Close()
+
+	getDefaultChannel, err := tx.Prepare(`SELECT default_channel FROM package WHERE name = ? LIMIT 1`)
+	if err != nil {
+		return err
+	}
+	defer getDefaultChannel.Close()
+
+	updateChannel, err := tx.Prepare("update channel set head_operatorbundle_name = ? where name = ? and package_name = ?")
+	if err != nil {
+		return err
+	}
+	defer updateChannel.Close()
+
+	addChannelEntry, err := tx.Prepare("insert into channel_entry(channel_name, package_name, operatorbundle_name, depth) values(?, ?, ?, ?)")
+	if err != nil {
+		return err
+	}
+	defer addChannelEntry.Close()
+
+	updateChannelEntry, err := tx.Prepare("update channel_entry set depth = ? where channel_name = ? and package_name = ? and operatorbundle_name = ?")
+	if err != nil {
+		return err
+	}
+	defer updateChannelEntry.Close()
+
+	addReplaces, err := tx.Prepare("update channel_entry set replaces = ? where entry_id = ?")
+	if err != nil {
+		return err
+	}
+	defer addReplaces.Close()
+
+	getDepth, err := tx.Prepare(`
+	  SELECT channel_entry.depth, channel_entry.entry_id
+	  FROM channel_entry
+	  WHERE channel_name = ? and package_name = ? and operatorbundle_name =?
+	  LIMIT 1`)
+	if err != nil {
+		return err
+	}
+	defer getDepth.Close()
+
+	getChannelEntryID, err := tx.Prepare(`
+	  SELECT channel_entry.entry_id
+	  FROM channel_entry
+	  WHERE channel_name = ? and package_name = ? and operatorbundle_name =?
+	  LIMIT 1`)
+	if err != nil {
+		return err
+	}
+	defer getChannelEntryID.Close()
+
+	updateDepth, err := tx.Prepare("update channel_entry set depth = depth + 1 where channel_name = ? and package_name = ? and operatorbundle_name = ?")
+	if err != nil {
+		return err
+	}
+	defer updateDepth.Close()
+
+	removeSkipped, err := tx.Prepare("delete from channel_entry where channel_name = ? and package_name = ? and operatorbundle_name = ?")
+	if err != nil {
+		return err
+	}
+	defer removeSkipped.Close()
+
+	getBundleIDNameFromDepthToHead, err := tx.Prepare(`
+	  SELECT entry_id, operatorbundle_name
+	  FROM channel_entry
+	  WHERE depth < ? and channel_name = ? and package_name = ?`)
+	if err != nil {
+		return err
+	}
+	defer getBundleIDNameFromDepthToHead.Close()
+
+	var errs []error
+
+	// update head bundle name in channel table
+	for _, c := range manifest.Channels {
+		if _, err := updateChannel.Exec(c.CurrentCSVName, c.Name, manifest.PackageName); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+	}
+
+	// insert/replace default channel
+	defaultChannelName := manifest.GetDefaultChannel()
+	if defaultChannelName != "" {
+		if _, err := updateDefaultChannel.Exec(defaultChannelName, manifest.PackageName); err != nil {
+			errs = append(errs, err)
+		}
+	} // else assume default channel is already in db and need not be changed
+
+	// For each channel, check where in update graph
+	// the bundle is attempted to be inserted.
+	// If not at the head of the channel then error
+	for _, c := range manifest.Channels {
+		// don't need to check if version has been inserted for a given channel
+		// because this is caught by primary key of operatorbundle table
+
+		channelEntryCSV, err := s.getCSV(tx, c.CurrentCSVName)
+
+		// check replaces
+		replaces, err := channelEntryCSV.GetReplaces()
+		if err != nil {
+			errs = append(errs, err)
+			break
+		}
+
+		// where does the replaces fall in the update graph
+		rows, err := getDepth.Query(c.Name, manifest.PackageName, replaces)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		var depth int64
+		var currentID int64
+		var replacedIDs []int64
+		skips, err := channelEntryCSV.GetSkips()
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		if rows.Next() {
+			err := rows.Scan(&depth, &currentID)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			// check if replaces not at the head of the channel
+			if depth != 0 {
+				// if not at the head of the channel, need to specify appropriate skips
+				if len(skips) != int(depth) {
+					errs = append(errs, fmt.Errorf("%s attempts to replace %s that is already replaced by another version", c.CurrentCSVName, replaces))
+					return utilerrors.NewAggregate(errs)
+				}
+				skipmap := make(map[string]struct{}, 0)
+				for _, sk := range skips {
+					skipmap[sk] = struct{}{}
+				}
+				// get csv from depth to head for channel
+				skipped, err := getBundleIDNameFromDepthToHead.Query(depth, c.Name, manifest.PackageName)
+				if err != nil {
+					errs = append(errs, err)
+					continue
+				}
+				defer skipped.Close()
+
+				// see if csvs match skips
+				var skip string
+				var replacedID int64
+				for skipped.Next() {
+					err := skipped.Scan(&replacedID, &skip)
+					if err != nil {
+						errs = append(errs, err)
+						return utilerrors.NewAggregate(errs)
+					}
+					replacedIDs = append(replacedIDs, replacedID)
+					if _, ok := skipmap[skip]; !ok {
+						errs = append(errs, fmt.Errorf("%s attempts to replace %s that is already replaced by %s without specifying a skip", c.CurrentCSVName, replaces, skip))
+					}
+				}
+				// aggregate all the errors instead of returning on first error
+				if len(errs) > 0 {
+					return utilerrors.NewAggregate(errs)
+				}
+			}
+		} else {
+			// specifies a replacement that is not in db
+			errs = append(errs, fmt.Errorf("%s specifies a replacement %s that cannot be found", c.CurrentCSVName, replaces))
+			return utilerrors.NewAggregate(errs)
+		}
+
+		if err := rows.Close(); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		// insert version into head of channel
+		res, err := addChannelEntry.Exec(c.Name, manifest.PackageName, c.CurrentCSVName, 0)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		currentID, err = res.LastInsertId()
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		// update replacement to point to new head of channel
+		var replacedID int64
+		rows, err = getChannelEntryID.Query(c.Name, manifest.PackageName, replaces)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if rows.Next() {
+			err := rows.Scan(&replacedID)
+			if err != nil {
+				errs = append(errs, err)
+			}
+		} // else is not possible by previous SELECT statement on replaces
+
+		if err := rows.Close(); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		if _, err = addReplaces.Exec(replacedID, currentID); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		// remove skips from graph
+		for _, skip := range skips {
+			if _, err := removeSkipped.Exec(c.Name, manifest.PackageName, skip); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+		}
+
+		// add APIs
+		if err := s.addAPIs(tx, channelEntryCSV, currentID); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		// update depth to depth + 1 for replaced entry
+		_, err = updateDepth.Exec(c.Name, manifest.PackageName, replaces)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		// insert dummy skips entries if needed or update the graph based on skips
+		depth = 1
+		for _, skip := range skips {
+			// add dummy channel entry for the skipped version
+			skippedChannelEntry, err := addChannelEntry.Exec(c.Name, manifest.PackageName, skip, depth)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+
+			skippedID, err := skippedChannelEntry.LastInsertId()
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+
+			// add another channel entry for the parent, which replaces the skipped
+			synthesizedChannelEntry, err := addChannelEntry.Exec(c.Name, manifest.PackageName, c.CurrentCSVName, depth)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+
+			synthesizedID, err := synthesizedChannelEntry.LastInsertId()
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+
+			if _, err = addReplaces.Exec(skippedID, synthesizedID); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+
+			if err := s.addAPIs(tx, channelEntryCSV, synthesizedID); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+
+			depth++
+		}
+	}
+
+	if errs != nil {
+		return utilerrors.NewAggregate(errs)
 	}
 	return nil
 }

--- a/pkg/sqlite/migrations/004_cascade_delete.go
+++ b/pkg/sqlite/migrations/004_cascade_delete.go
@@ -1,0 +1,453 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+)
+
+var CascadeDeleteMigrationKey = 4
+
+// Register this migration
+func init() {
+	migrations[CascadeDeleteMigrationKey] = cascadeDeleteMigration
+}
+
+var cascadeDeleteMigration = &Migration{
+	Id: CascadeDeleteMigrationKey,
+	Up: func(ctx context.Context, tx *sql.Tx) error {
+		foreingKeyOff := `PRAGMA foreign_keys = 0`
+		renameTable := func(table string) string {
+			return `ALTER TABLE ` + table + ` RENAME TO ` + table + `_old;`
+		}
+		createNewOperatorBundleTable := `
+		CREATE TABLE operatorbundle (
+			name TEXT PRIMARY KEY,
+			csv TEXT,
+			bundle TEXT,
+			bundlepath TEXT);`
+		createNewPackageTable := `
+		CREATE TABLE package (
+			name TEXT PRIMARY KEY,
+			default_channel TEXT,
+			FOREIGN KEY(name, default_channel) REFERENCES channel(package_name,name) ON DELETE CASCADE
+		);`
+		createNewChannelTable := `
+		CREATE TABLE channel (
+			name TEXT,
+			package_name TEXT,
+			head_operatorbundle_name TEXT,
+			PRIMARY KEY(name, package_name),
+			FOREIGN KEY(head_operatorbundle_name) REFERENCES operatorbundle(name) ON DELETE CASCADE
+		);`
+		createNewChannelEntryTable := `
+		CREATE TABLE channel_entry (
+			entry_id INTEGER PRIMARY KEY,
+			channel_name TEXT,
+			package_name TEXT,
+			operatorbundle_name TEXT,
+			replaces INTEGER,
+			depth INTEGER,
+			FOREIGN KEY(replaces) REFERENCES channel_entry(entry_id) DEFERRABLE INITIALLY DEFERRED, 
+			FOREIGN KEY(channel_name, package_name) REFERENCES channel(name, package_name) ON DELETE CASCADE
+		);`
+		createNewAPIProviderTable := `
+		CREATE TABLE api_provider (
+			group_name TEXT,
+			version TEXT,
+			kind TEXT,
+			channel_entry_id INTEGER,
+			PRIMARY KEY(group_name, version, kind, channel_entry_id),
+			FOREIGN KEY(channel_entry_id) REFERENCES channel_entry(entry_id) ON DELETE CASCADE,
+			FOREIGN KEY(group_name, version, kind) REFERENCES api(group_name, version, kind)
+		);`
+		createNewRelatedImageTable := `
+		CREATE TABLE related_image (
+			image TEXT,
+     		operatorbundle_name TEXT,
+     		FOREIGN KEY(operatorbundle_name) REFERENCES operatorbundle(name) ON DELETE CASCADE
+		);`
+		createNewAPIRequirerTable := `
+		CREATE TABLE api_requirer (
+			group_name TEXT,
+			version TEXT,
+			kind TEXT,
+			channel_entry_id INTEGER,
+			PRIMARY KEY(group_name, version, kind, channel_entry_id),
+			FOREIGN KEY(channel_entry_id) REFERENCES channel_entry(entry_id) ON DELETE CASCADE,
+			FOREIGN KEY(group_name, version, kind) REFERENCES api(group_name, version, kind)
+		);`
+		newTableTransfer := func(table string) string {
+			return `INSERT INTO ` + table + ` SELECT * FROM "` + table + `_old"`
+		}
+		dropTable := func(table string) string {
+			return `DROP TABLE "` + table + `_old"`
+		}
+		foreingKeyOn := `PRAGMA foreign_keys = 1`
+
+		_, err := tx.ExecContext(ctx, foreingKeyOff)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, renameTable(`operatorbundle`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, renameTable(`package`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, renameTable(`channel`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, renameTable(`channel_entry`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, renameTable(`api_provider`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, renameTable(`related_image`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, renameTable(`api_requirer`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, createNewOperatorBundleTable)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, createNewPackageTable)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, createNewChannelTable)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, createNewChannelEntryTable)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, createNewAPIProviderTable)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, createNewRelatedImageTable)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, createNewAPIRequirerTable)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, newTableTransfer(`operatorbundle`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, dropTable(`operatorbundle`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, newTableTransfer(`package`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, dropTable(`package`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, newTableTransfer(`channel`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, dropTable(`channel`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, newTableTransfer(`channel_entry`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, dropTable(`channel_entry`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, newTableTransfer(`api_provider`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, dropTable(`api_provider`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, newTableTransfer(`related_image`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, dropTable(`related_image`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, newTableTransfer(`api_requirer`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, dropTable(`api_requirer`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, foreingKeyOn)
+		return err
+	},
+	Down: func(ctx context.Context, tx *sql.Tx) error {
+		foreingKeyOff := `PRAGMA foreign_keys = 0`
+		renameTable := func(table string) string {
+			return `ALTER TABLE ` + table + ` RENAME TO ` + table + `_old;`
+		}
+		createBackupOperatorBundleTable := `
+		CREATE TABLE operatorbundle (
+			name TEXT PRIMARY KEY,
+			csv TEXT UNIQUE,
+			bundle TEXT,
+			bundlepath TEXT);`
+		createBackupPackageTable := `
+		CREATE TABLE IF NOT EXISTS package (
+			name TEXT PRIMARY KEY,
+			default_channel TEXT,
+			FOREIGN KEY(name, default_channel) REFERENCES channel(package_name,name)
+		);`
+		createBackupChannelTable := `
+		CREATE TABLE IF NOT EXISTS channel (
+			name TEXT,
+			package_name TEXT,
+			head_operatorbundle_name TEXT,
+			PRIMARY KEY(name, package_name),
+			FOREIGN KEY(package_name) REFERENCES package(name),
+			FOREIGN KEY(head_operatorbundle_name) REFERENCES operatorbundle(name)
+		);`
+		createBackupChannelEntryTable := `
+		CREATE TABLE IF NOT EXISTS channel_entry (
+			entry_id INTEGER PRIMARY KEY,
+			channel_name TEXT,
+			package_name TEXT,
+			operatorbundle_name TEXT,
+			replaces INTEGER,
+			depth INTEGER,
+			FOREIGN KEY(replaces) REFERENCES channel_entry(entry_id)  DEFERRABLE INITIALLY DEFERRED,
+			FOREIGN KEY(channel_name, package_name) REFERENCES channel(name, package_name)
+		);`
+		createBackupAPIProviderTable := `
+		CREATE TABLE IF NOT EXISTS api_provider (
+			group_name TEXT,
+			version TEXT,
+			kind TEXT,
+			channel_entry_id INTEGER,
+			FOREIGN KEY(channel_entry_id) REFERENCES channel_entry(entry_id),
+			FOREIGN KEY(group_name, version, kind) REFERENCES api(group_name, version, kind)
+		);`
+		createBackupRelatedImageTable := `
+		CREATE TABLE IF NOT EXISTS related_image (
+			image TEXT,
+     		operatorbundle_name TEXT,
+     		FOREIGN KEY(operatorbundle_name) REFERENCES operatorbundle(name)
+		);`
+		createBackupAPIRequirerTable := `
+		CREATE TABLE IF NOT EXISTS api_requirer (
+			group_name TEXT,
+			version TEXT,
+			kind TEXT,
+			channel_entry_id INTEGER,
+			FOREIGN KEY(channel_entry_id) REFERENCES channel_entry(entry_id),
+			FOREIGN KEY(group_name, version, kind) REFERENCES api(group_name, version, kind)
+		);`
+		backupTableTransfer := func(table string) string {
+			return `INSERT INTO ` + table + ` SELECT * FROM "` + table + `_old"`
+		}
+		dropTable := func(table string) string {
+			return `DROP TABLE "` + table + `_old"`
+		}
+
+		foreingKeyOn := `PRAGMA foreign_keys = 1`
+
+		_, err := tx.ExecContext(ctx, foreingKeyOff)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, renameTable(`operatorbundle`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, renameTable(`package`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, renameTable(`channel`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, renameTable(`channel_entry`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, renameTable(`api_provider`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, renameTable(`related_image`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, renameTable(`api_requirer`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, createBackupOperatorBundleTable)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, createBackupPackageTable)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, createBackupChannelTable)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, createBackupChannelEntryTable)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, createBackupAPIProviderTable)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, createBackupRelatedImageTable)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, createBackupAPIRequirerTable)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, backupTableTransfer(`operatorbundle`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, dropTable(`operatorbundle`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, backupTableTransfer(`package`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, dropTable(`package`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, backupTableTransfer(`channel`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, dropTable(`channel`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, backupTableTransfer(`channel_entry`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, dropTable(`channel_entry`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, backupTableTransfer(`api_provider`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, dropTable(`api_provider`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, backupTableTransfer(`related_image`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, dropTable(`related_image`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, backupTableTransfer(`api_requirer`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, dropTable(`api_requirer`))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, foreingKeyOn)
+		return err
+	},
+}

--- a/pkg/sqlite/migrations/004_cascade_delete_test.go
+++ b/pkg/sqlite/migrations/004_cascade_delete_test.go
@@ -1,0 +1,318 @@
+package migrations_test
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/operator-framework/operator-registry/pkg/sqlite/migrations"
+)
+
+func TestBeforeCascadeDeleteUp(t *testing.T) {
+	// migrate up to, but not including, this migration
+	db, _, cleanup := CreateTestDbAt(t, migrations.CascadeDeleteMigrationKey-1)
+	defer cleanup()
+
+	tx, err := db.Begin()
+	require.NoError(t, err)
+
+	err = checkMigrationInPreviousState(t, tx)
+	require.NoError(t, err)
+}
+
+func TestAfterCascadeDeleteUp(t *testing.T) {
+	// migrate up to, but not including, this migration
+	db, migrator, cleanup := CreateTestDbAt(t, migrations.CascadeDeleteMigrationKey-1)
+	defer cleanup()
+
+	// run up migration
+	err := migrator.Up(context.TODO(), migrations.Only(migrations.CascadeDeleteMigrationKey))
+	require.NoError(t, err)
+
+	tx, err := db.Begin()
+	require.NoError(t, err)
+
+	err = checkMigrationInNextState(t, tx)
+	require.NoError(t, err)
+}
+
+func TestBeforeCascadeDeleteDown(t *testing.T) {
+	db, _, cleanup := CreateTestDbAt(t, migrations.CascadeDeleteMigrationKey)
+	defer cleanup()
+
+	tx, err := db.Begin()
+	require.NoError(t, err)
+
+	err = checkMigrationInNextState(t, tx)
+	require.NoError(t, err)
+}
+
+func TestAferCascadeDeleteDown(t *testing.T) {
+	db, migrator, cleanup := CreateTestDbAt(t, migrations.CascadeDeleteMigrationKey)
+	defer cleanup()
+
+	// run down migration
+	err := migrator.Down(context.TODO(), migrations.Only(migrations.CascadeDeleteMigrationKey))
+	require.NoError(t, err)
+
+	tx, err := db.Begin()
+	require.NoError(t, err)
+
+	err = checkMigrationInPreviousState(t, tx)
+	require.NoError(t, err)
+}
+
+func removeWhiteSpaces(s string) string {
+	unwanted := []string{" ", "\n", "\t"}
+	for _, char := range unwanted {
+		s = strings.Replace(s, char, "", -1)
+	}
+	return s
+}
+
+func checkMigrationInPreviousState(t *testing.T, tx *sql.Tx) error {
+	getCreateTableStatement := func(table string) string {
+		return `SELECT sql FROM sqlite_master where name="` + table + `"`
+	}
+
+	createNewOperatorBundleTable := `CREATE TABLE operatorbundle (
+			name TEXT PRIMARY KEY,
+			csv TEXT UNIQUE,
+			bundle TEXT,
+			bundlepath TEXT)`
+	createNewPackageTable := `CREATE TABLE package (
+			name TEXT PRIMARY KEY,
+			default_channel TEXT,
+			FOREIGN KEY(name, default_channel) REFERENCES channel(package_name,name)
+		)`
+	createNewChannelTable := `CREATE TABLE channel (
+			name TEXT,
+			package_name TEXT,
+			head_operatorbundle_name TEXT,
+			PRIMARY KEY(name, package_name),
+			FOREIGN KEY(package_name) REFERENCES package(name),
+			FOREIGN KEY(head_operatorbundle_name) REFERENCES operatorbundle(name)
+		)`
+	createNewChannelEntryTable := `CREATE TABLE channel_entry (
+			entry_id INTEGER PRIMARY KEY,
+			channel_name TEXT,
+			package_name TEXT,
+			operatorbundle_name TEXT,
+			replaces INTEGER,
+			depth INTEGER,
+			FOREIGN KEY(replaces) REFERENCES channel_entry(entry_id)  DEFERRABLE INITIALLY DEFERRED,
+			FOREIGN KEY(channel_name, package_name) REFERENCES channel(name, package_name)
+		)`
+	createNewAPIProviderTable := `CREATE TABLE api_provider (
+			group_name TEXT,
+			version TEXT,
+			kind TEXT,
+			channel_entry_id INTEGER,
+			FOREIGN KEY(channel_entry_id) REFERENCES channel_entry(entry_id),
+			FOREIGN KEY(group_name, version, kind) REFERENCES api(group_name, version, kind)
+		)`
+	createNewRelatedImageTable := `CREATE TABLE related_image (
+			image TEXT,
+     		operatorbundle_name TEXT,
+     		FOREIGN KEY(operatorbundle_name) REFERENCES operatorbundle(name)
+		)`
+	createNewAPIRequirerTable := `CREATE TABLE api_requirer (
+			group_name TEXT,
+			version TEXT,
+			kind TEXT,
+			channel_entry_id INTEGER,
+			FOREIGN KEY(channel_entry_id) REFERENCES channel_entry(entry_id),
+			FOREIGN KEY(group_name, version, kind) REFERENCES api(group_name, version, kind)
+		)`
+	var createStatement string
+
+	table, err := tx.Query(getCreateTableStatement("operatorbundle"))
+	hasRows := table.Next()
+	require.True(t, hasRows)
+	err = table.Scan(&createStatement)
+	require.NoError(t, err)
+	require.Equal(t, removeWhiteSpaces(createNewOperatorBundleTable), removeWhiteSpaces(createStatement))
+	err = table.Close()
+	require.NoError(t, err)
+
+	table, err = tx.Query(getCreateTableStatement("package"))
+	hasRows = table.Next()
+	require.True(t, hasRows)
+	err = table.Scan(&createStatement)
+	require.NoError(t, err)
+	require.Equal(t, removeWhiteSpaces(createNewPackageTable), removeWhiteSpaces(createStatement))
+	err = table.Close()
+	require.NoError(t, err)
+
+	table, err = tx.Query(getCreateTableStatement("channel"))
+	hasRows = table.Next()
+	require.True(t, hasRows)
+	err = table.Scan(&createStatement)
+	require.NoError(t, err)
+	require.Equal(t, removeWhiteSpaces(createNewChannelTable), removeWhiteSpaces(createStatement))
+	err = table.Close()
+	require.NoError(t, err)
+
+	table, err = tx.Query(getCreateTableStatement("channel_entry"))
+	hasRows = table.Next()
+	require.True(t, hasRows)
+	err = table.Scan(&createStatement)
+	require.NoError(t, err)
+	require.Equal(t, removeWhiteSpaces(createNewChannelEntryTable), removeWhiteSpaces(createStatement))
+	err = table.Close()
+	require.NoError(t, err)
+
+	table, err = tx.Query(getCreateTableStatement("api_requirer"))
+	hasRows = table.Next()
+	require.True(t, hasRows)
+	err = table.Scan(&createStatement)
+	require.NoError(t, err)
+	require.Equal(t, removeWhiteSpaces(createNewAPIRequirerTable), removeWhiteSpaces(createStatement))
+	err = table.Close()
+	require.NoError(t, err)
+
+	table, err = tx.Query(getCreateTableStatement("api_provider"))
+	hasRows = table.Next()
+	require.True(t, hasRows)
+	err = table.Scan(&createStatement)
+	require.NoError(t, err)
+	require.Equal(t, removeWhiteSpaces(createNewAPIProviderTable), removeWhiteSpaces(createStatement))
+	err = table.Close()
+	require.NoError(t, err)
+
+	table, err = tx.Query(getCreateTableStatement("related_image"))
+	hasRows = table.Next()
+	require.True(t, hasRows)
+	err = table.Scan(&createStatement)
+	require.NoError(t, err)
+	require.Equal(t, removeWhiteSpaces(createNewRelatedImageTable), removeWhiteSpaces(createStatement))
+	err = table.Close()
+	require.NoError(t, err)
+
+	return nil
+}
+
+func checkMigrationInNextState(t *testing.T, tx *sql.Tx) error {
+	getCreateTableStatement := func(table string) string {
+		return `SELECT sql FROM sqlite_master where name="` + table + `"`
+	}
+	createNewOperatorBundleTable := `CREATE TABLE operatorbundle (
+			name TEXT PRIMARY KEY,
+			csv TEXT,
+			bundle TEXT,
+			bundlepath TEXT)`
+	createNewPackageTable := `CREATE TABLE package (
+			name TEXT PRIMARY KEY,
+			default_channel TEXT,
+			FOREIGN KEY(name, default_channel) REFERENCES channel(package_name,name) ON DELETE CASCADE
+		)`
+	createNewChannelTable := `CREATE TABLE channel (
+			name TEXT,
+			package_name TEXT,
+			head_operatorbundle_name TEXT,
+			PRIMARY KEY(name, package_name),
+			FOREIGN KEY(head_operatorbundle_name) REFERENCES operatorbundle(name) ON DELETE CASCADE
+		)`
+	createNewChannelEntryTable := `CREATE TABLE channel_entry (
+			entry_id INTEGER PRIMARY KEY,
+			channel_name TEXT,
+			package_name TEXT,
+			operatorbundle_name TEXT,
+			replaces INTEGER,
+			depth INTEGER,
+			FOREIGN KEY(replaces) REFERENCES channel_entry(entry_id) DEFERRABLE INITIALLY DEFERRED, 
+			FOREIGN KEY(channel_name, package_name) REFERENCES channel(name, package_name) ON DELETE CASCADE
+		)`
+	createNewAPIProviderTable := `CREATE TABLE api_provider (
+			group_name TEXT,
+			version TEXT,
+			kind TEXT,
+			channel_entry_id INTEGER,
+			PRIMARY KEY(group_name, version, kind, channel_entry_id),
+			FOREIGN KEY(channel_entry_id) REFERENCES channel_entry(entry_id) ON DELETE CASCADE,
+			FOREIGN KEY(group_name, version, kind) REFERENCES api(group_name, version, kind)
+		)`
+	createNewRelatedImageTable := `CREATE TABLE related_image (
+			image TEXT,
+     		operatorbundle_name TEXT,
+     		FOREIGN KEY(operatorbundle_name) REFERENCES operatorbundle(name) ON DELETE CASCADE
+		)`
+	createNewAPIRequirerTable := `CREATE TABLE api_requirer (
+			group_name TEXT,
+			version TEXT,
+			kind TEXT,
+			channel_entry_id INTEGER,
+			PRIMARY KEY(group_name, version, kind, channel_entry_id),
+			FOREIGN KEY(channel_entry_id) REFERENCES channel_entry(entry_id) ON DELETE CASCADE,
+			FOREIGN KEY(group_name, version, kind) REFERENCES api(group_name, version, kind)
+		)`
+	var createStatement string
+
+	table, err := tx.Query(getCreateTableStatement("operatorbundle"))
+	hasRows := table.Next()
+	require.True(t, hasRows)
+	err = table.Scan(&createStatement)
+	require.NoError(t, err)
+	require.Equal(t, removeWhiteSpaces(createNewOperatorBundleTable), removeWhiteSpaces(createStatement))
+	err = table.Close()
+	require.NoError(t, err)
+
+	table, err = tx.Query(getCreateTableStatement("package"))
+	hasRows = table.Next()
+	require.True(t, hasRows)
+	err = table.Scan(&createStatement)
+	require.NoError(t, err)
+	require.Equal(t, removeWhiteSpaces(createNewPackageTable), removeWhiteSpaces(createStatement))
+	err = table.Close()
+	require.NoError(t, err)
+
+	table, err = tx.Query(getCreateTableStatement("channel"))
+	hasRows = table.Next()
+	require.True(t, hasRows)
+	err = table.Scan(&createStatement)
+	require.NoError(t, err)
+	require.Equal(t, removeWhiteSpaces(createNewChannelTable), removeWhiteSpaces(createStatement))
+	err = table.Close()
+	require.NoError(t, err)
+
+	table, err = tx.Query(getCreateTableStatement("channel_entry"))
+	hasRows = table.Next()
+	require.True(t, hasRows)
+	err = table.Scan(&createStatement)
+	require.NoError(t, err)
+	require.Equal(t, removeWhiteSpaces(createNewChannelEntryTable), removeWhiteSpaces(createStatement))
+	err = table.Close()
+	require.NoError(t, err)
+
+	table, err = tx.Query(getCreateTableStatement("api_requirer"))
+	hasRows = table.Next()
+	require.True(t, hasRows)
+	err = table.Scan(&createStatement)
+	require.NoError(t, err)
+	require.Equal(t, removeWhiteSpaces(createNewAPIRequirerTable), removeWhiteSpaces(createStatement))
+	err = table.Close()
+	require.NoError(t, err)
+
+	table, err = tx.Query(getCreateTableStatement("api_provider"))
+	hasRows = table.Next()
+	require.True(t, hasRows)
+	err = table.Scan(&createStatement)
+	require.NoError(t, err)
+	require.Equal(t, removeWhiteSpaces(createNewAPIProviderTable), removeWhiteSpaces(createStatement))
+	err = table.Close()
+	require.NoError(t, err)
+
+	table, err = tx.Query(getCreateTableStatement("related_image"))
+	hasRows = table.Next()
+	require.True(t, hasRows)
+	err = table.Scan(&createStatement)
+	require.NoError(t, err)
+	require.Equal(t, removeWhiteSpaces(createNewRelatedImageTable), removeWhiteSpaces(createStatement))
+	err = table.Close()
+	require.NoError(t, err)
+
+	return nil
+}

--- a/pkg/sqlite/remove.go
+++ b/pkg/sqlite/remove.go
@@ -1,0 +1,67 @@
+package sqlite
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"github.com/operator-framework/operator-registry/pkg/registry"
+)
+
+type SQLRemover interface {
+	Remove() error
+}
+
+// PackageRemover removes a package from the database
+type PackageRemover struct {
+	store    registry.Load
+	packages string
+}
+
+var _ SQLRemover = &PackageRemover{}
+
+func NewSQLRemoverForPackages(store registry.Load, packages string) *PackageRemover {
+	return &PackageRemover{
+		store:    store,
+		packages: packages,
+	}
+}
+
+func (d *PackageRemover) Remove() error {
+	log := logrus.WithField("pkg", d.packages)
+
+	log.Info("deleting packages")
+
+	var errs []error
+	packages := sanitizePackageList(strings.Split(d.packages, ","))
+	log.Info("input has been sanitized")
+	log.Infof("packages: %s", packages)
+
+	for _, pkg := range packages {
+		if err := d.store.RmPackageName(pkg); err != nil {
+			errs = append(errs, fmt.Errorf("error removing operator package %s: %s", pkg, err))
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
+// sanitizePackageList sanitizes the set of package(s) specified. It removes
+// duplicates and ignores empty string.
+func sanitizePackageList(in []string) []string {
+	out := make([]string, 0)
+
+	inMap := map[string]bool{}
+	for _, item := range in {
+		if _, ok := inMap[item]; ok || item == "" {
+			continue
+		}
+
+		inMap[item] = true
+		out = append(out, item)
+	}
+
+	return out
+}

--- a/pkg/sqlite/remove_test.go
+++ b/pkg/sqlite/remove_test.go
@@ -1,0 +1,65 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemover(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+	db, cleanup := CreateTestDb(t)
+	defer cleanup()
+	store, err := NewSQLLiteLoader(db)
+	require.NoError(t, err)
+	require.NoError(t, store.Migrate(context.TODO()))
+
+	image := "quay.io/test/"
+	etcdFirstVersion := &ImageLoader{
+		store:     store,
+		image:     image + "etcd.0.9.0",
+		directory: "../../bundles/etcd.0.9.0",
+	}
+	require.NoError(t, etcdFirstVersion.LoadBundleFunc())
+
+	etcdNextVersion := &ImageLoader{
+		store:     store,
+		image:     image + "etcd.0.9.2",
+		directory: "../../bundles/etcd.0.9.2",
+	}
+	require.NoError(t, etcdNextVersion.LoadBundleFunc())
+
+	prometheusFirstVersion := &ImageLoader{
+		store:     store,
+		image:     image + "prometheus.0.14.0",
+		directory: "../../bundles/prometheus.0.14.0",
+	}
+	require.NoError(t, prometheusFirstVersion.LoadBundleFunc())
+
+	prometheusSecondVersion := &ImageLoader{
+		store:     store,
+		image:     image + "prometheus.0.15.0",
+		directory: "../../bundles/prometheus.0.15.0",
+	}
+	require.NoError(t, prometheusSecondVersion.LoadBundleFunc())
+
+	prometheusThirdVersion := &ImageLoader{
+		store:     store,
+		image:     image + "prometheus.0.22.2",
+		directory: "../../bundles/prometheus.0.22.2",
+	}
+	require.NoError(t, prometheusThirdVersion.LoadBundleFunc())
+
+	// delete everything
+	require.NoError(t, store.RmPackageName("etcd"))
+	require.NoError(t, store.RmPackageName("prometheus"))
+
+	// and insert again
+	require.NoError(t, etcdFirstVersion.LoadBundleFunc())
+	require.NoError(t, etcdNextVersion.LoadBundleFunc())
+	require.NoError(t, prometheusFirstVersion.LoadBundleFunc())
+	require.NoError(t, prometheusSecondVersion.LoadBundleFunc())
+	require.NoError(t, prometheusThirdVersion.LoadBundleFunc())
+}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Adding a new cli to operator-registry called `opm`. It can add bundles to a database, delete packages from that db and serve its contents at a specified host and port.

Having built the binaries, a user can run the old binaries

```
./bin/initializer ...
./bin/appregistry-server ...
./bin/registry-server ...
./bin/configmap-server ...
```

or can use the new cli that supports (and will support) our new operator bundle format. Here is an example flow:

Build the database (or add to an existing one) using

```
./bin/opm registry add -d=bundles.db -b="quay.io/username/imagename,quay.io/username/otherimagename"
```

Remove operators from an existing db using

```
./bin/opm registry rm -d=bundles.db -o="operator-package-name"
```

Serve the db using (can optionally specify a host and port)

```
./bin/opm registry serve -t=path/to/file.log -d=bundles.db
```

**Motivation for the change:**

This is a first step toward creating new commands to interface with operator-registry as part of its corresponding epic.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
