### PR TITLE
fix(bundle): Fix manifest directory issue in generated Dockerfile

### DIFF
--- a/pkg/lib/bundle/generate.go
+++ b/pkg/lib/bundle/generate.go
@@ -246,7 +246,7 @@ func GenerateDockerfile(directory, mediaType, manifests, metadata, packageName, 
 	fileContent += fmt.Sprintf("LABEL %s=%s\n\n", ChannelDefaultLabel, chanDefault)
 
 	// CONTENT
-	fileContent += fmt.Sprintf("ADD %s %s\n", filepath.Join(directory, "*.yaml"), "/manifests")
+	fileContent += fmt.Sprintf("ADD %s %s\n", filepath.Join(directory, "*.yaml"), "/manifests/")
 	fileContent += fmt.Sprintf("ADD %s %s%s\n", filepath.Join(directory, metadata, AnnotationsFile), "/metadata/", AnnotationsFile)
 
 	return []byte(fileContent), nil

--- a/pkg/lib/bundle/generate_test.go
+++ b/pkg/lib/bundle/generate_test.go
@@ -212,7 +212,7 @@ func TestGenerateDockerfileFunc(t *testing.T) {
 		"LABEL operators.operatorframework.io.bundle.package.v1=test4\n"+
 		"LABEL operators.operatorframework.io.bundle.channels.v1=test5\n"+
 		"LABEL operators.operatorframework.io.bundle.channel.default.v1=test5\n\n"+
-		"ADD %s/*.yaml /manifests\n"+
+		"ADD %s/*.yaml /manifests/\n"+
 		"ADD %s/annotations.yaml /metadata/annotations.yaml\n", MetadataDir, getTestDir(),
 		filepath.Join(getTestDir(), MetadataDir))
 


### PR DESCRIPTION
When using ADD with more than one source file, the destination must
be a directory and end with a "/".

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
