### PR TITLE
fix(configmap): bump base image for configmap registry image

### DIFF
--- a/configmap-registry.Dockerfile
+++ b/configmap-registry.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/upstream-registry-builder:v1.1.0 as builder
+FROM quay.io/operator-framework/upstream-registry-builder:latest as builder
 
 FROM scratch
 COPY --from=builder /build/bin/configmap-server /bin/configmap-server


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Bumps the base image for the configmap registry image

**Motivation for the change:**
I believe that this is the source of the flakiness for `TestCreateInstallPlanWithPreExistingCRDOwners/PreExistingCRDOwnerIsReplaced` in OLM - I don't think it's flakey, I think it's completely broken because of this image.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
