### PR TITLE
[travis] pinning minikube version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ jobs:
       chmod +x minikube
       sudo mv minikube /bin/
       minikube config set vm-driver none
+      minikube config set kubernetes-version v1.17.3
   - os: osx
     install: |
       brew install make

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
       chmod +x minikube
       sudo mv minikube /bin/
       minikube config set vm-driver none
-      minikube config set kubernetes-version v1.17.3
+      minikube config set kubernetes-version $(go list -f '{{.Version}}' -m k8s.io/api | sed 's/^v0\./v1./')
   - os: osx
     install: |
       brew install make


### PR DESCRIPTION
This commit sets the minikube version to v1.17.3 and matches go.mod.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
