### PR TITLE
[WIP] Add custom labels to bundle

### DIFF
--- a/cmd/opm/alpha/bundle/build.go
+++ b/cmd/opm/alpha/bundle/build.go
@@ -14,6 +14,7 @@ var (
 	channelsArgs       string
 	channelDefaultArgs string
 	overwriteArgs      bool
+	labelsArgs         []string
 )
 
 // newBundleBuildCmd returns a command that will build operator bundle image.
@@ -69,12 +70,14 @@ func newBundleBuildCmd() *cobra.Command {
 
 	bundleBuildCmd.Flags().BoolVarP(&overwriteArgs, "overwrite", "o", false, "To overwrite annotations.yaml locally if existed. By default, overwrite is set to `false`.")
 
+	bundleBuildCmd.Flags().StringArrayVarP(&labelsArgs, "labels", "l", make([]string, 0), "Additional labels for the bundle image. These must be specified as key-value pairs separated by `:`. For example: `-l=\"key:value\"`.")
+
 	return bundleBuildCmd
 }
 
 func buildFunc(cmd *cobra.Command, args []string) error {
 	err := bundle.BuildFunc(dirBuildArgs, tagBuildArgs, imageBuilderArgs,
-		packageNameArgs, channelsArgs, channelDefaultArgs, overwriteArgs)
+		packageNameArgs, channelsArgs, channelDefaultArgs, overwriteArgs, labelsArgs)
 	if err != nil {
 		return err
 	}

--- a/cmd/opm/alpha/bundle/generate.go
+++ b/cmd/opm/alpha/bundle/generate.go
@@ -41,11 +41,13 @@ func newBundleGenerateCmd() *cobra.Command {
 
 	bundleGenerateCmd.Flags().StringVarP(&channelDefaultArgs, "default", "e", "", "The default channel for the bundle image")
 
+	bundleGenerateCmd.Flags().StringArrayVarP(&labelsArgs, "labels", "l", make([]string, 0), "Additional labels for the bundle image. These must be specified as key-value pairs separated by `:`. For example: `-l=\"key:value\"`.")
+
 	return bundleGenerateCmd
 }
 
 func generateFunc(cmd *cobra.Command, args []string) error {
-	err := bundle.GenerateFunc(dirBuildArgs, packageNameArgs, channelsArgs, channelDefaultArgs, true)
+	err := bundle.GenerateFunc(dirBuildArgs, packageNameArgs, channelsArgs, channelDefaultArgs, true, labelsArgs)
 	if err != nil {
 		return err
 	}

--- a/pkg/lib/bundle/build.go
+++ b/pkg/lib/bundle/build.go
@@ -53,14 +53,14 @@ func ExecuteCommand(cmd *exec.Cmd) error {
 // @channels: The list of channels that bundle image belongs to
 // @channelDefault: The default channel for the bundle image
 // @overwrite: Boolean flag to enable overwriting annotations.yaml locally if existed
-func BuildFunc(directory, imageTag, imageBuilder, packageName, channels, channelDefault string, overwrite bool) error {
+func BuildFunc(directory, imageTag, imageBuilder, packageName, channels, channelDefault string, overwrite bool, labels []string) error {
 	_, err := os.Stat(directory)
 	if os.IsNotExist(err) {
 		return err
 	}
 
 	// Generate annotations.yaml and Dockerfile
-	err = GenerateFunc(directory, packageName, channels, channelDefault, overwrite)
+	err = GenerateFunc(directory, packageName, channels, channelDefault, overwrite, labels)
 	if err != nil {
 		return err
 	}

--- a/pkg/lib/bundle/generate_test.go
+++ b/pkg/lib/bundle/generate_test.go
@@ -187,7 +187,7 @@ func TestGenerateAnnotationsFunc(t *testing.T) {
 	}
 	// Create result annotations struct
 	resultAnnotations := AnnotationMetadata{}
-	data, err := GenerateAnnotations("test1", "test2", "test3", "test4", "test5", "test5")
+	data, err := GenerateAnnotations("test1", "test2", "test3", "test4", "test5", "test5", map[string]string{"test6": "test7"})
 	require.NoError(t, err)
 
 	err = yaml.Unmarshal(data, &resultAnnotations)
@@ -205,12 +205,13 @@ func TestGenerateDockerfileFunc(t *testing.T) {
 		"LABEL operators.operatorframework.io.bundle.metadata.v1=%s\n"+
 		"LABEL operators.operatorframework.io.bundle.package.v1=test4\n"+
 		"LABEL operators.operatorframework.io.bundle.channels.v1=test5\n"+
-		"LABEL operators.operatorframework.io.bundle.channel.default.v1=test5\n\n"+
+		"LABEL operators.operatorframework.io.bundle.channel.default.v1=test5\n"+
+		"LABEL test6=test7\n\n"+
 		"COPY /*.yaml /manifests/\n"+
 		"COPY %s/annotations.yaml /metadata/annotations.yaml\n", MetadataDir,
 		filepath.Join("/", MetadataDir))
 
-	content, err := GenerateDockerfile("test1", "test2", MetadataDir, "test4", "test5", "")
+	content, err := GenerateDockerfile("test1", "test2", MetadataDir, "test4", "test5", "", map[string]string{"test6": "test7"})
 	require.NoError(t, err)
 	require.Equal(t, output, string(content))
 }


### PR DESCRIPTION
Users can add custom labels through the opm CLI while generating or
building their bundle.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
