### PR TITLE
Add bundle image validation feature to bundle library and bundle cli

### DIFF
--- a/cmd/opm/alpha/bundle/cmd.go
+++ b/cmd/opm/alpha/bundle/cmd.go
@@ -13,6 +13,7 @@ func NewCmd() *cobra.Command {
 
 	runCmd.AddCommand(newBundleGenerateCmd())
 	runCmd.AddCommand(newBundleBuildCmd())
+	runCmd.AddCommand(newBundleValidateCmd())
 	runCmd.AddCommand(extractCmd)
 	return runCmd
 }

--- a/cmd/opm/alpha/bundle/validate.go
+++ b/cmd/opm/alpha/bundle/validate.go
@@ -1,0 +1,40 @@
+package bundle
+
+import (
+	"github.com/operator-framework/operator-registry/pkg/lib/bundle"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func newBundleValidateCmd() *cobra.Command {
+	bundleValidateCmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate bundle image",
+		Long: `The "opm alpha bundle validate" command will validate bundle image
+    from a remote source to determine if its format and content information are
+    accurate.
+
+        $ opm alpha bundle validate --tag quay.io/test/test-operator:latest \
+		--image-builder docker`,
+		RunE: validateFunc,
+	}
+
+	bundleValidateCmd.Flags().StringVarP(&tagBuildArgs, "tag", "t", "",
+		"The path of a registry to pull from, image name and its tag that present the bundle image (e.g. quay.io/test/test-operator:latest)")
+	if err := bundleValidateCmd.MarkFlagRequired("tag"); err != nil {
+		log.Fatalf("Failed to mark `tag` flag for `validate` subcommand as required")
+	}
+
+	bundleValidateCmd.Flags().StringVarP(&imageBuilderArgs, "image-builder", "b", "docker", "Tool to build container images. One of: [docker, podman]")
+
+	return bundleValidateCmd
+}
+
+func validateFunc(cmd *cobra.Command, args []string) error {
+	err := bundle.ValidateFunc(tagBuildArgs, imageBuilderArgs)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/lib/bundle/untar.go
+++ b/pkg/lib/bundle/untar.go
@@ -1,0 +1,100 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package untar untars a tarball to disk.
+package bundle
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// Untar reads the tar file from r and writes it into dir.
+func Untar(r io.Reader, dir string) error {
+	return untar(r, dir)
+}
+
+func untar(r io.Reader, dir string) (err error) {
+	madeDir := map[string]bool{}
+
+	tr := tar.NewReader(r)
+	for {
+		f, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			log.Printf("tar reading error: %v", err)
+			return fmt.Errorf("tar error: %v", err)
+		}
+		if !validRelPath(f.Name) {
+			return fmt.Errorf("tar contained invalid name error %q", f.Name)
+		}
+		rel := filepath.FromSlash(f.Name)
+		abs := filepath.Join(dir, rel)
+
+		fi := f.FileInfo()
+		mode := fi.Mode()
+		switch {
+		case mode.IsRegular():
+			// Make the directory. This is redundant because it should
+			// already be made by a directory entry in the tar
+			// beforehand. Thus, don't check for errors; the next
+			// write will fail with the same error.
+			dir := filepath.Dir(abs)
+			if !madeDir[dir] {
+				if err := os.MkdirAll(filepath.Dir(abs), 0755); err != nil {
+					return err
+				}
+				madeDir[dir] = true
+			}
+			wf, err := os.OpenFile(abs, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode.Perm())
+			if err != nil {
+				return err
+			}
+			n, err := io.Copy(wf, tr)
+			if closeErr := wf.Close(); closeErr != nil && err == nil {
+				err = closeErr
+			}
+			if err != nil {
+				return fmt.Errorf("error writing to %s: %v", abs, err)
+			}
+			if n != f.Size {
+				return fmt.Errorf("only wrote %d bytes to %s; expected %d", n, abs, f.Size)
+			}
+		case mode.IsDir():
+			if err := os.MkdirAll(abs, 0755); err != nil {
+				return err
+			}
+			madeDir[abs] = true
+		default:
+			return fmt.Errorf("tar file entry %s contained unsupported file type %v", f.Name, mode)
+		}
+	}
+	return nil
+}
+
+func validRelativeDir(dir string) bool {
+	if strings.Contains(dir, `\`) || path.IsAbs(dir) {
+		return false
+	}
+	dir = path.Clean(dir)
+	if strings.HasPrefix(dir, "../") || strings.HasSuffix(dir, "/..") || dir == ".." {
+		return false
+	}
+	return true
+}
+
+func validRelPath(p string) bool {
+	if p == "" || strings.Contains(p, `\`) || strings.HasPrefix(p, "/") || strings.Contains(p, "../") {
+		return false
+	}
+	return true
+}

--- a/pkg/lib/bundle/validate.go
+++ b/pkg/lib/bundle/validate.go
@@ -1,0 +1,256 @@
+package bundle
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	FileStoreDir     = "bundle-"
+	BundleTarFile    = "bundle.tar"
+	ManifestJsonFile = "manifest.json"
+)
+
+type ManifestJson struct {
+	Config string   `json:"Config"`
+	Layers []string `json:"Layers"`
+}
+
+type LabelsJson struct {
+	Config ConfigData `json:"config"`
+}
+
+type ConfigData struct {
+	Labels map[string]string `json:"Labels"`
+}
+
+// ValidateFunc is used to validate bundle container image.
+// Inputs:
+// @imageTag: The image tag that is applied to the bundle image
+// @imageBuilder: The image builder tool that is used to build container image
+// (docker or podman)
+func ValidateFunc(imageTag, imageBuilder string) error {
+	dir, err := ioutil.TempDir("", FileStoreDir)
+	log.Infof("Create a temp directory at %s", dir)
+	if err != nil {
+		return err
+	}
+	//defer os.RemoveAll(dir)
+
+	log.Infof("Pulling bunde image %s", imageTag)
+	pullCmd, err := FullImage(imageTag, imageBuilder)
+
+	if err := ExecuteCommand(pullCmd); err != nil {
+		return err
+	}
+
+	log.Infof("Saving bunde image into tarball %s", BundleTarFile)
+	saveCmd, err := SaveImage(dir, imageTag, imageBuilder)
+	if err := ExecuteCommand(saveCmd); err != nil {
+		return err
+	}
+
+	log.Infof("Extracting tarball %s", BundleTarFile)
+	err = UntarFile(dir, BundleTarFile)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Parsing manifest.json")
+	file, err := ioutil.ReadFile(filepath.Join(dir, ManifestJsonFile))
+	if err != nil {
+		return err
+	}
+	_, layerFiles, err := ParseManifestJson(file)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Verify image labels
+	if len(layerFiles) < 1 {
+		return fmt.Errorf("Expecting at least one layer in bundle image")
+	}
+
+	var manifestsFound, metadataFound bool
+	var annotationsDir, manifestsDir string
+	for _, item := range layerFiles {
+		log.Infof("Extracting layer tarball %s", item)
+		err = UntarFile(dir, item)
+		if err != nil {
+			return err
+		}
+
+		items, _ := ioutil.ReadDir(dir)
+		for _, item := range items {
+			if item.IsDir() {
+				switch s := item.Name(); s {
+				case strings.TrimSuffix(ManifestsDir, "/"):
+					log.Info("Found manifests directory")
+					manifestsFound = true
+					manifestsDir = filepath.Join(dir, ManifestsDir)
+				case strings.TrimSuffix(MetadataDir, "/"):
+					log.Info("Found metadata directory")
+					metadataFound = true
+					annotationsDir = filepath.Join(dir, MetadataDir)
+				}
+			}
+		}
+	}
+
+	if manifestsFound == false {
+		return fmt.Errorf("Unable to locate manifests directory")
+	} else if metadataFound == false {
+		return fmt.Errorf("Unable to locate metadata directory")
+	}
+
+	log.Info("Getting mediaType info from manifests directory")
+	mediaType, err := GetMediaType(manifestsDir)
+	if err != nil {
+		log.Error("Unable to determine manifests mediaType")
+		return err
+	}
+
+	// Validate annotations.yaml
+	file, err = ioutil.ReadFile(filepath.Join(annotationsDir, AnnotationsFile))
+	if err != nil {
+		log.Error("Unable to validate annotations.yaml")
+		return err
+	} else {
+		if err = ValidateBundleAnnotations(mediaType, file); err != nil {
+			return err
+		}
+	}
+
+	log.Info("All validation tests have been completed successfully")
+
+	return nil
+}
+
+func UntarFile(dir, tarName string) error {
+	file, err := os.Open(filepath.Join(dir, tarName))
+	if err != nil {
+		return err
+	}
+
+	err = Untar(file, dir)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func FullImage(imageTag, imageBuilder string) (*exec.Cmd, error) {
+	var args []string
+
+	switch imageBuilder {
+	case "docker", "podman":
+		args = append(args, "pull", imageTag)
+	default:
+		return nil, fmt.Errorf("%s is not supported image builder", imageBuilder)
+	}
+
+	return exec.Command(imageBuilder, args...), nil
+}
+
+func SaveImage(directory, imageTag, imageBuilder string) (*exec.Cmd, error) {
+	var args []string
+
+	switch imageBuilder {
+	case "docker", "podman":
+		args = append(args, "save", "-o", filepath.Join(directory, BundleTarFile), imageTag)
+	default:
+		return nil, fmt.Errorf("%s is not supported image builder", imageBuilder)
+	}
+
+	return exec.Command(imageBuilder, args...), nil
+}
+
+func ParseManifestJson(file []byte) (string, []string, error) {
+	var manifest = []*ManifestJson{}
+
+	err := json.Unmarshal(file, &manifest)
+	if err != nil {
+		log.Errorf("Unable to parse manifest.json")
+		return "", nil, err
+	}
+
+	return manifest[0].Config, manifest[0].Layers, nil
+}
+
+func ValidateBundleAnnotations(mediaType string, file []byte) error {
+	var fileAnnotations AnnotationMetadata
+	var invalid bool
+
+	annotations := map[string]string{
+		MediatypeLabel:      mediaType,
+		ManifestsLabel:      ManifestsDir,
+		MetadataLabel:       MetadataDir,
+		PackageLabel:        "",
+		ChannelsLabel:       "",
+		ChannelDefaultLabel: "",
+	}
+
+	log.Info("Validating annotations.yaml")
+
+	err := yaml.Unmarshal(file, &fileAnnotations)
+	if err != nil {
+		log.Error("Unable to parse annotations.yaml")
+		return err
+	}
+
+	for label, item := range annotations {
+		val, ok := fileAnnotations.Annotations[label]
+		if ok {
+			log.Infof(`Found annotation "%s" with value "%s"`, label, val)
+		} else {
+			log.Errorf(`Missing annotation "%s"`, label)
+			invalid = true
+		}
+
+		switch label {
+		case MediatypeLabel:
+			if item != val {
+				log.Errorf(`Expecting annotation "%s" to have value "%s" instead of "%s"`, label, item, val)
+				invalid = true
+			}
+		case ManifestsLabel:
+			if item != ManifestsDir {
+				log.Errorf(`Expecting annotation "%s" to have value "%s" instead of "%s"`, label, ManifestsDir, val)
+				invalid = true
+			}
+		case MetadataDir:
+			if item != MetadataLabel {
+				log.Errorf(`Expecting annotation "%s" to have value "%s" instead of "%s"`, label, MetadataDir, val)
+				invalid = true
+			}
+		case ChannelsLabel, ChannelDefaultLabel:
+			if val == "" {
+				log.Errorf(`Expecting annotation "%s" to have non-empty value`, label)
+				invalid = true
+			} else {
+				annotations[label] = val
+			}
+		}
+	}
+
+	_, err = ValidateChannelDefault(annotations[ChannelsLabel], annotations[ChannelDefaultLabel])
+	if err != nil {
+		log.Error(err.Error())
+		invalid = true
+	}
+
+	if invalid {
+		return fmt.Errorf("The annotations.yaml is invalid")
+	}
+
+	return nil
+}


### PR DESCRIPTION
1. Enable bundle image validation: manifests and annotations.yaml
2. Add internal opm cli to use validation feature

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
