### PR TITLE
fix(index): gen index dockerfiles from opm image

### DIFF
--- a/pkg/containertools/dockerfilegenerator.go
+++ b/pkg/containertools/dockerfilegenerator.go
@@ -8,9 +8,8 @@ import (
 )
 
 const (
-	baseImage                = "scratch"
 	defaultBinarySourceImage = "quay.io/operator-framework/upstream-registry-builder"
-	DefaultDbLocation        = "./index.db"
+	DefaultDbLocation        = "/database/index.db"
 	DbLocationLabel          = "operators.operatorframework.io.index.database.v1"
 )
 
@@ -42,22 +41,17 @@ func (g *IndexDockerfileGenerator) GenerateIndexDockerfile(binarySourceImage, da
 
 	g.Logger.Info("Generating dockerfile")
 
-	// Where to collect the binary
-	dockerfile += fmt.Sprintf("FROM %s AS builder\n", binarySourceImage)
-
 	// From
-	dockerfile += fmt.Sprintf("\nFROM %s\n", baseImage)
+	dockerfile += fmt.Sprintf("FROM %s\n", binarySourceImage)
 
 	// Labels
 	dockerfile += fmt.Sprintf("LABEL %s=%s\n", DbLocationLabel, DefaultDbLocation)
 
 	// Content
-	dockerfile += fmt.Sprintf("COPY %s ./\n", databaseFolder)
-	dockerfile += fmt.Sprintf("COPY --from=builder /bin/opm /opm\n")
-	dockerfile += fmt.Sprintf("COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe\n")
+	dockerfile += fmt.Sprintf("ADD %s /database\n", databaseFolder)
 	dockerfile += fmt.Sprintf("EXPOSE 50051\n")
-	dockerfile += fmt.Sprintf("ENTRYPOINT [\"/opm\"]\n")
-	dockerfile += fmt.Sprintf("CMD [\"registry\", \"serve\", \"--database\", \"index.db\"]\n")
+	dockerfile += fmt.Sprintf("ENTRYPOINT [\"/bin/opm\"]\n")
+	dockerfile += fmt.Sprintf("CMD [\"registry\", \"serve\", \"--database\", \"%s\"]\n", DefaultDbLocation)
 
 	return dockerfile
 }

--- a/pkg/containertools/dockerfilegenerator_test.go
+++ b/pkg/containertools/dockerfilegenerator_test.go
@@ -16,16 +16,12 @@ func TestGenerateDockerfile(t *testing.T) {
 
 	binarySourceImage := "quay.io/operator-framework/builder"
 	databaseFolder := "database"
-	expectedDockerfile := `FROM quay.io/operator-framework/builder AS builder
-
-FROM scratch
-LABEL operators.operatorframework.io.index.database.v1=./index.db
-COPY database ./
-COPY --from=builder /bin/opm /opm
-COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
+	expectedDockerfile := `FROM quay.io/operator-framework/builder
+LABEL operators.operatorframework.io.index.database.v1=/database/index.db
+ADD database /database
 EXPOSE 50051
-ENTRYPOINT ["/opm"]
-CMD ["registry", "serve", "--database", "index.db"]
+ENTRYPOINT ["/bin/opm"]
+CMD ["registry", "serve", "--database", "/database/index.db"]
 `
 
 	logger := logrus.NewEntry(logrus.New())
@@ -43,16 +39,12 @@ func TestGenerateDockerfile_EmptyBaseImage(t *testing.T) {
 	defer controller.Finish()
 
 	databaseFolder := "database"
-	expectedDockerfile := `FROM quay.io/operator-framework/upstream-registry-builder AS builder
-
-FROM scratch
-LABEL operators.operatorframework.io.index.database.v1=./index.db
-COPY database ./
-COPY --from=builder /bin/opm /opm
-COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
+	expectedDockerfile := `FROM quay.io/operator-framework/upstream-registry-builder
+LABEL operators.operatorframework.io.index.database.v1=/database/index.db
+ADD database /database
 EXPOSE 50051
-ENTRYPOINT ["/opm"]
-CMD ["registry", "serve", "--database", "index.db"]
+ENTRYPOINT ["/bin/opm"]
+CMD ["registry", "serve", "--database", "/database/index.db"]
 `
 
 	logger := logrus.NewEntry(logrus.New())


### PR DESCRIPTION
Generate Dockerfiles on index add with a single stage FROM the binary opm image given to avoid issues when opm isn't compiled with static linking.

