### PR TITLE
fix understaiding bundles feature

### DIFF
--- a/cmd/opm/alpha/bundle/generate.go
+++ b/cmd/opm/alpha/bundle/generate.go
@@ -31,9 +31,6 @@ func newBundleGenerateCmd() *cobra.Command {
 	}
 
 	bundleGenerateCmd.Flags().StringVarP(&packageNameArgs, "package", "p", "",
-		"The name of the package that bundle image belongs to")
-
-	bundleGenerateCmd.Flags().StringVarP(&packageNameArgs, "package", "p", "",
 		"The name of the package that bundle image belongs to "+
 			"(Required if `directory` is not pointing to a bundle in the nested bundle format)")
 

--- a/pkg/lib/bundle/generate.go
+++ b/pkg/lib/bundle/generate.go
@@ -80,13 +80,16 @@ func GenerateFunc(directory, outputDir, packageName, channels, channelDefault st
 	// and that either of the required field is missing. We are interpreting the bundle information through
 	// bundle directory embedded in the package folder.
 	if channels == "" || packageName == "" {
-		i, err := NewBundleDirInterperter(filepath.Join(directory, ".."))
+		i, err := NewBundleDirInterperter(directory)
 		if err != nil {
 			return fmt.Errorf("please manually input channels and packageName, "+
 				"error interpreting bundle from directory %s, %v", directory, err)
 		}
 		if channels == "" {
 			channels = strings.Join(i.GetBundleChannels(), ",")
+			if channels == "" {
+				return fmt.Errorf("error interpreting channels, please manually input channels instead")
+			}
 		}
 
 		if packageName == "" {

--- a/pkg/registry/csv.go
+++ b/pkg/registry/csv.go
@@ -88,7 +88,7 @@ func ReadCSVFromBundleDirectory(bundleDir string) (*ClusterServiceVersion, error
 
 		decoder := yaml.NewYAMLOrJSONDecoder(yamlReader, 30)
 		if err = decoder.Decode(&unstructuredCSV); err != nil {
-			return nil, fmt.Errorf("error unmarshalling CSV, %v", err)
+			continue
 		}
 
 		if unstructuredCSV.GetKind() != operators.ClusterServiceVersionKind {


### PR DESCRIPTION
This commit is responding to the false commit 13373cb43e72cb3b025e6f693fffccf94c13d817
that accidentally changed opm command.
This commit removes the duplicated package flag.
This commit corrects bundle dir from pakcgae directory.
This commit adds an error message for getting empty channels for a bundle.
This commit skipes error for trying to parse anyfile as Json or Yaml format.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
