### PR TITLE
Bug 1790785: feat(appr): exit build early if no manifests were downloaded

### DIFF
--- a/pkg/appregistry/builder.go
+++ b/pkg/appregistry/builder.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"context"
 	"database/sql"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -90,6 +91,11 @@ func (b *AppregistryImageBuilder) Build() error {
 	if err := downloader.DownloadManifests(b.ManifestDir, b.AppRegistryOrg); err != nil {
 		return err
 	}
+
+	if !hasManifests(b.ManifestDir) {
+		return fmt.Errorf("no manifests downloaded from appregistry %s/%s", b.AppRegistryEndpoint, b.AppRegistryOrg)
+	}
+
 	klog.V(4).Infof("downloaded manifests to %s\n", b.ManifestDir)
 
 	if err := BuildDatabase(b.ManifestDir, b.DatabasePath); err != nil {
@@ -211,4 +217,12 @@ func BuildLayer(directory string) (string, error) {
 	}
 
 	return archive.Name(), nil
+}
+
+func hasManifests(path string) bool {
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		return false
+	}
+	return len(files) > 0
 }

--- a/pkg/appregistry/builder_test.go
+++ b/pkg/appregistry/builder_test.go
@@ -20,63 +20,93 @@ var _ = Describe("Image building", func() {
 		operator *apprclient.OperatorMetadata
 	)
 
-	JustBeforeEach(func() {
-		var err error
-		builder, err = NewAppregistryImageBuilder(options...)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(builder).ToNot(BeNil())
-		Expect(builder.Build()).To(Succeed())
-	})
-
-	BeforeEach(func() {
-		var noopAppender ImageAppendFunc = func(from, to, layer string) error {
-			return nil
-		}
-
-		client := &apprclientfakes.FakeClient{}
-		pkg = &apprclient.RegistryMetadata{
-			Namespace: "marsupials",
-			Name:      "koala",
-		}
-		client.ListPackagesReturns([]*apprclient.RegistryMetadata{pkg}, nil)
-
-		pkgBlob, err := ioutil.ReadFile("testdata/golden/marsupials_pkg.tar")
-		Expect(err).ToNot(HaveOccurred())
-
-		operator = &apprclient.OperatorMetadata{
-			RegistryMetadata: *pkg,
-			Blob:             pkgBlob,
-		}
-		client.RetrieveOneReturns(operator, nil)
-
-		options = append(options,
-			WithAppender(noopAppender),
-			WithAppRegistryOrg("metatheria"),
-			WithClient(client),
-		)
-	})
-
-	Context("with a custom cache dir", func() {
-		var (
-			cacheDir      string
-			manifestsGlob string
-		)
-
+	Context("with no manifests returned", func() {
 		BeforeEach(func() {
-			cacheDir = filepath.Join("testdata", "custom-cache")
-			options = append(options, WithCacheDir(cacheDir))
-			manifestsGlob = filepath.Join(cacheDir, "manifests-*/koala/marsupials")
+			var noopAppender ImageAppendFunc = func(from, to, layer string) error {
+				return nil
+			}
+
+			client := &apprclientfakes.FakeClient{}
+			client.RetrieveOneReturns(nil, nil)
+
+			options = append(options,
+				WithAppender(noopAppender),
+				WithAppRegistryOrg("metatheria"),
+				WithClient(client),
+			)
 		})
 
-		AfterEach(func() {
-			Expect(os.RemoveAll(cacheDir)).To(Succeed())
+		It("should show an error", func() {
+			var err error
+			builder, err = NewAppregistryImageBuilder(options...)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(builder).ToNot(BeNil())
+			err = builder.Build()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("no manifests downloaded from appregistry https://quay.io/cnr/metatheria"))
 		})
-
-		It("should retain unpacked operator manifests", func() {
-			Expect(cacheDir).To(BeADirectory())
-			Expect(filepath.Glob(filepath.Join(manifestsGlob, "package.yaml"))).To(HaveLen(1))
-			Expect(filepath.Glob(filepath.Join(manifestsGlob, "v1.0.0", "koala.v1.0.0.clusterserviceversion.yaml"))).To(HaveLen(1))
-		})
-
 	})
+
+	Context("with good manifests returned", func() {
+		BeforeEach(func() {
+			var noopAppender ImageAppendFunc = func(from, to, layer string) error {
+				return nil
+			}
+
+			client := &apprclientfakes.FakeClient{}
+			pkg = &apprclient.RegistryMetadata{
+				Namespace: "marsupials",
+				Name:      "koala",
+			}
+			client.ListPackagesReturns([]*apprclient.RegistryMetadata{pkg}, nil)
+
+			pkgBlob, err := ioutil.ReadFile("testdata/golden/marsupials_pkg.tar")
+			Expect(err).ToNot(HaveOccurred())
+
+			operator = &apprclient.OperatorMetadata{
+				RegistryMetadata: *pkg,
+				Blob:             pkgBlob,
+			}
+			client.RetrieveOneReturns(operator, nil)
+
+			options = append(options,
+				WithAppender(noopAppender),
+				WithAppRegistryOrg("metatheria"),
+				WithClient(client),
+			)
+		})
+
+		JustBeforeEach(func() {
+			var err error
+			builder, err = NewAppregistryImageBuilder(options...)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(builder).ToNot(BeNil())
+			Expect(builder.Build()).To(Succeed())
+		})
+
+		Context("with a custom cache dir", func() {
+			var (
+				cacheDir      string
+				manifestsGlob string
+			)
+
+			BeforeEach(func() {
+				cacheDir = filepath.Join("testdata", "custom-cache")
+				options = append(options, WithCacheDir(cacheDir))
+				manifestsGlob = filepath.Join(cacheDir, "manifests-*/koala/marsupials")
+			})
+
+			AfterEach(func() {
+				Expect(os.RemoveAll(cacheDir)).To(Succeed())
+			})
+
+			It("should retain unpacked operator manifests", func() {
+				Expect(cacheDir).To(BeADirectory())
+				Expect(filepath.Glob(filepath.Join(manifestsGlob, "package.yaml"))).To(HaveLen(1))
+				Expect(filepath.Glob(filepath.Join(manifestsGlob, "v1.0.0", "koala.v1.0.0.clusterserviceversion.yaml"))).To(HaveLen(1))
+			})
+
+		})
+	})
+
 })


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Fail out if we don't find any manifests.

**Motivation for the change:**
This is to improve UX in oc adm catalog build.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
