### PR TITLE
feat(imagebuild): add opm binary to registry image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ COPY --from=builder /src/bin/initializer /bin/initializer
 COPY --from=builder /src/bin/registry-server /bin/registry-server
 COPY --from=builder /src/bin/configmap-server /bin/configmap-server
 COPY --from=builder /src/bin/appregistry-server /bin/appregistry-server
+COPY --from=builder /src/bin/opm /bin/opm
 COPY --from=builder /go/bin/grpc_health_probe /bin/grpc_health_probe
 
 RUN chgrp -R 0 /registry && \


### PR DESCRIPTION
The opm command is being added here specifically for use when extracting bundle data from an image.
