### PR TITLE
Fixing ci and travis tests 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ jobs:
       chmod +x minikube
       sudo mv minikube /bin/
       minikube config set vm-driver none
+      minikube config set kubernetes-version $(go list -f '{{.Version}}' -m k8s.io/api | sed 's/^v0\./v1./')
   - os: osx
     install: |
       brew install make

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,7 @@ COPY --from=builder /src/bin/opm /bin/opm
 COPY --from=builder /go/bin/grpc-health-probe /bin/grpc_health_probe
 
 RUN chgrp -R 0 /registry && \
-    chgrp -R 0 /dev && \
-    chmod -R g+rwx /registry && \
-    chmod -R g+rwx /dev
+    chmod -R g+rwx /registry
 
 # This image doesn't need to run as root user
 USER 1001


### PR DESCRIPTION
Kube 1.18 is released recently, which reveals that `operator-registry` should not relying on the latest kube-version available. To avoid adjusting the minikube version, we, therefore, are pining the version to go.mod k8s/api.

Accidentally, at the same time, the ci-operator changed their way of testing image build by using buildah instead of docker. This change loses the sudo privileges and therefore the permission change for dev is no longer possible. 