### PR TITLE
[WIP] feat: add bundle commutativity checks to opm registry add command

### DIFF
--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -34,7 +34,6 @@ func NewSQLLoaderForImage(store registry.Load, image, containerTool string) *Ima
 }
 
 func (i *ImageLoader) Populate() error {
-
 	log := logrus.WithField("img", i.image)
 
 	workingDir, err := ioutil.TempDir("./", "bundle_tmp")

--- a/pkg/sqlite/multi_image.go
+++ b/pkg/sqlite/multi_image.go
@@ -1,0 +1,26 @@
+package sqlite
+
+import "github.com/operator-framework/operator-registry/pkg/registry"
+
+// MultiImageLoader loads multiple bundle images into the database.
+// It builds a graph between the new bundles and those already present in the database.
+type MultiImageLoader struct {
+	store         registry.Load
+	images        []string
+	directory     string
+	containerTool string
+}
+
+var _ SQLPopulator = &MultiImageLoader{}
+
+func NewSQLLoaderForMultiImage(store registry.Load, bundles []string, containerTool string) *MultiImageLoader {
+	return &MultiImageLoader{
+		store:         store,
+		images:        bundles,
+		containerTool: containerTool,
+	}
+}
+
+func (m *MultiImageLoader) Populate() error {
+	return nil
+}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Add support for adding multiple packages in different order to the `opm registry add` command. 

Acceptance Criteria:
The opm commands in operator registry that add bundle images to existing registry databases are order independent.

This comes for free with semver bundles, but these bundles are not treated any differently for the purposes of this PR so the hot codepath stays the same. The idea was to keep the existing code (that generally assumes one bundle is loaded independently of another) as in-tact as possible while extending it (having the command aware of other bundles being loaded simultaneously) 

**Motivation for the change:**
More opm features around index upgrade paths 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
