### PR TITLE
Fix issue with empty docker error output

### DIFF
--- a/pkg/containertools/command.go
+++ b/pkg/containertools/command.go
@@ -2,6 +2,7 @@
 package containertools
 
 import (
+	"fmt"
 	"os/exec"
 
 	"github.com/sirupsen/logrus"
@@ -23,15 +24,15 @@ type CommandRunner interface {
 	Inspect(image string) ([]byte, error)
 }
 
-// ContainerCommandRunner is configured to select a container cli tool and execute commands with that
-// tooling.
+// ContainerCommandRunner is configured to select a container cli tool and
+// execute commands with that tooling.
 type ContainerCommandRunner struct {
 	logger        *logrus.Entry
 	containerTool string
 }
 
-// NewCommandRunner takes the containerTool as an input string and returns a CommandRunner to
-// run commands with that cli tool
+// NewCommandRunner takes the containerTool as an input string and returns a
+// CommandRunner to run commands with that cli tool
 func NewCommandRunner(containerTool string, logger *logrus.Entry) CommandRunner {
 	r := ContainerCommandRunner{
 		logger: logger,
@@ -54,8 +55,8 @@ func (r *ContainerCommandRunner) GetToolName() string {
 	return r.containerTool
 }
 
-// Pull takes a container image path hosted on a container registry and runs the pull command to
-// download it onto the local environment
+// Pull takes a container image path hosted on a container registry and runs the
+// pull command to download it onto the local environment
 func (r *ContainerCommandRunner) Pull(image string) error {
 	args := []string{"pull", image}
 
@@ -64,10 +65,10 @@ func (r *ContainerCommandRunner) Pull(image string) error {
 	r.logger.Infof("running %s pull", r.containerTool)
 	r.logger.Debugf("%s", command.Args)
 
-	out, err := command.Output()
+	out, err := command.CombinedOutput()
 	if err != nil {
 		r.logger.Errorf(string(out))
-		return err
+		return fmt.Errorf("error pulling image: %s. %v", string(out), err)
 	}
 
 	return nil
@@ -88,17 +89,17 @@ func (r *ContainerCommandRunner) Build(dockerfile, tag string) error {
 	r.logger.Infof("running %s build", r.containerTool)
 	r.logger.Infof("%s", command.Args)
 
-	out, err := command.Output()
+	out, err := command.CombinedOutput()
 	if err != nil {
 		r.logger.Errorf(string(out))
-		return err
+		return fmt.Errorf("error building image: %s. %v", string(out), err)
 	}
 
 	return nil
 }
 
-// Save takes a local container image and runs the save commmand to convert the image into a specified
-// tarball and push it to the local directory
+// Save takes a local container image and runs the save commmand to convert the
+// image into a specified tarball and push it to the local directory
 func (r *ContainerCommandRunner) Save(image, tarFile string) error {
 	args := []string{"save", image, "-o", tarFile}
 
@@ -107,17 +108,17 @@ func (r *ContainerCommandRunner) Save(image, tarFile string) error {
 	r.logger.Infof("running %s save", r.containerTool)
 	r.logger.Debugf("%s", command.Args)
 
-	out, err := command.Output()
+	out, err := command.CombinedOutput()
 	if err != nil {
 		r.logger.Errorf(string(out))
-		return err
+		return fmt.Errorf("error saving image: %s. %v", string(out), err)
 	}
 
 	return nil
 }
 
-// Inspect runs the 'inspect' command to get image metadata of a local container image
-// and returns a byte array of the command's output
+// Inspect runs the 'inspect' command to get image metadata of a local container
+// image and returns a byte array of the command's output
 func (r *ContainerCommandRunner) Inspect(image string) ([]byte, error) {
 	args := []string{"inspect", image}
 


### PR DESCRIPTION
Docker CLI returns error message via StdErr which doesn't get collected
from cmd.Output(). As a result, an empty tring is returned if an error
occurs with Docker CLI. Instead, using cmd.CombinedOutput() will collect
StdErr informationas well.

Bonus: Minor command wrapping to fit into 80 char limit to better
display the code in browser.

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
