### PR TITLE
Build binaries for linux, windows, and mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: go
+go:
+- 1.13
+sudo: true
+
+os:
+- linux
+- osx
+- windows
+
+install:
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install make; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install make; fi
+
+script:
+- if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then mingw32-make build; fi
+- if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then make unit build; fi
+
+notifications:
+  email: false
+
+deploy:
+  provider: releases
+  api_key:
+    secure: CMJ3KGhwuB7YRCYsJMe0cWAY/gkj2BVGorW9G1awxOyR2+Dv9G5PhItVkVfti0P2LzX8K2rplDp4O8b976wWzWJlJ6MQsSkFId0wYJSXRwNGdqnGhTLdDXB4FmPKapTBqTaYQgumrfvSOMiZ3tAwCD9AjW2fqYnBWnJXJ3yv8cpmN+TOZLJAKG+wAqb2foD9mS3HEQ9ItcoBqqEg8eRedzLuLGKVROLdFweLpi9gWdC22xLNomySwITTXX4kVs35MS0iwZE2cpTNDR8tLLIirHNgkiCCVYdiY0AB77Ikp5AF458UA064yr1b8TjAC3oyi4h6ddFaXo6CT9PZmsc41Te7cguSm2J9Ok2OdxLGitce7oty38QeY0QaG0oolcbXYw6QeiUXJ3BScAzVQBveDYgIACkSlsXAFEgdmR9YLOjYcw1MmquhmDbEuvaHi5T85aqsL8v5PUTMZq9+X/wOTqzR6D+8nQGqvqodxnopAFKpiR7UyiCl16VqrTJnkpWnYEerlx1i3Y7JLEiEK9O8UKL13J65cumCHPbcPNXbIsV6cFM+WXV8XhzKNOenrI5LZS9ske73wN9mOlgJKPwzEzP1H5hw1DTgm7gH/T+0bPCUdg7vh+dGavunjHEth1HmD2F8p6dvMC7+JG7Fjyw2PU76yl9DDm611p69A5auQ14=
+  file: bin/$TRAVIS_OS_NAME/opm
+  skip_cleanup: true
+  on:
+    repo: operator-framework/operator-registry
+    tags: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,11 @@ FROM openshift/origin-base
 RUN mkdir /registry
 WORKDIR /registry
 
-COPY --from=builder /src/bin/initializer /bin/initializer
-COPY --from=builder /src/bin/registry-server /bin/registry-server
-COPY --from=builder /src/bin/configmap-server /bin/configmap-server
-COPY --from=builder /src/bin/appregistry-server /bin/appregistry-server
-COPY --from=builder /src/bin/opm /bin/opm
+COPY --from=builder /src/bin/linux/initializer /bin/initializer
+COPY --from=builder /src/bin/linux/registry-server /bin/registry-server
+COPY --from=builder /src/bin/linux/configmap-server /bin/configmap-server
+COPY --from=builder /src/bin/linux/appregistry-server /bin/appregistry-server
+COPY --from=builder /src/bin/linux/opm /bin/opm
 COPY --from=builder /go/bin/grpc-health-probe /bin/grpc_health_probe
 
 RUN chgrp -R 0 /registry && \
@@ -46,5 +46,5 @@ USER 1001
 EXPOSE 50051
 
 LABEL io.k8s.display-name="OpenShift Operator Registry" \
-    io.k8s.description="This is a component of OpenShift Operator Lifecycle Manager and is the base for operator catalog API containers." \
-    maintainer="Odin Team <aos-odin@redhat.com>"
+      io.k8s.description="This is a component of OpenShift Operator Lifecycle Manager and is the base for operator catalog API containers." \
+      maintainer="Odin Team <aos-odin@redhat.com>"

--- a/appr-registry.Dockerfile
+++ b/appr-registry.Dockerfile
@@ -1,15 +1,16 @@
-FROM golang:1.10-alpine as builder
+FROM golang:1.13-alpine as builder
 
-RUN apk update && apk add sqlite build-base git mercurial
+RUN apk update && apk add sqlite build-base git mercurial bash
 WORKDIR /go/src/github.com/operator-framework/operator-registry
 
 COPY vendor vendor
 COPY cmd cmd
 COPY pkg pkg
 COPY Makefile Makefile
+COPY go.mod go.mod
 RUN make static
 
-FROM golang:1.10-alpine as probe-builder
+FROM golang:1.13-alpine as probe-builder
 
 RUN apk update && apk add build-base git
 ENV ORG github.com/grpc-ecosystem
@@ -19,10 +20,12 @@ WORKDIR /go/src/$PROJECT
 COPY --from=builder /go/src/github.com/operator-framework/operator-registry/vendor/$ORG/grpc-health-probe .
 COPY --from=builder /go/src/github.com/operator-framework/operator-registry/vendor .
 RUN CGO_ENABLED=0 go install -a -tags netgo -ldflags "-w"
+RUN ls /go/bin
+RUN ls .
 
 
 FROM scratch
