### PR TITLE
chore(release): use robot for deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
+
 go:
 - 1.13
-sudo: true
 
 os:
 - linux
@@ -21,10 +21,12 @@ notifications:
 
 deploy:
   provider: releases
-  api_key:
-    secure: CMJ3KGhwuB7YRCYsJMe0cWAY/gkj2BVGorW9G1awxOyR2+Dv9G5PhItVkVfti0P2LzX8K2rplDp4O8b976wWzWJlJ6MQsSkFId0wYJSXRwNGdqnGhTLdDXB4FmPKapTBqTaYQgumrfvSOMiZ3tAwCD9AjW2fqYnBWnJXJ3yv8cpmN+TOZLJAKG+wAqb2foD9mS3HEQ9ItcoBqqEg8eRedzLuLGKVROLdFweLpi9gWdC22xLNomySwITTXX4kVs35MS0iwZE2cpTNDR8tLLIirHNgkiCCVYdiY0AB77Ikp5AF458UA064yr1b8TjAC3oyi4h6ddFaXo6CT9PZmsc41Te7cguSm2J9Ok2OdxLGitce7oty38QeY0QaG0oolcbXYw6QeiUXJ3BScAzVQBveDYgIACkSlsXAFEgdmR9YLOjYcw1MmquhmDbEuvaHi5T85aqsL8v5PUTMZq9+X/wOTqzR6D+8nQGqvqodxnopAFKpiR7UyiCl16VqrTJnkpWnYEerlx1i3Y7JLEiEK9O8UKL13J65cumCHPbcPNXbIsV6cFM+WXV8XhzKNOenrI5LZS9ske73wN9mOlgJKPwzEzP1H5hw1DTgm7gH/T+0bPCUdg7vh+dGavunjHEth1HmD2F8p6dvMC7+JG7Fjyw2PU76yl9DDm611p69A5auQ14=
-  file: bin/$TRAVIS_OS_NAME/opm
-  skip_cleanup: true
+  edge: true
+  token:
+    secure: 1mcUdIu9BBQloKWHEXIum9XFunDVDtWvbL5HuebsSJOlePTRnccBnhwwyxytkxO8bkWlB7RXRwa2JRKAOtrB2sgyvG4zthQeiyuq3qNRuZPyl/KxcHT5swYhwXaFy2kSmsG3WJy6Yx+Rw82yDelnyUkv2XcJODcU3Sf0CZIaYmCHmT9dFJ97yGd5x/Xbw+ApBIjRYQgL/NCXcvR/7ftIMUGcYc6zSMG9U6eWCvY28gZGhElvywbm51UuwOzK37jNKrp9xe4c+Fbp+7EqEUY4ooxCxX82PmJRDEcdjY0NLdafmPN40TA6oDB1873OEIWCa7+Lfn5k+X+JTcV/rPOfOIRB0vS04m5HWJONu4gNHB5lYl3DRHonbhF4X/hzkujlFGkWB/3XDwSj9X88McL0P7mwZsXV5KsiH7kqH3FTzlH2Fm3OTHhBOEJ1s+OEcwRlBRahh8LfzD6Da7BNncSWi2zdc7erD5WVmeiJngZXzGquo3Ly3GWB9Pfkd0rriclHC0CmIj5EeD7NBnrCu18dwdlKRR5L18dUmoLV1I/IUh0BIn0i7CNt3iw15LVX4Lk6wz2JzEfytGQ3GzfIf4cPjmGqIYwlOUuyiht7AyEUg3QIBiqTbU/PL+krvFhAtf3RkD7/5+NZF6VF4p4hYXJN0sGq3XOsN7Ol1nVvc6RpAlk=
+  file_glob: true
+  file: bin/**/*-opm
+  cleanup: false
   on:
     repo: operator-framework/operator-registry
     tags: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,11 @@ FROM openshift/origin-base
 RUN mkdir /registry
 WORKDIR /registry
 
-COPY --from=builder /src/bin/linux/initializer /bin/initializer
-COPY --from=builder /src/bin/linux/registry-server /bin/registry-server
-COPY --from=builder /src/bin/linux/configmap-server /bin/configmap-server
-COPY --from=builder /src/bin/linux/appregistry-server /bin/appregistry-server
-COPY --from=builder /src/bin/linux/opm /bin/opm
+COPY --from=builder /src/bin/linux-amd64-initializer /bin/initializer
+COPY --from=builder /src/bin/linux-amd64-registry-server /bin/registry-server
+COPY --from=builder /src/bin/linux-amd64-configmap-server /bin/configmap-server
+COPY --from=builder /src/bin/linux-amd64-appregistry-server /bin/appregistry-server
+COPY --from=builder /src/bin/linux-amd64-opm /bin/opm
 COPY --from=builder /go/bin/grpc-health-probe /bin/grpc_health_probe
 
 RUN chgrp -R 0 /registry && \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GOOS := $(shell go env GOOS)
-OS := $(shell bash -c 'if [[ $(GOOS) == darwin ]]; then echo osx; else echo $(GOOS); fi')
-CMDS  := $(addprefix bin/$(OS)/, $(shell ls ./cmd))
+GOARCH := $(shell go env GOARCH)
+CMDS  := $(addprefix bin/$(GOOS)-$(GOARCH)-, $(shell ls ./cmd))
 SPECIFIC_UNIT_TEST := $(if $(TEST),-run $(TEST),)
 MOD_FLAGS := $(shell bash -c 'if [[ "$(shell go env GOFLAGS)" == "-mod=vendor" ]]; then echo ""; else echo "-mod=vendor"; fi')
 
