### PR TITLE
fix(builder): Add AppRegistry org to `ToOption`

### DIFF
--- a/pkg/appregistry/builder_options.go
+++ b/pkg/appregistry/builder_options.go
@@ -56,16 +56,21 @@ func (o *AppregistryBuildOptions) Complete() error {
 
 	// build a separate path for manifests and the built database, so that
 	// building is idempotent
-	manifestDir, err := ioutil.TempDir("", "manifests-")
-	if err != nil {
-		return err
+	if o.ManifestDir == "" {
+		manifestDir, err := ioutil.TempDir("", "manifests-")
+		if err != nil {
+			return err
+		}
+		o.ManifestDir = manifestDir
 	}
-	o.ManifestDir = manifestDir
-	databaseDir, err := ioutil.TempDir("", "db-")
-	if err != nil {
-		return err
+
+	if o.DatabaseDir == "" {
+		databaseDir, err := ioutil.TempDir("", "db-")
+		if err != nil {
+			return err
+		}
+		o.DatabaseDir = databaseDir
 	}
-	o.DatabaseDir = databaseDir
 
 	if o.DatabasePath == "" {
 		o.DatabasePath = path.Join(o.DatabaseDir, "bundles.db")
@@ -96,6 +101,9 @@ func (c *AppregistryBuildOptions) ToOption() AppregistryBuildOption {
 		if c.AuthToken != "" {
 			o.AuthToken = c.AuthToken
 		}
+		if c.AppRegistryOrg != "" {
+			o.AppRegistryOrg = c.AppRegistryOrg
+		}
 		if c.AppRegistryEndpoint != "" {
 			o.AppRegistryEndpoint = c.AppRegistryEndpoint
 		}
@@ -104,6 +112,9 @@ func (c *AppregistryBuildOptions) ToOption() AppregistryBuildOption {
 		}
 		if c.CacheDir != "" {
 			o.CacheDir = c.CacheDir
+		}
+		if c.DatabaseDir != "" {
+			o.DatabaseDir = c.DatabaseDir
 		}
 	}
 }


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
The appregistry org isn't being copied over when converting to an optionfunction.

**Motivation for the change:**
Fixes building from oc adm catalog

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
