### PR TITLE
fix(index): copy correct opm bin builder path

### DIFF
--- a/index.Dockerfile
+++ b/index.Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/operator-framework/upstream-registry-builder AS builder
 FROM scratch
 LABEL operators.operatorframework.io.index.database.v1=./index.db
 COPY database ./
-COPY --from=builder /build/bin/opm /opm
+COPY --from=builder /bin/opm /opm
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/opm"]

--- a/pkg/containertools/dockerfilegenerator.go
+++ b/pkg/containertools/dockerfilegenerator.go
@@ -53,7 +53,7 @@ func (g *IndexDockerfileGenerator) GenerateIndexDockerfile(binarySourceImage, da
 
 	// Content
 	dockerfile += fmt.Sprintf("COPY %s ./\n", databaseFolder)
-	dockerfile += fmt.Sprintf("COPY --from=builder /build/bin/opm /opm\n")
+	dockerfile += fmt.Sprintf("COPY --from=builder /bin/opm /opm\n")
 	dockerfile += fmt.Sprintf("COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe\n")
 	dockerfile += fmt.Sprintf("EXPOSE 50051\n")
 	dockerfile += fmt.Sprintf("ENTRYPOINT [\"/opm\"]\n")

--- a/pkg/containertools/dockerfilegenerator_test.go
+++ b/pkg/containertools/dockerfilegenerator_test.go
@@ -21,7 +21,7 @@ func TestGenerateDockerfile(t *testing.T) {
 FROM scratch
 LABEL operators.operatorframework.io.index.database.v1=./index.db
 COPY database ./
-COPY --from=builder /build/bin/opm /opm
+COPY --from=builder /bin/opm /opm
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/opm"]
@@ -48,7 +48,7 @@ func TestGenerateDockerfile_EmptyBaseImage(t *testing.T) {
 FROM scratch
 LABEL operators.operatorframework.io.index.database.v1=./index.db
 COPY database ./
-COPY --from=builder /build/bin/opm /opm
+COPY --from=builder /bin/opm /opm
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/opm"]


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Use the correct path when copying `opm` from the builder image for generated index Dockerfiles.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
