### PR TITLE
add cp to configmap-registry image

### DIFF
--- a/configmap-registry.Dockerfile
+++ b/configmap-registry.Dockerfile
@@ -1,8 +1,10 @@
 FROM quay.io/operator-framework/upstream-registry-builder:latest as builder
+FROM busybox as userspace
 
 FROM scratch
 COPY --from=builder /build/bin/configmap-server /bin/configmap-server
 COPY --from=builder /build/bin/opm /bin/opm
+COPY --from=userspace /bin/cp /bin/cp
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/bin/configmap-server"]


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This adds cp to the image so that copying opm (recently added) can actually be copied out.

**Motivation for the change:**
Required for extracting data out of bundle images.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
