### PR TITLE
pkg/lib/bundle: fix copyManifestDir so it actually copies file contents

### DIFF
--- a/pkg/lib/bundle/generate.go
+++ b/pkg/lib/bundle/generate.go
@@ -389,7 +389,7 @@ func WriteFile(fileName, directory string, content []byte) error {
 	return nil
 }
 
-// copy the contents of a flat manifest dir into an output dir
+// copy the contents of a potentially nested manifest dir into an output dir.
 func copyManifestDir(from, to string, overwrite bool) error {
 	fromFiles, err := ioutil.ReadDir(from)
 	if err != nil {
@@ -397,7 +397,9 @@ func copyManifestDir(from, to string, overwrite bool) error {
 	}
 
 	if _, err := os.Stat(to); os.IsNotExist(err) {
-		os.MkdirAll(to, os.ModePerm)
+		if err = os.MkdirAll(to, os.ModePerm); err != nil {
+			return err
+		}
 	}
 
 	for _, fromFile := range fromFiles {
@@ -415,6 +417,11 @@ func copyManifestDir(from, to string, overwrite bool) error {
 		if err != nil {
 			return err
 		}
+		defer func() {
+			if err := contents.Close(); err != nil {
+				log.Fatal(err)
+			}
+		}()
 
 		toFilePath := filepath.Join(to, fromFile.Name())
 		_, err = os.Stat(toFilePath)
@@ -428,8 +435,13 @@ func copyManifestDir(from, to string, overwrite bool) error {
 		if err != nil {
 			return err
 		}
+		defer func() {
+			if err := toFile.Close(); err != nil {
+				log.Fatal(err)
+			}
+		}()
 
-		_, err = io.Copy(contents, toFile)
+		_, err = io.Copy(toFile, contents)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
From `io.Copy()` docs:
>// Copy copies from src to dst...
>...
>func Copy(dst Writer, src Reader)

Arguments were backwards. Also added file closing and another error check.

/cc @kevinrizza 

/kind bug