### PR TITLE
Bug 1809320: fix(registry): change db load to get providedAPIs via bundle content

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -159,8 +159,7 @@ func TestGetBundle(t *testing.T) {
 		Version:   "0.9.2",
 		SkipRange: "< 0.6.0",
 	}
-
-	require.Equal(t, expected, bundle)
+	compareBundle(t, expected, bundle)
 }
 
 func TestGetBundleForChannel(t *testing.T) {
@@ -192,7 +191,7 @@ func TestGetBundleForChannel(t *testing.T) {
 		Version:   "0.9.2",
 		SkipRange: "< 0.6.0",
 	}
-	require.Equal(t, expected, bundle)
+	compareBundle(t, expected, bundle)
 }
 
 func TestGetChannelEntriesThatReplace(t *testing.T) {
@@ -275,7 +274,7 @@ func TestGetBundleThatReplaces(t *testing.T) {
 		Version:   "0.9.2",
 		SkipRange: "< 0.6.0",
 	}
-	require.Equal(t, expected, bundle)
+	compareBundle(t, expected, bundle)
 }
 
 func TestGetBundleThatReplacesSynthetic(t *testing.T) {
@@ -308,7 +307,7 @@ func TestGetBundleThatReplacesSynthetic(t *testing.T) {
 		Version:   "0.9.2",
 		SkipRange: "< 0.6.0",
 	}
-	require.Equal(t, expected, bundle)
+	compareBundle(t, expected, bundle)
 }
 
 func TestGetChannelEntriesThatProvide(t *testing.T) {
@@ -484,5 +483,5 @@ func TestGetDefaultBundleThatProvides(t *testing.T) {
 		Version:   "0.9.2",
 		SkipRange: "< 0.6.0",
 	}
-	require.Equal(t, expected, bundle)
+	compareBundle(t, expected, bundle)
 }

--- a/pkg/server/utils_test.go
+++ b/pkg/server/utils_test.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/operator-framework/operator-registry/pkg/api"
+	"github.com/stretchr/testify/require"
+)
+
+func compareBundle(t *testing.T, expected, actual *api.Bundle) {
+	require.Equal(t, expected.CsvName, actual.CsvName)
+	require.Equal(t, expected.PackageName, actual.PackageName)
+	require.Equal(t, expected.ChannelName, actual.ChannelName)
+	require.Equal(t, expected.Version, actual.Version)
+	require.Equal(t, expected.SkipRange, actual.SkipRange)
+	require.Equal(t, expected.CsvJson, actual.CsvJson)
+	require.Equal(t, expected.Object, actual.Object)
+	require.Equal(t, expected.BundlePath, actual.BundlePath)
+	require.Equal(t, len(expected.ProvidedApis), len(actual.ProvidedApis))
+	require.Equal(t, len(expected.RequiredApis), len(actual.RequiredApis))
+
+	expectedProvidedAPIs := make(map[string]struct{})
+	for _, v := range expected.ProvidedApis {
+		expectedProvidedAPIs[v.String()] = struct{}{}
+	}
+	for _, v := range actual.ProvidedApis {
+		_, ok := expectedProvidedAPIs[v.String()]
+		require.True(t, ok, "Unable to find provided API: %s", v.String())
+	}
+
+	expectedRequiredAPIs := make(map[string]struct{})
+	for _, v := range expected.RequiredApis {
+		expectedRequiredAPIs[v.String()] = struct{}{}
+	}
+	for _, v := range actual.RequiredApis {
+		_, ok := expectedRequiredAPIs[v.String()]
+		require.True(t, ok, "Unable to find required API: %s", v.String())
+	}
+}

--- a/pkg/sqlite/configmap_test.go
+++ b/pkg/sqlite/configmap_test.go
@@ -76,8 +76,8 @@ func TestReplaceCycle(t *testing.T) {
 
 	// Make etcdoperator.v0.9.0 in the example replace 0.9.2 to create a loop
 	sReader := strings.NewReader(string(bytes.Replace(cmap,
-			[]byte("replaces: etcdoperator.v0.6.1"),
-			[]byte("replaces: etcdoperator.v0.9.2"), 1)))
+		[]byte("replaces: etcdoperator.v0.6.1"),
+		[]byte("replaces: etcdoperator.v0.9.2"), 1)))
 
 	decoder := yaml.NewYAMLOrJSONDecoder(sReader, 30)
 	manifest := v1.ConfigMap{}
