### PR TITLE
Fix the opm binary path

### DIFF
--- a/docs/design/opm-tooling.md
+++ b/docs/design/opm-tooling.md
@@ -66,7 +66,7 @@ FROM quay.io/operator-framework/upstream-registry-builder AS builder
 FROM scratch
 LABEL operators.operatorframework.io.index.database.v1=./index.db
 COPY database ./
-COPY --from=builder /build/bin/opm /opm
+COPY --from=builder /build/bin/linux-amd64-opm /opm
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/opm"]

--- a/index.Dockerfile
+++ b/index.Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/operator-framework/upstream-registry-builder AS builder
 FROM scratch
 LABEL operators.operatorframework.io.index.database.v1=./index.db
 COPY database ./
-COPY --from=builder /build/bin/opm /opm
+COPY --from=builder /build/bin/linux-amd64-opm /opm
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/opm"]

--- a/pkg/containertools/dockerfilegenerator.go
+++ b/pkg/containertools/dockerfilegenerator.go
@@ -53,7 +53,7 @@ func (g *IndexDockerfileGenerator) GenerateIndexDockerfile(binarySourceImage, da
 
 	// Content
 	dockerfile += fmt.Sprintf("COPY %s ./\n", databaseFolder)
-	dockerfile += fmt.Sprintf("COPY --from=builder /build/bin/opm /opm\n")
+	dockerfile += fmt.Sprintf("COPY --from=builder /build/bin/linux-amd64-opm /opm\n")
 	dockerfile += fmt.Sprintf("COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe\n")
 	dockerfile += fmt.Sprintf("EXPOSE 50051\n")
 	dockerfile += fmt.Sprintf("ENTRYPOINT [\"/opm\"]\n")

--- a/pkg/containertools/dockerfilegenerator_test.go
+++ b/pkg/containertools/dockerfilegenerator_test.go
@@ -21,7 +21,7 @@ func TestGenerateDockerfile(t *testing.T) {
 FROM scratch
 LABEL operators.operatorframework.io.index.database.v1=./index.db
 COPY database ./
-COPY --from=builder /build/bin/opm /opm
+COPY --from=builder /build/bin/linux-amd64-opm /opm
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/opm"]
@@ -48,7 +48,7 @@ func TestGenerateDockerfile_EmptyBaseImage(t *testing.T) {
 FROM scratch
 LABEL operators.operatorframework.io.index.database.v1=./index.db
 COPY database ./
-COPY --from=builder /build/bin/opm /opm
+COPY --from=builder /build/bin/linux-amd64-opm /opm
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/opm"]


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
The generated docker file expects the opm binary to be under /build/bin/opm.
Though, the name of the binary changed.

```
$ docker run -it quay.io/operator-framework/upstream-registry-builder ls /build/bin
linux-amd64-appregistry-server  linux-amd64-opm
linux-amd64-configmap-server    linux-amd64-registry-server
linux-amd64-initializer
```

**Motivation for the change:**

Otherwise, I will get:
```
# ./bin/linux-amd64-opm index add --bundles quay.io/jchaloup/ose-cluster-kube-descheduler-operator-bundle:latest --tag quay.io/jchaloup/ose-cluster-kube-descheduler-operator-bundle-index:1.0.0
INFO[0000] building the index                            bundles="[quay.io/jchaloup/ose-cluster-kube-descheduler-operator-bundle:latest]"
INFO[0000] running podman pull                           img="quay.io/jchaloup/ose-cluster-kube-descheduler-operator-bundle:latest"
INFO[0000] running podman save                           img="quay.io/jchaloup/ose-cluster-kube-descheduler-operator-bundle:latest"
INFO[0006] loading Bundle quay.io/jchaloup/ose-cluster-kube-descheduler-operator-bundle:latest  img="quay.io/jchaloup/ose-cluster-kube-descheduler-operator-bundle:latest"
INFO[0006] found annotations file searching for csv      dir=bundle_tmp432563351 file=bundle_tmp432563351/metadata load=annotations
INFO[0006] found csv, loading bundle                     dir=bundle_tmp432563351 file=bundle_tmp432563351/manifests load=bundle
INFO[0006] loading bundle file                           dir=bundle_tmp432563351/manifests file=cluster-kube-descheduler-operator.v4.4.0.clusterserviceversion.yaml load=bundle
INFO[0006] loading bundle file                           dir=bundle_tmp432563351/manifests file=image-references load=bundle
INFO[0006] loading bundle file                           dir=bundle_tmp432563351/manifests file=kube-descheduler-operator.crd.yaml load=bundle
INFO[0006] loading bundle file                           dir=bundle_tmp432563351/manifests file=kube-system-rolebinding.yaml load=bundle
INFO[0006] Generating dockerfile                         bundles="[quay.io/jchaloup/ose-cluster-kube-descheduler-operator-bundle:latest]"
INFO[0006] writing dockerfile: index.Dockerfile804812513  bundles="[quay.io/jchaloup/ose-cluster-kube-descheduler-operator-bundle:latest]"
INFO[0006] running podman build                          bundles="[quay.io/jchaloup/ose-cluster-kube-descheduler-operator-bundle:latest]"
INFO[0006] [podman build -f index.Dockerfile804812513 -t quay.io/jchaloup/ose-cluster-kube-descheduler-operator-bundle-index:1.0.0 .]  bundles="[quay.io/jchaloup/ose-cluster-kube-descheduler-operator-bundle:latest]"
ERRO[0007] STEP 1: FROM quay.io/operator-framework/upstream-registry-builder AS builder
5bc0d687217f3da8bc75930ce2414412b98be1d0bb2fecb760398fa319f00e3a
STEP 2: FROM scratch
STEP 3: LABEL operators.operatorframework.io.index.database.v1=./index.db
--> Using cache a4293823a9b716f8e7386bd1a2673ab7770dd6fdbf3119d5b572c962c9abd97f
STEP 4: COPY index_tmp049218072 ./
94a90bcdc7a9eb9ba04f59fe7cb8cd66ea125ccd7114eb273763bdf85d1c93b7
STEP 5: COPY --from=builder /build/bin/opm /opm
Error: error building at STEP "COPY --from=builder /build/bin/opm /opm": no files found matching "/var/lib/containers/storage/overlay/f61fd774c27260dc4eb5fc012fc29e9748021d69d69e3fd1ecbf65c48ec286fc/merged/build/bin/opm": no such file or directory  bundles="[quay.io/jchaloup/ose-cluster-kube-descheduler-operator-bundle:latest]"
Error: error building image: STEP 1: FROM quay.io/operator-framework/upstream-registry-builder AS builder
5bc0d687217f3da8bc75930ce2414412b98be1d0bb2fecb760398fa319f00e3a
STEP 2: FROM scratch
STEP 3: LABEL operators.operatorframework.io.index.database.v1=./index.db
--> Using cache a4293823a9b716f8e7386bd1a2673ab7770dd6fdbf3119d5b572c962c9abd97f
STEP 4: COPY index_tmp049218072 ./
94a90bcdc7a9eb9ba04f59fe7cb8cd66ea125ccd7114eb273763bdf85d1c93b7
STEP 5: COPY --from=builder /build/bin/opm /opm
Error: error building at STEP "COPY --from=builder /build/bin/opm /opm": no files found matching "/var/lib/containers/storage/overlay/f61fd774c27260dc4eb5fc012fc29e9748021d69d69e3fd1ecbf65c48ec286fc/merged/build/bin/opm": no such file or directory
. exit status 125
Usage:
  opm index add [flags]

Examples:
  # Create an index image from scratch with a single bundle image
  opm index add --bundles quay.io/operator-framework/operator-bundle-prometheus@sha256:a3ee653ffa8a0d2bbb2fabb150a94da6e878b6e9eb07defd40dc884effde11a0 --tag quay.io/operator-framework/monitoring:1.0.0
  
  # Add a single bundle image to an index image
  opm index add --bundles quay.io/operator-framework/operator-bundle-prometheus:0.15.0 --from-index quay.io/operator-framework/monitoring:1.0.0 --tag quay.io/operator-framework/monitoring:1.0.1
  
  # Add multiple bundles to an index and generate a Dockerfile instead of an image
  opm index add --bundles quay.io/operator-framework/operator-bundle-prometheus:0.15.0,quay.io/operator-framework/operator-bundle-prometheus:0.22.2 --generate

Flags:
  -i, --binary-image opm        container image for on-image opm command
  -b, --bundles strings         comma separated list of bundles to add
  -c, --container-tool string   tool to interact with container images (save, build, etc.). One of: [docker, podman] (default "podman")
  -f, --from-index string       previous index to add to
      --generate                if enabled, just creates the dockerfile and saves it to local disk
  -h, --help                    help for add
  -d, --out-dockerfile string   if generating the dockerfile, this flag is used to (optionally) specify a dockerfile name
      --permissive              allow registry load errors
  -t, --tag string              custom tag for container image being built
```

Other branches are affected as well (just checked release-4.4 one).

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
