### PR TITLE
fix(bundle): Fix the build parameter order mix-up

### DIFF
--- a/pkg/lib/bundle/build.go
+++ b/pkg/lib/bundle/build.go
@@ -62,7 +62,7 @@ func BuildFunc(directory, imageTag, imageBuilder, packageName, channels, channel
 
 	// Build bundle image
 	log.Info("Building bundle image")
-	buildCmd, err := BuildBundleImage(path.Clean(directory), imageBuilder, imageTag)
+	buildCmd, err := BuildBundleImage(path.Clean(directory), imageTag, imageBuilder)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The imageTag and imageBuilder parameters got mixed-up.

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
