### PR TITLE
Produce binaries without target platform prefixes by default.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ script:
 notifications:
   email: false
 
+before_deploy:
+- ls bin | xargs -n1 -I{} mv bin/{} "bin/$(go env GOOS)-$(go env GOARCH)-{}"
 deploy:
   provider: releases
   edge: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,11 @@ FROM openshift/origin-base
 RUN mkdir /registry
 WORKDIR /registry
 
-COPY --from=builder /src/bin/linux-amd64-initializer /bin/initializer
-COPY --from=builder /src/bin/linux-amd64-registry-server /bin/registry-server
-COPY --from=builder /src/bin/linux-amd64-configmap-server /bin/configmap-server
-COPY --from=builder /src/bin/linux-amd64-appregistry-server /bin/appregistry-server
-COPY --from=builder /src/bin/linux-amd64-opm /bin/opm
+COPY --from=builder /src/bin/initializer /bin/initializer
+COPY --from=builder /src/bin/registry-server /bin/registry-server
+COPY --from=builder /src/bin/configmap-server /bin/configmap-server
+COPY --from=builder /src/bin/appregistry-server /bin/appregistry-server
+COPY --from=builder /src/bin/opm /bin/opm
 COPY --from=builder /go/bin/grpc-health-probe /bin/grpc_health_probe
 
 RUN chgrp -R 0 /registry && \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GOOS := $(shell go env GOOS)
 GOARCH := $(shell go env GOARCH)
-CMDS  := $(addprefix bin/$(GOOS)-$(GOARCH)-, $(shell ls ./cmd))
+CMDS := $(addprefix bin/, $(shell ls ./cmd))
 SPECIFIC_UNIT_TEST := $(if $(TEST),-run $(TEST),)
 MOD_FLAGS := $(shell bash -c 'if [[ "$(shell go env GOFLAGS)" == "-mod=vendor" ]]; then echo ""; else echo "-mod=vendor"; fi')
 
@@ -9,7 +9,7 @@ MOD_FLAGS := $(shell bash -c 'if [[ "$(shell go env GOFLAGS)" == "-mod=vendor" ]
 all: clean test build
 
 $(CMDS):
-	go build $(MOD_FLAGS) $(extra_flags) -o $@ ./cmd/$(shell basename $@ | cut -d- -f3-)
+	go build $(MOD_FLAGS) $(extra_flags) -o $@ ./cmd/$(notdir $@)
 
 build: clean $(CMDS)
 

--- a/appr-registry.Dockerfile
+++ b/appr-registry.Dockerfile
@@ -22,7 +22,7 @@ COPY --from=builder /go/src/github.com/operator-framework/operator-registry/vend
 RUN CGO_ENABLED=0 go install -a -tags netgo -ldflags "-w"
 
 FROM scratch
-COPY --from=builder /go/src/github.com/operator-framework/operator-registry/bin/linux-amd64-appregistry-server /bin/appregistry-server
+COPY --from=builder /go/src/github.com/operator-framework/operator-registry/bin/appregistry-server /bin/appregistry-server
 COPY --from=probe-builder /go/bin/grpc-health-probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/bin/appregistry-server"]

--- a/configmap-registry.Dockerfile
+++ b/configmap-registry.Dockerfile
@@ -2,8 +2,8 @@ FROM quay.io/operator-framework/upstream-registry-builder:latest as builder
 FROM busybox as userspace
 
 FROM scratch
-COPY --from=builder /build/bin/linux-amd64-configmap-server /bin/configmap-server
-COPY --from=builder /build/bin/linux-amd64-opm /bin/opm
+COPY --from=builder /build/bin/configmap-server /bin/configmap-server
+COPY --from=builder /build/bin/opm /bin/opm
 COPY --from=userspace /bin/cp /bin/cp
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051

--- a/opm-example.Dockerfile
+++ b/opm-example.Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/operator-framework/upstream-registry-builder AS builder
 FROM scratch
 LABEL operators.operatorframework.io.index.database.v1=./index.db
 COPY database ./
-COPY --from=builder /build/bin/linux-amd64-opm /opm
+COPY --from=builder /build/bin/opm /opm
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/opm"]

--- a/registry.Dockerfile
+++ b/registry.Dockerfile
@@ -10,11 +10,11 @@ COPY Makefile Makefile
 COPY go.mod go.mod
 RUN make static
 RUN GRPC_HEALTH_PROBE_VERSION=v0.2.1 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-$(go env GOARCH) && \
     chmod +x /bin/grpc_health_probe
 
 FROM scratch
-COPY --from=builder /build/bin/linux-amd64-registry-server /registry-server
+COPY --from=builder /build/bin/registry-server /registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/registry-server"]

--- a/upstream-builder.Dockerfile
+++ b/upstream-builder.Dockerfile
@@ -10,10 +10,10 @@ COPY Makefile Makefile
 COPY go.mod go.mod
 RUN make static
 RUN GRPC_HEALTH_PROBE_VERSION=v0.2.1 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-$(go env GOARCH) && \
     chmod +x /bin/grpc_health_probe
-RUN cp /build/bin/linux-amd64-opm /bin/opm && \
-    cp /build/bin/linux-amd64-initializer /bin/initializer && \
-    cp /build/bin/linux-amd64-appregistry-server /bin/appregistry-server && \
-    cp /build/bin/linux-amd64-configmap-server /bin/configmap-server && \
-    cp /build/bin/linux-amd64-registry-server /bin/registry-server
+RUN cp /build/bin/opm /bin/opm && \
+    cp /build/bin/initializer /bin/initializer && \
+    cp /build/bin/appregistry-server /bin/appregistry-server && \
+    cp /build/bin/configmap-server /bin/configmap-server && \
+    cp /build/bin/registry-server /bin/registry-server


### PR DESCRIPTION
This is aimed at fixing downstream image builds targeting non-amd64
architectures.
