### PR TITLE
Bug 1795658: Remove dependency on sqlite from pkg/configmap.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -514,8 +514,6 @@ github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible/go.mo
 github.com/openshift/client-go v0.0.0-20190923180330-3b6373338c9b/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
-github.com/operator-framework/api v0.0.0-20191127212340-9066a6e95573 h1:bMO43IWWPM3HCGIiuM/GyXjtSJWsrhOlzUpZMesVUw0=
-github.com/operator-framework/api v0.0.0-20191127212340-9066a6e95573/go.mod h1:S5IdlJvmKkF84K2tBvsrqJbI2FVy03P88R75snpRxJo=
 github.com/operator-framework/api v0.0.0-20200120235816-80fd2f1a09c9 h1:HfxMEPJ0djo/RNfrmli3kI2oKS6IeuIZWu1Q5Rewt/o=
 github.com/operator-framework/api v0.0.0-20200120235816-80fd2f1a09c9/go.mod h1:S5IdlJvmKkF84K2tBvsrqJbI2FVy03P88R75snpRxJo=
 github.com/operator-framework/operator-lifecycle-manager v0.0.0-20191115003340-16619cd27fa5 h1:rjaihxY50c5C+kbQIK4s36R8zxByATYrgRbua4eiG6o=

--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/operator-framework/operator-registry/pkg/api"
 	"github.com/operator-framework/operator-registry/pkg/registry"
-	"github.com/operator-framework/operator-registry/pkg/sqlite"
 )
 
 func NewBundleLoader() *BundleLoader {
@@ -72,7 +71,7 @@ func loadBundle(entry *logrus.Entry, data map[string]string) (bundle *api.Bundle
 			continue
 		}
 
-		if resource.GetKind() == sqlite.ClusterServiceVersionKind {
+		if resource.GetKind() == "ClusterServiceVersion" {
 			csvBytes, err := resource.MarshalJSON()
 			if err != nil {
 				return nil, nil, err

--- a/pkg/configmap/configmap_writer.go
+++ b/pkg/configmap/configmap_writer.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 
 	"github.com/ghodss/yaml"
-	_ "github.com/mattn/go-sqlite3"
 	errorwrap "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	batchv1 "k8s.io/api/batch/v1"


### PR DESCRIPTION
The package github.com/mattn/go-sqlite3 needs CGO enabled to
build. Since pkg/configmap has both direct and transitive dependencies
on go-sqlite3, anything importing pkg/configmap will also need to
enable CGO.
