### PR TITLE
[dockerfile] removing dev directory permission change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,7 @@ COPY --from=builder /src/bin/opm /bin/opm
 COPY --from=builder /go/bin/grpc-health-probe /bin/grpc_health_probe
 
 RUN chgrp -R 0 /registry && \
-    chgrp -R 0 /dev && \
-    chmod -R g+rwx /registry && \
-    chmod -R g+rwx /dev
+    chmod -R g+rwx /registry
 
 # This image doesn't need to run as root user
 USER 1001


### PR DESCRIPTION
openshift ci test is changing from 3.11 clauster to 4.3 and started to use buildah instead of docker for building image from dockerfiles. This commit fix image test failure byu removing dev directory permission change.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
