### PR TITLE
Bug 1795237: Revert "fix(ci): build opm statically in CI"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY vendor vendor
 COPY cmd cmd
 COPY pkg pkg
 COPY Makefile go.mod go.sum ./
-RUN make static
+RUN make build
 
 # copy and build vendored grpc_health_probe
 RUN mkdir -p /go/src/github.com/grpc-ecosystem && \


### PR DESCRIPTION
Reverts operator-framework/operator-registry#160