### PR TITLE
GRPC client wrapper returns api objects

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -9,14 +9,13 @@ import (
 
 	"github.com/operator-framework/operator-registry/pkg/api"
 	"github.com/operator-framework/operator-registry/pkg/api/grpc_health_v1"
-	"github.com/operator-framework/operator-registry/pkg/registry"
 )
 
 type Interface interface {
-	GetBundle(ctx context.Context, packageName, channelName, csvName string) (*registry.Bundle, error)
-	GetBundleInPackageChannel(ctx context.Context, packageName, channelName string) (*registry.Bundle, error)
-	GetReplacementBundleInPackageChannel(ctx context.Context, currentName, packageName, channelName string) (*registry.Bundle, error)
-	GetBundleThatProvides(ctx context.Context, group, version, kind string) (*registry.Bundle, error)
+	GetBundle(ctx context.Context, packageName, channelName, csvName string) (*api.Bundle, error)
+	GetBundleInPackageChannel(ctx context.Context, packageName, channelName string) (*api.Bundle, error)
+	GetReplacementBundleInPackageChannel(ctx context.Context, currentName, packageName, channelName string) (*api.Bundle, error)
+	GetBundleThatProvides(ctx context.Context, group, version, kind string) (*api.Bundle, error)
 	HealthCheck(ctx context.Context, reconnectTimeout time.Duration) (bool, error)
 	Close() error
 }
@@ -29,40 +28,20 @@ type Client struct {
 
 var _ Interface = &Client{}
 
-func (c *Client) GetBundle(ctx context.Context, packageName, channelName, csvName string) (*registry.Bundle, error) {
-	bundle, err := c.Registry.GetBundle(ctx, &api.GetBundleRequest{PkgName: packageName, ChannelName: channelName, CsvName: csvName})
-	if err != nil {
-		return nil, err
-	}
-	return registry.NewBundleFromStrings(bundle.CsvName, bundle.PackageName, bundle.ChannelName, bundle.Object)
+func (c *Client) GetBundle(ctx context.Context, packageName, channelName, csvName string) (*api.Bundle, error) {
+	return c.Registry.GetBundle(ctx, &api.GetBundleRequest{PkgName: packageName, ChannelName: channelName, CsvName: csvName})
 }
 
-func (c *Client) GetBundleInPackageChannel(ctx context.Context, packageName, channelName string) (*registry.Bundle, error) {
-	bundle, err := c.Registry.GetBundleForChannel(ctx, &api.GetBundleInChannelRequest{PkgName: packageName, ChannelName: channelName})
-	if err != nil {
-		return nil, err
-	}
-	return registry.NewBundleFromStrings(bundle.CsvName, packageName, channelName, bundle.Object)
+func (c *Client) GetBundleInPackageChannel(ctx context.Context, packageName, channelName string) (*api.Bundle, error) {
+	return c.Registry.GetBundleForChannel(ctx, &api.GetBundleInChannelRequest{PkgName: packageName, ChannelName: channelName})
 }
 
-func (c *Client) GetReplacementBundleInPackageChannel(ctx context.Context, currentName, packageName, channelName string) (*registry.Bundle, error) {
-	bundle, err := c.Registry.GetBundleThatReplaces(ctx, &api.GetReplacementRequest{CsvName: currentName, PkgName: packageName, ChannelName: channelName})
-	if err != nil {
-		return nil, err
-	}
-	return registry.NewBundleFromStrings(bundle.CsvName, packageName, channelName, bundle.Object)
+func (c *Client) GetReplacementBundleInPackageChannel(ctx context.Context, currentName, packageName, channelName string) (*api.Bundle, error) {
+	return c.Registry.GetBundleThatReplaces(ctx, &api.GetReplacementRequest{CsvName: currentName, PkgName: packageName, ChannelName: channelName})
 }
 
-func (c *Client) GetBundleThatProvides(ctx context.Context, group, version, kind string) (*registry.Bundle, error) {
-	bundle, err := c.Registry.GetDefaultBundleThatProvides(ctx, &api.GetDefaultProviderRequest{Group: group, Version: version, Kind: kind})
-	if err != nil {
-		return nil, err
-	}
-	parsedBundle, err := registry.NewBundleFromStrings(bundle.CsvName, bundle.PackageName, bundle.ChannelName, bundle.Object)
-	if err != nil {
-		return nil, err
-	}
-	return parsedBundle, nil
+func (c *Client) GetBundleThatProvides(ctx context.Context, group, version, kind string) (*api.Bundle, error) {
+	return c.Registry.GetDefaultBundleThatProvides(ctx, &api.GetDefaultProviderRequest{Group: group, Version: version, Kind: kind})
 }
 
 func (c *Client) Close() error {


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This changes the client wrapper to return the grpc api objects directly, instead of abstracting them with the `registry.Bundle` object.

**Motivation for the change:**
The registry.Bundle object is not a particularly useful abstraction now that the api is returning data directly (instead of returning a CSV that is then parsed for the data). On the OLM side, we just want to use the fields on the object directly instead of calculating them, when possible.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