@@ -9,7 +9,7 @@ MOD_FLAGS := $(shell bash -c 'if [[ "$(shell go env GOFLAGS)" == "-mod=vendor" ]
 all: clean test build
 
 $(CMDS):
-	go build $(MOD_FLAGS) $(extra_flags) -o $@ ./cmd/$(shell basename $@)
+	go build $(MOD_FLAGS) $(extra_flags) -o $@ ./cmd/$(shell basename $@ | cut -d- -f3-)
 
 build: clean $(CMDS)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.com/operator-framework/operator-registry.svg?branch=master)](https://travis-ci.com/operator-framework/operator-registry)
 # operator-registry
 
 Operator Registry runs in a Kubernetes or OpenShift cluster to provide operator catalog data to [Operator Lifecycle Manager](https://github.com/operator-framework/operator-lifecycle-manager). 

--- a/appr-registry.Dockerfile
+++ b/appr-registry.Dockerfile
@@ -20,12 +20,9 @@ WORKDIR /go/src/$PROJECT
 COPY --from=builder /go/src/github.com/operator-framework/operator-registry/vendor/$ORG/grpc-health-probe .
 COPY --from=builder /go/src/github.com/operator-framework/operator-registry/vendor .
 RUN CGO_ENABLED=0 go install -a -tags netgo -ldflags "-w"
-RUN ls /go/bin
-RUN ls .
-
 
 FROM scratch
-COPY --from=builder /go/src/github.com/operator-framework/operator-registry/bin/linux/appregistry-server /bin/appregistry-server
+COPY --from=builder /go/src/github.com/operator-framework/operator-registry/bin/linux-amd64-appregistry-server /bin/appregistry-server
 COPY --from=probe-builder /go/bin/grpc-health-probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/bin/appregistry-server"]

--- a/configmap-registry.Dockerfile
+++ b/configmap-registry.Dockerfile
@@ -2,8 +2,8 @@ FROM quay.io/operator-framework/upstream-registry-builder:latest as builder
 FROM busybox as userspace
 
 FROM scratch
-COPY --from=builder /build/bin/linux/configmap-server /bin/configmap-server
-COPY --from=builder /build/bin/linux/opm /bin/opm
+COPY --from=builder /build/bin/linux-amd64-configmap-server /bin/configmap-server
+COPY --from=builder /build/bin/linux-amd64-opm /bin/opm
 COPY --from=userspace /bin/cp /bin/cp
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051

--- a/docs/contributors/releases.md
+++ b/docs/contributors/releases.md
@@ -21,3 +21,20 @@ Builds are also triggered for the following docker images. The tags in Quay.io w
  - [quay.io/operator-framework/upstream-registry-builder](https://quay.io/repository/operator-framework/upstream-registry-builder?tab=tags)
  
  Images are also built to track master with `latest` tags. It is recommended that you always pull by digest, and only use images that are tagged with a version.
+ 
+ 
+## Generating Travis API keys
+
+This requires the travis CLI tool to be installed.
+
+First, backup the existing deploy config in `.travis.yml` - the prompts will overwrite some of the config, and 
+we only need the generated api token. This can be done by renaming the `deploy` yaml key to something else.
+
+```sh
+$ travis setup releases -r operator-framework/operator-registry --force --pro
+```
+
+When prompted, enter credentials for the of-deploy-robot account. Copy the api key from the newly generated `deploy` section in .travis.yml, place
+it in the right place in the actual deploy config, and delete the generated deploy section.
+
+You mean need to `travis login --pro` first.

--- a/opm-example.Dockerfile
+++ b/opm-example.Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/operator-framework/upstream-registry-builder AS builder
 FROM scratch
 LABEL operators.operatorframework.io.index.database.v1=./index.db
 COPY database ./
-COPY --from=builder /build/bin/linux/opm /opm
+COPY --from=builder /build/bin/linux-amd64-opm /opm
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/opm"]

--- a/registry.Dockerfile
+++ b/registry.Dockerfile
@@ -14,7 +14,7 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.2.1 && \
     chmod +x /bin/grpc_health_probe
 
 FROM scratch
-COPY --from=builder /build/bin/linux/registry-server /registry-server
+COPY --from=builder /build/bin/linux-amd64-registry-server /registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/registry-server"]

--- a/upstream-builder.Dockerfile
+++ b/upstream-builder.Dockerfile
@@ -12,8 +12,8 @@ RUN make static
 RUN GRPC_HEALTH_PROBE_VERSION=v0.2.1 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe
-RUN cp /build/bin/linux/opm /bin/opm && \
-    cp /build/bin/linux/initializer /bin/initializer && \
-    cp /build/bin/linux/appregistry-server /bin/appregistry-server && \
-    cp /build/bin/linux/configmap-server /bin/configmap-server && \
-    cp /build/bin/linux/registry-server /bin/registry-server
+RUN cp /build/bin/linux-amd64-opm /bin/opm && \
+    cp /build/bin/linux-amd64-initializer /bin/initializer && \
+    cp /build/bin/linux-amd64-appregistry-server /bin/appregistry-server && \
+    cp /build/bin/linux-amd64-configmap-server /bin/configmap-server && \
+    cp /build/bin/linux-amd64-registry-server /bin/registry-server


### PR DESCRIPTION
**Description of the change:**
This switches the api key to use `of-deploy-bot`'s credentials, which currently only has write on this repo (versus my credentials which have access to many and which I will now rotate).

This also shuffles the release artifacts a bit so that they don't conflict when updating a release. See this test release made from this branch: https://github.com/operator-framework/operator-registry/releases/tag/v0.0.7-test

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
