### PR TITLE
fix(e2e): update ginkgo configmap test

### DIFF
--- a/test/e2e/image-bundle/Dockerfile.serve
+++ b/test/e2e/image-bundle/Dockerfile.serve
@@ -1,4 +1,4 @@
 # docker build -t init-operator-manifest .
 FROM busybox
 
-COPY opm /
+COPY opm /bin


### PR DESCRIPTION
Since this test isn't running in the gate (yet), there were a few things that needed updating.

(Eventually this test will be modified to use an image builder that doesn't require a daemon.)