@@ -151,11 +151,11 @@ func TestQuerierForConfigmap(t *testing.T) {
 			"{\"apiVersion\":\"apiextensions.k8s.io/v1beta1\",\"kind\":\"CustomResourceDefinition\",\"metadata\":{\"creationTimestamp\":null,\"name\":\"etcdrestores.etcd.database.coreos.com\"},\"spec\":{\"group\":\"etcd.database.coreos.com\",\"names\":{\"kind\":\"EtcdRestore\",\"listKind\":\"EtcdRestoreList\",\"plural\":\"etcdrestores\",\"singular\":\"etcdrestore\"},\"scope\":\"Namespaced\",\"version\":\"v1beta2\",\"versions\":[{\"name\":\"v1beta2\",\"served\":true,\"storage\":true}]},\"status\":{\"acceptedNames\":{\"kind\":\"\",\"plural\":\"\"},\"conditions\":null,\"storedVersions\":null}}",
 		},
 	}
-	require.EqualValues(t, expectedBundle, etcdBundleByChannel)
+	compareBundle(t, expectedBundle, etcdBundleByChannel)
 
 	etcdBundle, err := store.GetBundle(context.TODO(), "etcd", "alpha", "etcdoperator.v0.9.2")
 	require.NoError(t, err)
-	require.Equal(t, expectedBundle, etcdBundle)
+	compareBundle(t, expectedBundle, etcdBundle)
 
 	etcdChannelEntries, err := store.GetChannelEntriesThatReplace(context.TODO(), "etcdoperator.v0.9.0")
 	require.NoError(t, err)
