### PR TITLE
Bug 1751388: fix(query): return all channels when querying

### DIFF
--- a/manifests/etcd/etcd.package.yaml
+++ b/manifests/etcd/etcd.package.yaml
@@ -1,5 +1,10 @@
 #! package-manifest: ./deploy/chart/catalog_resources/rh-operators/etcdoperator.v0.9.2.clusterserviceversion.yaml
 packageName: etcd
+defaultChannel: alpha
 channels:
 - name: alpha
+  currentCSV: etcdoperator.v0.9.2
+- name: beta
+  currentCSV: etcdoperator.v0.9.0
+- name: stable
   currentCSV: etcdoperator.v0.9.2

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -106,6 +106,14 @@ func TestGetPackage(t *testing.T) {
 				Name:    "alpha",
 				CsvName: "etcdoperator.v0.9.2",
 			},
+			{
+				Name:    "beta",
+				CsvName: "etcdoperator.v0.9.0",
+			},
+			{
+				Name:    "stable",
+				CsvName: "etcdoperator.v0.9.2",
+			},
 		},
 		DefaultChannelName: "alpha",
 	}
@@ -185,6 +193,18 @@ func TestGetChannelEntriesThatReplace(t *testing.T) {
 		{
 			PackageName: "etcd",
 			ChannelName: "alpha",
+			BundleName:  "etcdoperator.v0.9.0",
+			Replaces:    "etcdoperator.v0.6.1",
+		},
+		{
+			PackageName: "etcd",
+			ChannelName: "beta",
+			BundleName:  "etcdoperator.v0.9.0",
+			Replaces:    "etcdoperator.v0.6.1",
+		},
+		{
+			PackageName: "etcd",
+			ChannelName: "stable",
 			BundleName:  "etcdoperator.v0.9.0",
 			Replaces:    "etcdoperator.v0.6.1",
 		},
@@ -288,6 +308,42 @@ func TestGetChannelEntriesThatProvide(t *testing.T) {
 			BundleName:  "etcdoperator.v0.9.2",
 			Replaces:    "etcdoperator.v0.9.0",
 		},
+		{
+			PackageName: "etcd",
+			ChannelName: "beta",
+			BundleName:  "etcdoperator.v0.6.1",
+			Replaces:    "",
+		},
+		{
+			PackageName: "etcd",
+			ChannelName: "beta",
+			BundleName:  "etcdoperator.v0.9.0",
+			Replaces:    "etcdoperator.v0.6.1",
+		},
+		{
+			PackageName: "etcd",
+			ChannelName: "stable",
+			BundleName:  "etcdoperator.v0.6.1",
+			Replaces:    "",
+		},
+		{
+			PackageName: "etcd",
+			ChannelName: "stable",
+			BundleName:  "etcdoperator.v0.9.0",
+			Replaces:    "etcdoperator.v0.6.1",
+		},
+		{
+			PackageName: "etcd",
+			ChannelName: "stable",
+			BundleName:  "etcdoperator.v0.9.2",
+			Replaces:    "etcdoperator.v0.9.1",
+		},
+		{
+			PackageName: "etcd",
+			ChannelName: "stable",
+			BundleName:  "etcdoperator.v0.9.2",
+			Replaces:    "etcdoperator.v0.9.0",
+		},
 	}
 
 	require.ElementsMatch(t, expected, channelEntries)
@@ -324,6 +380,18 @@ func TestGetLatestChannelEntriesThatProvide(t *testing.T) {
 		{
 			PackageName: "etcd",
 			ChannelName: "alpha",
+			BundleName:  "etcdoperator.v0.9.2",
+			Replaces:    "etcdoperator.v0.9.0",
+		},
+		{
+			PackageName: "etcd",
+			ChannelName: "beta",
+			BundleName:  "etcdoperator.v0.9.0",
+			Replaces:    "etcdoperator.v0.6.1",
+		},
+		{
+			PackageName: "etcd",
+			ChannelName: "stable",
 			BundleName:  "etcdoperator.v0.9.2",
 			Replaces:    "etcdoperator.v0.9.0",
 		},

--- a/pkg/sqlite/directory_test.go
+++ b/pkg/sqlite/directory_test.go
@@ -47,6 +47,14 @@ func TestQuerierForDirectory(t *testing.T) {
 				Name:           "alpha",
 				CurrentCSVName: "etcdoperator.v0.9.2",
 			},
+			{
+				Name:           "beta",
+				CurrentCSVName: "etcdoperator.v0.9.0",
+			},
+			{
+				Name:           "stable",
+				CurrentCSVName: "etcdoperator.v0.9.2",
+			},
 		},
 	}, etcdPackage)
 
