### PR TITLE
fix(bundle): set csv name field on configmap loading

### DIFF
--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -78,6 +78,7 @@ func loadBundle(entry *logrus.Entry, data map[string]string) (bundle *api.Bundle
 				return nil, nil, err
 			}
 			bundle.CsvJson = string(csvBytes)
+			bundle.CsvName = resource.GetName()
 		}
 		bundle.Object = append(bundle.Object, content)
 		logger.Infof("added to bundle, Kind=%s", resource.GetKind())

--- a/pkg/configmap/configmap_test.go
+++ b/pkg/configmap/configmap_test.go
@@ -25,6 +25,7 @@ func TestLoad(t *testing.T) {
 			assertFunc: func(t *testing.T, bundleGot *api.Bundle) {
 				csvGot := bundleGot.GetCsvJson()
 				assert.NotNil(t, csvGot)
+				assert.Equal(t, "etcdoperator.v0.6.1", bundleGot.GetCsvName())
 
 				crdListGot := bundleGot.GetObject()
 				// 1 CSV + 1 CRD = 2 objects


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Sets the CSV name of the bundle when loading from a configmap.

**Motivation for the change:**

Bundle loading should be authoritative so that OLM doesn't need to unmarshal the CSV to access its metadata.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
