### PR TITLE
Bug 1800460: fix(docker): add entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,9 @@ USER 1001
 
 EXPOSE 50051
 
+ENTRYPOINT ["/bin/registry-server"]
+CMD ["--database", "/bundles.db"]
+
 LABEL io.k8s.display-name="OpenShift Operator Registry" \
     io.k8s.description="This is a component of OpenShift Operator Lifecycle Manager and is the base for operator catalog API containers." \
     maintainer="Odin Team <aos-odin@redhat.com>" \


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This adds a default entrypoint to the root Dockerfile that serves a registry image.

**Motivation for the change:**
This allows the image built from the Dockerfile to be used as a registry based simply by `oc image append`ing a database to the image. 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