@@ -61,7 +69,7 @@ func TestQuerierForDirectory(t *testing.T) {
 
 	etcdChannelEntries, err := store.GetChannelEntriesThatReplace(context.TODO(), "etcdoperator.v0.9.0")
 	require.NoError(t, err)
-	require.ElementsMatch(t, []*registry.ChannelEntry{{"etcd", "alpha", "etcdoperator.v0.9.2", "etcdoperator.v0.9.0"}}, etcdChannelEntries)
+	require.ElementsMatch(t, []*registry.ChannelEntry{{"etcd", "alpha", "etcdoperator.v0.9.2", "etcdoperator.v0.9.0"},{"etcd", "stable", "etcdoperator.v0.9.2", "etcdoperator.v0.9.0"}}, etcdChannelEntries)
 
 	etcdBundleByReplaces, err := store.GetBundleThatReplaces(context.TODO(), "etcdoperator.v0.9.0", "etcd", "alpha")
 	require.NoError(t, err)
@@ -72,11 +80,22 @@ func TestQuerierForDirectory(t *testing.T) {
 		{"etcd", "alpha", "etcdoperator.v0.6.1", ""},
 		{"etcd", "alpha", "etcdoperator.v0.9.0", "etcdoperator.v0.6.1"},
 		{"etcd", "alpha", "etcdoperator.v0.9.2", "etcdoperator.v0.9.1"},
-		{"etcd", "alpha", "etcdoperator.v0.9.2", "etcdoperator.v0.9.0"}}, etcdChannelEntriesThatProvide)
+		{"etcd", "alpha", "etcdoperator.v0.9.2", "etcdoperator.v0.9.0"},
+
+		{"etcd", "beta", "etcdoperator.v0.6.1", ""},
+	{"etcd", "beta", "etcdoperator.v0.9.0", "etcdoperator.v0.6.1"},
+	{"etcd", "stable", "etcdoperator.v0.6.1", ""},
+	{"etcd", "stable", "etcdoperator.v0.9.0", "etcdoperator.v0.6.1"},
+	{"etcd", "stable", "etcdoperator.v0.9.2", "etcdoperator.v0.9.1"},
+	{"etcd", "stable", "etcdoperator.v0.9.2", "etcdoperator.v0.9.0"},
+	}, etcdChannelEntriesThatProvide)
 
 	etcdLatestChannelEntriesThatProvide, err := store.GetLatestChannelEntriesThatProvide(context.TODO(), "etcd.database.coreos.com", "v1beta2", "EtcdCluster")
 	require.NoError(t, err)
-	require.ElementsMatch(t, []*registry.ChannelEntry{{"etcd", "alpha", "etcdoperator.v0.9.2", "etcdoperator.v0.9.0"}}, etcdLatestChannelEntriesThatProvide)
+	require.ElementsMatch(t, []*registry.ChannelEntry{
+		{"etcd", "alpha", "etcdoperator.v0.9.2", "etcdoperator.v0.9.0"},
+		{"etcd", "beta", "etcdoperator.v0.9.0", "etcdoperator.v0.6.1"},
+		{"etcd", "stable", "etcdoperator.v0.9.2", "etcdoperator.v0.9.0"}}, etcdLatestChannelEntriesThatProvide)
 
 	etcdBundleByProvides, entry, err := store.GetBundleThatProvides(context.TODO(), "etcd.database.coreos.com", "v1beta2", "EtcdCluster")
 	require.NoError(t, err)

--- a/pkg/sqlite/query.go
+++ b/pkg/sqlite/query.go
@@ -94,7 +94,7 @@ func (s *SQLQuerier) GetPackage(ctx context.Context, name string) (*registry.Pac
 		},
 	}
 
-	if rows.Next() {
+	for rows.Next() {
 		if err := rows.Scan(&pkgName, &defaultChannel, &channelName, &bundleName); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

This is a backport of the fix that returns all channels (instead of at most two channels) to the api when querying.

**Motivation for the change:**
Without this change, users have no indication that there are other channels they can subscribe to. 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
