### PR TITLE
pkg/sqlite: add logrus.Entry arguments to loader constructors

### DIFF
--- a/cmd/initializer/main.go
+++ b/cmd/initializer/main.go
@@ -69,7 +69,7 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	loader := sqlite.NewSQLLoaderForDirectory(dbLoader, manifestDir)
+	loader := sqlite.NewSQLLoaderForDirectory(nil, dbLoader, manifestDir)
 	if err := loader.Populate(); err != nil {
 		err = fmt.Errorf("error loading manifests from directory: %s", err)
 		if !permissive {

--- a/go.sum
+++ b/go.sum
@@ -175,7 +175,6 @@ github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d h1:3PaI8p3seN09Vjb
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang-migrate/migrate/v4 v4.6.2 h1:LDDOHo/q1W5UDj6PbkxdCv7lv9yunyZHXvxuwDkGo3k=
 github.com/golang-migrate/migrate/v4 v4.6.2/go.mod h1:JYi6reN3+Z734VZ0akNuyOJNcrg45ZL7LDBMW3WGJL0=
-github.com/golang/dep v0.5.4 h1:WfV5qbGwsBNUDhk+pfI6emWm7SdDFsnSWkqCMNG3BRs=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903 h1:LbsanbbD6LieFkXbj9YNNBupiGHJgFeLpO0j0Fza1h8=

--- a/pkg/appregistry/builder.go
+++ b/pkg/appregistry/builder.go
@@ -130,7 +130,7 @@ func BuildDatabase(manifestPath, databasePath string) error {
 		return err
 	}
 
-	loader := sqlite.NewSQLLoaderForDirectory(dbLoader, manifestPath)
+	loader := sqlite.NewSQLLoaderForDirectory(nil, dbLoader, manifestPath)
 	if err := loader.Populate(); err != nil {
 		klog.Warningf("error building database: %s", err.Error())
 	}

--- a/pkg/appregistry/dbloader.go
+++ b/pkg/appregistry/dbloader.go
@@ -80,7 +80,7 @@ func (l *dbLoader) LoadBundleDirectoryToSQLite(directory string) error {
 		return err
 	}
 
-	loader := sqlite.NewSQLLoaderForDirectory(l.loader, directory)
+	loader := sqlite.NewSQLLoaderForDirectory(nil, l.loader, directory)
 	if err := loader.Populate(); err != nil {
 		return err
 	}

--- a/pkg/lib/registry/registry.go
+++ b/pkg/lib/registry/registry.go
@@ -10,16 +10,15 @@ import (
 	"github.com/operator-framework/operator-registry/pkg/sqlite"
 )
 
-
 type RegistryUpdater struct {
 	Logger *logrus.Entry
 }
 
 type AddToRegistryRequest struct {
-	Permissive bool
+	Permissive    bool
 	InputDatabase string
 	ContainerTool string
-	Bundles []string
+	Bundles       []string
 }
 
 func (r RegistryUpdater) AddToRegistry(request AddToRegistryRequest) error {
@@ -40,7 +39,7 @@ func (r RegistryUpdater) AddToRegistry(request AddToRegistryRequest) error {
 	}
 
 	for _, bundleImage := range request.Bundles {
-		loader := sqlite.NewSQLLoaderForImage(dbLoader, bundleImage, request.ContainerTool)
+		loader := sqlite.NewSQLLoaderForImage(nil, dbLoader, bundleImage, request.ContainerTool)
 		if err := loader.Populate(); err != nil {
 			err = fmt.Errorf("error loading bundle from image: %s", err)
 			if !request.Permissive {
@@ -55,9 +54,9 @@ func (r RegistryUpdater) AddToRegistry(request AddToRegistryRequest) error {
 }
 
 type DeleteFromRegistryRequest struct {
-	Permissive bool
+	Permissive    bool
 	InputDatabase string
-	Packages []string
+	Packages      []string
 }
 
 func (r RegistryUpdater) DeleteFromRegistry(request DeleteFromRegistryRequest) error {

--- a/pkg/mirror/mirror_test.go
+++ b/pkg/mirror/mirror_test.go
@@ -23,7 +23,7 @@ func CreateTestDb(t *testing.T) (*sql.DB, string, func()) {
 	require.NoError(t, err)
 	require.NoError(t, load.Migrate(context.TODO()))
 
-	loader := sqlite.NewSQLLoaderForDirectory(load, "../../manifests")
+	loader := sqlite.NewSQLLoaderForDirectory(nil, load, "../../manifests")
 	require.NoError(t, loader.Populate())
 
 	return db, dbName, func() {
@@ -37,7 +37,6 @@ func CreateTestDb(t *testing.T) (*sql.DB, string, func()) {
 		}
 	}
 }
-
 
 func TestIndexImageMirrorer_Mirror(t *testing.T) {
 	_, path, cleanup := CreateTestDb(t)
@@ -60,24 +59,24 @@ func TestIndexImageMirrorer_Mirror(t *testing.T) {
 	}{
 		{
 			name: "mirror images",
-			fields:fields{
+			fields: fields{
 				DatabaseExtractor: testExtractor,
 				Source:            "example",
 				Dest:              "localhost",
 			},
 			want: map[string]string{
-				"quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943":"localhost/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943",
-				"quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2":"localhost/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2",
-				"quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8":"localhost/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8",
-				"quay.io/coreos/etcd@sha256:3816b6daf9b66d6ced6f0f966314e2d4f894982c6b1493061502f8c2bf86ac84":"localhost/coreos/etcd@sha256:3816b6daf9b66d6ced6f0f966314e2d4f894982c6b1493061502f8c2bf86ac84",
-				"quay.io/coreos/etcd@sha256:49d3d4a81e0d030d3f689e7167f23e120abf955f7d08dbedf3ea246485acee9f":"localhost/coreos/etcd@sha256:49d3d4a81e0d030d3f689e7167f23e120abf955f7d08dbedf3ea246485acee9f",
-				"quay.io/coreos/prometheus-operator@sha256:0e92dd9b5789c4b13d53e1319d0a6375bcca4caaf0d698af61198061222a576d":"localhost/coreos/prometheus-operator@sha256:0e92dd9b5789c4b13d53e1319d0a6375bcca4caaf0d698af61198061222a576d",
-				"quay.io/coreos/prometheus-operator@sha256:3daa69a8c6c2f1d35dcf1fe48a7cd8b230e55f5229a1ded438f687debade5bcf":"localhost/coreos/prometheus-operator@sha256:3daa69a8c6c2f1d35dcf1fe48a7cd8b230e55f5229a1ded438f687debade5bcf",
-				"quay.io/coreos/prometheus-operator@sha256:5037b4e90dbb03ebdefaa547ddf6a1f748c8eeebeedf6b9d9f0913ad662b5731":"localhost/coreos/prometheus-operator@sha256:5037b4e90dbb03ebdefaa547ddf6a1f748c8eeebeedf6b9d9f0913ad662b5731",
-				"docker.io/strimzi/cluster-operator:0.11.0": "localhost/strimzi/cluster-operator:0.11.0",
-				"docker.io/strimzi/cluster-operator:0.11.1": "localhost/strimzi/cluster-operator:0.11.1",
-				"docker.io/strimzi/operator:0.12.1": "localhost/strimzi/operator:0.12.1",
-				"docker.io/strimzi/operator:0.12.2": "localhost/strimzi/operator:0.12.2",
+				"quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943":       "localhost/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943",
+				"quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2":       "localhost/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2",
+				"quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8":       "localhost/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8",
+				"quay.io/coreos/etcd@sha256:3816b6daf9b66d6ced6f0f966314e2d4f894982c6b1493061502f8c2bf86ac84":                "localhost/coreos/etcd@sha256:3816b6daf9b66d6ced6f0f966314e2d4f894982c6b1493061502f8c2bf86ac84",
+				"quay.io/coreos/etcd@sha256:49d3d4a81e0d030d3f689e7167f23e120abf955f7d08dbedf3ea246485acee9f":                "localhost/coreos/etcd@sha256:49d3d4a81e0d030d3f689e7167f23e120abf955f7d08dbedf3ea246485acee9f",
+				"quay.io/coreos/prometheus-operator@sha256:0e92dd9b5789c4b13d53e1319d0a6375bcca4caaf0d698af61198061222a576d": "localhost/coreos/prometheus-operator@sha256:0e92dd9b5789c4b13d53e1319d0a6375bcca4caaf0d698af61198061222a576d",
+				"quay.io/coreos/prometheus-operator@sha256:3daa69a8c6c2f1d35dcf1fe48a7cd8b230e55f5229a1ded438f687debade5bcf": "localhost/coreos/prometheus-operator@sha256:3daa69a8c6c2f1d35dcf1fe48a7cd8b230e55f5229a1ded438f687debade5bcf",
+				"quay.io/coreos/prometheus-operator@sha256:5037b4e90dbb03ebdefaa547ddf6a1f748c8eeebeedf6b9d9f0913ad662b5731": "localhost/coreos/prometheus-operator@sha256:5037b4e90dbb03ebdefaa547ddf6a1f748c8eeebeedf6b9d9f0913ad662b5731",
+				"docker.io/strimzi/cluster-operator:0.11.0":                                                                  "localhost/strimzi/cluster-operator:0.11.0",
+				"docker.io/strimzi/cluster-operator:0.11.1":                                                                  "localhost/strimzi/cluster-operator:0.11.1",
+				"docker.io/strimzi/operator:0.12.1":                                                                          "localhost/strimzi/operator:0.12.1",
+				"docker.io/strimzi/operator:0.12.2":                                                                          "localhost/strimzi/operator:0.12.2",
 			},
 		},
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -42,7 +42,7 @@ func server() {
 		logrus.Fatal(err)
 	}
 
-	loader := sqlite.NewSQLLoaderForDirectory(load, "../../manifests")
+	loader := sqlite.NewSQLLoaderForDirectory(nil, load, "../../manifests")
 	if err := loader.Populate(); err != nil {
 		logrus.Fatal(err)
 	}

--- a/pkg/sqlite/configmap.go
+++ b/pkg/sqlite/configmap.go
@@ -39,6 +39,12 @@ var _ SQLPopulator = &ConfigMapLoader{}
 // originate from a different source than a configMap. For example, operator
 // manifest(s) can be downloaded from a remote registry like quay.io.
 func NewSQLLoaderForConfigMapData(logger *logrus.Entry, store registry.Load, configMapData map[string]string) *ConfigMapLoader {
+	if logger == nil {
+		logger = logrus.NewEntry(logrus.New())
+	}
+	if logger.Logger == nil {
+		logger.Logger = logrus.New()
+	}
 	return &ConfigMapLoader{
 		log:           logger,
 		store:         store,

--- a/pkg/sqlite/directory_test.go
+++ b/pkg/sqlite/directory_test.go
@@ -24,7 +24,7 @@ func TestDirectoryLoader(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, store.Migrate(context.TODO()))
 
-	loader := NewSQLLoaderForDirectory(store, "../../manifests")
+	loader := NewSQLLoaderForDirectory(nil, store, "../../manifests")
 	require.NoError(t, loader.Populate())
 }
 
@@ -63,7 +63,7 @@ func TestDirectoryLoaderWithBadPackageData(t *testing.T) {
 	require.NoError(t, yaml.NewEncoder(w).Encode(pkg))
 
 	// Load and expect error
-	loader := NewSQLLoaderForDirectory(store, dir)
+	loader := NewSQLLoaderForDirectory(nil, store, dir)
 	require.Error(t, loader.Populate(), "error loading package into db: no bundle found for csv imaginary")
 }
 
@@ -79,7 +79,7 @@ func TestDirectoryLoaderWithBadBundleData(t *testing.T) {
 	// Load and expect error
 	// incorrectbundle has an operator which has incorrect data
 	// (a number where a string is expected) in it's CSV
-	loader := NewSQLLoaderForDirectory(store, "pkg/sqlite/testdata/incorrectbundle")
+	loader := NewSQLLoaderForDirectory(nil, store, "pkg/sqlite/testdata/incorrectbundle")
 	require.Error(t, loader.Populate(), "error loading manifests from directory: [error adding operator bundle : json: cannot unmarshal number into Go struct field EnvVar.Install.spec.Deployments.Spec.template.spec.containers.env.value of type string, error loading package into db: [FOREIGN KEY constraint failed, no bundle found for csv 3scale-community-operator.v0.3.0]]")
 }
 func TestQuerierForDirectory(t *testing.T) {
@@ -89,7 +89,7 @@ func TestQuerierForDirectory(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, load.Migrate(context.TODO()))
 
-	loader := NewSQLLoaderForDirectory(load, "../../manifests")
+	loader := NewSQLLoaderForDirectory(nil, load, "../../manifests")
 	require.NoError(t, loader.Populate())
 
 	store := NewSQLLiteQuerierFromDb(db)

--- a/pkg/sqlite/image_test.go
+++ b/pkg/sqlite/image_test.go
@@ -17,38 +17,23 @@ func TestImageLoader(t *testing.T) {
 	require.NoError(t, store.Migrate(context.TODO()))
 
 	image := "quay.io/test/"
-	etcdFirstVersion := &ImageLoader{
-		store:     store,
-		image:     image + "etcd.0.9.0",
-		directory: "../../bundles/etcd.0.9.0",
-	}
+	etcdFirstVersion := NewSQLLoaderForImage(nil, store, image+"etcd.0.9.0", "")
+	etcdFirstVersion.directory = "../../bundles/etcd.0.9.0"
 	require.NoError(t, etcdFirstVersion.LoadBundleFunc())
 
-	etcdNextVersion := &ImageLoader{
-		store:     store,
-		image:     image + "etcd.0.9.2",
-		directory: "../../bundles/etcd.0.9.2",
-	}
+	etcdNextVersion := NewSQLLoaderForImage(nil, store, image+"etcd.0.9.2", "")
+	etcdNextVersion.directory = "../../bundles/etcd.0.9.2"
 	require.NoError(t, etcdNextVersion.LoadBundleFunc())
 
-	prometheusFirstVersion := &ImageLoader{
-		store:     store,
-		image:     image + "prometheus.0.14.0",
-		directory: "../../bundles/prometheus.0.14.0",
-	}
+	prometheusFirstVersion := NewSQLLoaderForImage(nil, store, image+"prometheus.0.14.0", "")
+	prometheusFirstVersion.directory = "../../bundles/prometheus.0.14.0"
 	require.NoError(t, prometheusFirstVersion.LoadBundleFunc())
 
-	prometheusSecondVersion := &ImageLoader{
-		store:     store,
-		image:     image + "prometheus.0.15.0",
-		directory: "../../bundles/prometheus.0.15.0",
-	}
+	prometheusSecondVersion := NewSQLLoaderForImage(nil, store, image+"prometheus.0.15.0", "")
+	prometheusSecondVersion.directory = "../../bundles/prometheus.0.15.0"
 	require.NoError(t, prometheusSecondVersion.LoadBundleFunc())
 
-	prometheusThirdVersion := &ImageLoader{
-		store:     store,
-		image:     image + "prometheus.0.22.2",
-		directory: "../../bundles/prometheus.0.22.2",
-	}
+	prometheusThirdVersion := NewSQLLoaderForImage(nil, store, image+"prometheus.0.22.2", "")
+	prometheusThirdVersion.directory = "../../bundles/prometheus.0.22.2"
 	require.NoError(t, prometheusThirdVersion.LoadBundleFunc())
 }

--- a/pkg/sqlite/remove_test.go
+++ b/pkg/sqlite/remove_test.go
@@ -17,39 +17,25 @@ func TestRemover(t *testing.T) {
 	require.NoError(t, store.Migrate(context.TODO()))
 
 	image := "quay.io/test/"
-	etcdFirstVersion := &ImageLoader{
-		store:     store,
-		image:     image + "etcd.0.9.0",
-		directory: "../../bundles/etcd.0.9.0",
-	}
+
+	etcdFirstVersion := NewSQLLoaderForImage(nil, store, image+"etcd.0.9.0", "")
+	etcdFirstVersion.directory = "../../bundles/etcd.0.9.0"
 	require.NoError(t, etcdFirstVersion.LoadBundleFunc())
 
-	etcdNextVersion := &ImageLoader{
-		store:     store,
-		image:     image + "etcd.0.9.2",
-		directory: "../../bundles/etcd.0.9.2",
-	}
+	etcdNextVersion := NewSQLLoaderForImage(nil, store, image+"etcd.0.9.2", "")
+	etcdNextVersion.directory = "../../bundles/etcd.0.9.2"
 	require.NoError(t, etcdNextVersion.LoadBundleFunc())
 
-	prometheusFirstVersion := &ImageLoader{
-		store:     store,
-		image:     image + "prometheus.0.14.0",
-		directory: "../../bundles/prometheus.0.14.0",
-	}
+	prometheusFirstVersion := NewSQLLoaderForImage(nil, store, image+"prometheus.0.14.0", "")
+	prometheusFirstVersion.directory = "../../bundles/prometheus.0.14.0"
 	require.NoError(t, prometheusFirstVersion.LoadBundleFunc())
 
-	prometheusSecondVersion := &ImageLoader{
-		store:     store,
-		image:     image + "prometheus.0.15.0",
-		directory: "../../bundles/prometheus.0.15.0",
-	}
+	prometheusSecondVersion := NewSQLLoaderForImage(nil, store, image+"prometheus.0.15.0", "")
+	prometheusSecondVersion.directory = "../../bundles/prometheus.0.15.0"
 	require.NoError(t, prometheusSecondVersion.LoadBundleFunc())
 
-	prometheusThirdVersion := &ImageLoader{
-		store:     store,
-		image:     image + "prometheus.0.22.2",
-		directory: "../../bundles/prometheus.0.22.2",
-	}
+	prometheusThirdVersion := NewSQLLoaderForImage(nil, store, image+"prometheus.0.22.2", "")
+	prometheusThirdVersion.directory = "../../bundles/prometheus.0.22.2"
 	require.NoError(t, prometheusThirdVersion.LoadBundleFunc())
 
 	// delete everything


### PR DESCRIPTION
**Description of the change:**
* pkg/sqlite: add logrus.Entry arguments to loader constructors to align with ConfigMapLoader.
* pkg,cmd: update calls to loader constructors or direct instantiations of loader structs to correctly configure logging
* go.sum: tidy

**Motivation for the change:**
As a user of operator-registry's bundle `SQLPopulator`'s, I would like to configure logging for those exported. Currently only `ConfigMapLoader`'s logging can be configured.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

/cc @njhale @jpeeler @dinhxuanvu 