@@ -163,7 +163,7 @@ func TestQuerierForConfigmap(t *testing.T) {
 
 	etcdBundleByReplaces, err := store.GetBundleThatReplaces(context.TODO(), "etcdoperator.v0.9.0", "etcd", "alpha")
 	require.NoError(t, err)
-	require.EqualValues(t, expectedBundle, etcdBundleByReplaces)
+	compareBundle(t, expectedBundle, etcdBundleByReplaces)
 
 	etcdChannelEntriesThatProvide, err := store.GetChannelEntriesThatProvide(context.TODO(), "etcd.database.coreos.com", "v1beta2", "EtcdCluster")
 	require.ElementsMatch(t, []*registry.ChannelEntry{

--- a/pkg/sqlite/directory_test.go
+++ b/pkg/sqlite/directory_test.go
@@ -143,11 +143,11 @@ func TestQuerierForDirectory(t *testing.T) {
 			{Group: "etcd.database.coreos.com", Version: "v1beta2", Kind: "EtcdCluster", Plural: "etcdclusters"},
 		},
 	}
-	require.Equal(t, expectedBundle, etcdBundleByChannel)
+	compareBundle(t, expectedBundle, etcdBundleByChannel)
 
 	etcdBundle, err := store.GetBundle(context.TODO(), "etcd", "alpha", "etcdoperator.v0.9.2")
 	require.NoError(t, err)
-	require.Equal(t, expectedBundle, etcdBundle)
+	compareBundle(t, expectedBundle, etcdBundle)
 
 	etcdChannelEntries, err := store.GetChannelEntriesThatReplace(context.TODO(), "etcdoperator.v0.9.0")
 	require.NoError(t, err)
@@ -155,7 +155,7 @@ func TestQuerierForDirectory(t *testing.T) {
 
 	etcdBundleByReplaces, err := store.GetBundleThatReplaces(context.TODO(), "etcdoperator.v0.9.0", "etcd", "alpha")
 	require.NoError(t, err)
-	require.EqualValues(t, expectedBundle, etcdBundleByReplaces)
+	compareBundle(t, expectedBundle, etcdBundleByReplaces)
 
 	etcdChannelEntriesThatProvide, err := store.GetChannelEntriesThatProvide(context.TODO(), "etcd.database.coreos.com", "v1beta2", "EtcdCluster")
 	require.ElementsMatch(t, []*registry.ChannelEntry{
@@ -178,7 +178,7 @@ func TestQuerierForDirectory(t *testing.T) {
 
 	etcdBundleByProvides, err := store.GetBundleThatProvides(context.TODO(), "etcd.database.coreos.com", "v1beta2", "EtcdCluster")
 	require.NoError(t, err)
-	require.Equal(t, expectedBundle, etcdBundleByProvides)
+	compareBundle(t, expectedBundle, etcdBundleByProvides)
 
 	kafkaPackage, err := store.GetPackage(context.TODO(), "strimzi-kafka-operator")
 	require.NoError(t, err)

--- a/pkg/sqlite/image_test.go
+++ b/pkg/sqlite/image_test.go
@@ -131,11 +131,11 @@ func TestQuerierForImage(t *testing.T) {
 			{Group: "etcd.database.coreos.com", Version: "v1beta2", Kind: "EtcdCluster", Plural: "etcdclusters"},
 		},
 	}
-	require.Equal(t, expectedBundle, etcdBundleByChannel)
+	compareBundle(t, expectedBundle, etcdBundleByChannel)
 
 	etcdBundle, err := store.GetBundle(context.TODO(), "etcd", "alpha", "etcdoperator.v0.9.2")
 	require.NoError(t, err)
-	require.Equal(t, expectedBundle, etcdBundle)
+	compareBundle(t, expectedBundle, etcdBundle)
 
 	etcdChannelEntries, err := store.GetChannelEntriesThatReplace(context.TODO(), "etcdoperator.v0.9.0")
 	require.NoError(t, err)
@@ -143,7 +143,7 @@ func TestQuerierForImage(t *testing.T) {
 
 	etcdBundleByReplaces, err := store.GetBundleThatReplaces(context.TODO(), "etcdoperator.v0.9.0", "etcd", "alpha")
 	require.NoError(t, err)
-	require.EqualValues(t, expectedBundle, etcdBundleByReplaces)
+	compareBundle(t, expectedBundle, etcdBundleByReplaces)
 
 	etcdChannelEntriesThatProvide, err := store.GetChannelEntriesThatProvide(context.TODO(), "etcd.database.coreos.com", "v1beta2", "EtcdCluster")
 	require.ElementsMatch(t, []*registry.ChannelEntry{
@@ -161,7 +161,7 @@ func TestQuerierForImage(t *testing.T) {
 
 	etcdBundleByProvides, err := store.GetBundleThatProvides(context.TODO(), "etcd.database.coreos.com", "v1beta2", "EtcdCluster")
 	require.NoError(t, err)
-	require.Equal(t, expectedBundle, etcdBundleByProvides)
+	compareBundle(t, expectedBundle, etcdBundleByProvides)
 
 	expectedEtcdImages := []string{
 		"quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2",

--- a/pkg/sqlite/utils_test.go
+++ b/pkg/sqlite/utils_test.go
@@ -1,0 +1,39 @@
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/operator-framework/operator-registry/pkg/api"
+	"github.com/stretchr/testify/require"
+)
+
+func compareBundle(t *testing.T, expected, actual *api.Bundle) {
+	require.Equal(t, expected.CsvName, actual.CsvName)
+	require.Equal(t, expected.PackageName, actual.PackageName)
+	require.Equal(t, expected.ChannelName, actual.ChannelName)
+	require.Equal(t, expected.Version, actual.Version)
+	require.Equal(t, expected.SkipRange, actual.SkipRange)
+	require.Equal(t, expected.CsvJson, actual.CsvJson)
+	require.Equal(t, expected.Object, actual.Object)
+	require.Equal(t, expected.BundlePath, actual.BundlePath)
+	require.Equal(t, len(expected.ProvidedApis), len(actual.ProvidedApis))
+	require.Equal(t, len(expected.RequiredApis), len(actual.RequiredApis))
+
+	expectedProvidedAPIs := make(map[string]struct{})
+	for _, v := range expected.ProvidedApis {
+		expectedProvidedAPIs[v.String()] = struct{}{}
+	}
+	for _, v := range actual.ProvidedApis {
+		_, ok := expectedProvidedAPIs[v.String()]
+		require.True(t, ok, "Unable to find provided API: %s", v.String())
+	}
+
+	expectedRequiredAPIs := make(map[string]struct{})
+	for _, v := range expected.RequiredApis {
+		expectedRequiredAPIs[v.String()] = struct{}{}
+	}
+	for _, v := range actual.RequiredApis {
+		_, ok := expectedRequiredAPIs[v.String()]
+		require.True(t, ok, "Unable to find required API: %s", v.String())
+	}
+}


### PR DESCRIPTION
Currently, when bundle is loaded into the database, the providedAPIs
are extracted from CSV instead of bundle content. As a result, if
CRDs are dropped in the bundle but not referenced in CSV, they won't
get added into the DB. This ProvidedAPIs info in DB then gets queried
via registry API and causes the dependency resolution discrepancy
between 4.2 and 4.3+.

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
