### PR TITLE
upstream-builder: update grpc-health-probe version

### DIFF
--- a/registry.Dockerfile
+++ b/registry.Dockerfile
@@ -9,7 +9,7 @@ COPY pkg pkg
 COPY Makefile Makefile
 COPY go.mod go.mod
 RUN make static
-RUN GRPC_HEALTH_PROBE_VERSION=v0.2.1 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-$(go env GOARCH) && \
     chmod +x /bin/grpc_health_probe
 

--- a/upstream-builder.Dockerfile
+++ b/upstream-builder.Dockerfile
@@ -9,7 +9,7 @@ COPY pkg pkg
 COPY Makefile Makefile
 COPY go.mod go.mod
 RUN make static
-RUN GRPC_HEALTH_PROBE_VERSION=v0.2.1 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-$(go env GOARCH) && \
     chmod +x /bin/grpc_health_probe
 RUN cp /build/bin/opm /bin/opm && \


### PR DESCRIPTION
This version provides binaries for ARM 64, IBM Power LE, and IBM Z architectures:

https://github.com/grpc-ecosystem/grpc-health-probe/releases/tag/v0.3.2
