### PR TITLE
fix(sqlite): enable foreign keys for sqlite

### DIFF
--- a/pkg/sqlite/load.go
+++ b/pkg/sqlite/load.go
@@ -35,7 +35,7 @@ func NewSQLLiteLoader(outFilename string) (*SQLLoader, error) {
 	CREATE TABLE IF NOT EXISTS package (
 		name TEXT PRIMARY KEY,
 		default_channel TEXT,
-		FOREIGN KEY(default_channel) REFERENCES channel(name)
+		FOREIGN KEY(name, default_channel) REFERENCES channel(package_name,name)
 	);
 	CREATE TABLE IF NOT EXISTS channel (
 		name TEXT, 
@@ -53,9 +53,7 @@ func NewSQLLiteLoader(outFilename string) (*SQLLoader, error) {
 		replaces INTEGER,
 		depth INTEGER,
 		FOREIGN KEY(replaces) REFERENCES channel_entry(entry_id)  DEFERRABLE INITIALLY DEFERRED, 
-		FOREIGN KEY(channel_name) REFERENCES channel(name),
-		FOREIGN KEY(package_name) REFERENCES channel(package_name),
-		FOREIGN KEY(operatorbundle_name) REFERENCES operatorbundle(name)
+		FOREIGN KEY(channel_name, package_name) REFERENCES channel(name, package_name)
 	);
 	CREATE TABLE IF NOT EXISTS api (
 		group_name TEXT,
@@ -73,6 +71,10 @@ func NewSQLLiteLoader(outFilename string) (*SQLLoader, error) {
 		FOREIGN KEY(group_name, version, kind) REFERENCES api(group_name, version, kind) 
 	);
 	`
+
+	if _, err := db.Exec("PRAGMA foreign_keys = ON", nil); err != nil {
+		return nil, err
+	}
 
 	if _, err = db.Exec(createTable); err != nil {
 		return nil, err


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Foreign key constraints were not being enforced - thanks @gallettilance for finding this issue!

There were a couple of problems with the foreign keys that are fixed in this PR

**Motivation for the change:**
We want to rely on sqlite's enforcement of foreign keys so that we don't need to enforce them ourselves.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
