### PR TITLE
test(server): wait for connection to go healthy before running tests

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -6,11 +6,13 @@ import (
 	"net"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 
 	"github.com/operator-framework/operator-registry/pkg/api"
 	"github.com/operator-framework/operator-registry/pkg/sqlite"
@@ -75,6 +77,10 @@ func client(t *testing.T) (api.RegistryClient, *grpc.ClientConn) {
 	if err != nil {
 		t.Fatalf("did not connect: %v", err)
 	}
+
+	ctx, _ := context.WithTimeout(context.Background(), 30*time.Second)
+	conn.WaitForStateChange(ctx, connectivity.TransientFailure)
+
 	return api.NewRegistryClient(conn), conn
 }
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Waits for the grpc connection to go healthy before running tests.

**Motivation for the change:**
This may reduce flakiness for the server e2e tests

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