-COPY --from=builder /go/src/github.com/operator-framework/operator-registry/bin/appregistry-server /bin/appregistry-server
-COPY --from=probe-builder /go/bin/grpc_health_probe /bin/grpc_health_probe
+COPY --from=builder /go/src/github.com/operator-framework/operator-registry/bin/linux/appregistry-server /bin/appregistry-server
+COPY --from=probe-builder /go/bin/grpc-health-probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/bin/appregistry-server"]

--- a/configmap-registry.Dockerfile
+++ b/configmap-registry.Dockerfile
@@ -2,8 +2,8 @@ FROM quay.io/operator-framework/upstream-registry-builder:latest as builder
 FROM busybox as userspace
 
 FROM scratch
-COPY --from=builder /build/bin/configmap-server /bin/configmap-server
-COPY --from=builder /build/bin/opm /bin/opm
+COPY --from=builder /build/bin/linux/configmap-server /bin/configmap-server
+COPY --from=builder /build/bin/linux/opm /bin/opm
 COPY --from=userspace /bin/cp /bin/cp
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051

--- a/docs/contributors/releases.md
+++ b/docs/contributors/releases.md
@@ -1,0 +1,23 @@
+# Releases
+
+## opm
+
+Releases of opm are built by travis, see the [travis.yml](../../.travis.yml) for details.
+
+## Triggering a release
+
+Releases are triggered via tags. Make a new release by tagging a commit with an appropriate semver tag.
+
+## Checking the build
+
+Builds for a release can be found [on travis](https://travis-ci.com/operator-framework/operator-registry). After triggering a build, watch for logs. If the build is successful, a new [release](https://github.com/operator-framework/operator-registry) should appear in GitHub.
+
+## Docker images
+
+Builds are also triggered for the following docker images. The tags in Quay.io will match the git tag:
+
+ - [quay.io/operator-framework/operator-registry-server](https://quay.io/repository/operator-framework/operator-registry-server)
+ - [quay.io/operator-framework/configmap-operator-registry](https://quay.io/repository/operator-framework/configmap-operator-registry)
+ - [quay.io/operator-framework/upstream-registry-builder](https://quay.io/repository/operator-framework/upstream-registry-builder?tab=tags)
+ 
+ Images are also built to track master with `latest` tags. It is recommended that you always pull by digest, and only use images that are tagged with a version.

--- a/opm-example.Dockerfile
+++ b/opm-example.Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/operator-framework/upstream-registry-builder AS builder
 FROM scratch
 LABEL operators.operatorframework.io.index.database.v1=./index.db
 COPY database ./
-COPY --from=builder /build/bin/opm /opm
+COPY --from=builder /build/bin/linux/opm /opm
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/opm"]

--- a/registry.Dockerfile
+++ b/registry.Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.12-alpine as builder
+FROM golang:1.13-alpine as builder
 
-RUN apk update && apk add sqlite build-base git mercurial
+RUN apk update && apk add sqlite build-base git mercurial bash
 WORKDIR /build
 
 COPY vendor vendor
@@ -14,7 +14,7 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.2.1 && \
     chmod +x /bin/grpc_health_probe
 
 FROM scratch
-COPY --from=builder /build/bin/registry-server /registry-server
+COPY --from=builder /build/bin/linux/registry-server /registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/registry-server"]

--- a/upstream-builder.Dockerfile
+++ b/upstream-builder.Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.12-alpine
+FROM golang:1.13-alpine
 
-RUN apk update && apk add sqlite build-base git mercurial
+RUN apk update && apk add sqlite build-base git mercurial bash
 WORKDIR /build
 
 COPY vendor vendor
@@ -12,3 +12,8 @@ RUN make static
 RUN GRPC_HEALTH_PROBE_VERSION=v0.2.1 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe
+RUN cp /build/bin/linux/opm /bin/opm && \
+    cp /build/bin/linux/initializer /bin/initializer && \
+    cp /build/bin/linux/appregistry-server /bin/appregistry-server && \
+    cp /build/bin/linux/configmap-server /bin/configmap-server && \
+    cp /build/bin/linux/registry-server /bin/registry-server

--- a/upstream-example.Dockerfile
+++ b/upstream-example.Dockerfile
@@ -1,11 +1,11 @@
 FROM quay.io/operator-framework/upstream-registry-builder as builder
 
 COPY manifests manifests
-RUN ./bin/initializer -o ./bundles.db
+RUN /bin/initializer -o ./bundles.db
 
 FROM scratch
 COPY --from=builder /build/bundles.db /bundles.db
-COPY --from=builder /build/bin/registry-server /registry-server
+COPY --from=builder /bin/registry-server /registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/registry-server"]


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

This adds a travis job that will build for mac, linux, and windows on tags.

This also required changing the makefile a bit to produce builds with different paths for each OS, which in turn meant that each dockerfile needed to be updated.

I won't be able to test the GH integration with tags until after this merges.

**Motivation for the change:**

Make builds available of opm for mac, linux, and windows.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
