### PR TITLE
bug 1827748: feature: opm (index|registry) prune command

### DIFF
--- a/cmd/opm/index/cmd.go
+++ b/cmd/opm/index/cmd.go
@@ -24,4 +24,5 @@ func AddCommand(parent *cobra.Command) {
 	cmd.AddCommand(newIndexDeleteCmd())
 	addIndexAddCmd(cmd)
 	cmd.AddCommand(newIndexExportCmd())
+	cmd.AddCommand(newIndexPruneCmd())
 }

--- a/cmd/opm/index/prune.go
+++ b/cmd/opm/index/prune.go
@@ -1,0 +1,120 @@
+package index
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/operator-framework/operator-registry/pkg/containertools"
+	"github.com/operator-framework/operator-registry/pkg/lib/indexer"
+)
+
+func newIndexPruneCmd() *cobra.Command {
+	indexCmd := &cobra.Command{
+		Use:   "prune",
+		Short: "prune an index of all but specified packages",
+		Long:  `prune an index of all but specified packages`,
+
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if debug, _ := cmd.Flags().GetBool("debug"); debug {
+				logrus.SetLevel(logrus.DebugLevel)
+			}
+			return nil
+		},
+
+		RunE: runIndexPruneCmdFunc,
+	}
+
+	indexCmd.Flags().Bool("debug", false, "enable debug logging")
+	indexCmd.Flags().Bool("generate", false, "if enabled, just creates the dockerfile and saves it to local disk")
+	indexCmd.Flags().StringP("out-dockerfile", "d", "", "if generating the dockerfile, this flag is used to (optionally) specify a dockerfile name")
+	indexCmd.Flags().StringP("from-index", "f", "", "index to prune")
+	if err := indexCmd.MarkFlagRequired("from-index"); err != nil {
+		logrus.Panic("Failed to set required `from-index` flag for `index prune`")
+	}
+	indexCmd.Flags().StringSliceP("packages", "p", nil, "comma separated list of packages to keep")
+	if err := indexCmd.MarkFlagRequired("packages"); err != nil {
+		logrus.Panic("Failed to set required `packages` flag for `index prune`")
+	}
+	indexCmd.Flags().StringP("binary-image", "i", "", "container image for on-image `opm` command")
+	indexCmd.Flags().StringP("container-tool", "c", "podman", "tool to interact with container images (save, build, etc.). One of: [docker, podman]")
+	indexCmd.Flags().StringP("tag", "t", "", "custom tag for container image being built")
+	indexCmd.Flags().Bool("permissive", false, "allow registry load errors")
+
+	if err := indexCmd.Flags().MarkHidden("debug"); err != nil {
+		logrus.Panic(err.Error())
+	}
+
+	return indexCmd
+
+}
+
+func runIndexPruneCmdFunc(cmd *cobra.Command, args []string) error {
+	generate, err := cmd.Flags().GetBool("generate")
+	if err != nil {
+		return err
+	}
+
+	outDockerfile, err := cmd.Flags().GetString("out-dockerfile")
+	if err != nil {
+		return err
+	}
+
+	fromIndex, err := cmd.Flags().GetString("from-index")
+	if err != nil {
+		return err
+	}
+
+	packages, err := cmd.Flags().GetStringSlice("packages")
+	if err != nil {
+		return err
+	}
+
+	binaryImage, err := cmd.Flags().GetString("binary-image")
+	if err != nil {
+		return err
+	}
+
+	containerTool, err := cmd.Flags().GetString("container-tool")
+	if err != nil {
+		return err
+	}
+
+	if containerTool == "none" {
+		return fmt.Errorf("none is not a valid container-tool for index prune")
+	}
+
+	tag, err := cmd.Flags().GetString("tag")
+	if err != nil {
+		return err
+	}
+
+	permissive, err := cmd.Flags().GetBool("permissive")
+	if err != nil {
+		return err
+	}
+
+	logger := logrus.WithFields(logrus.Fields{"packages": packages})
+
+	logger.Info("pruning the index")
+
+	indexPruner := indexer.NewIndexPruner(containertools.NewContainerTool(containerTool, containertools.PodmanTool), logger)
+
+	request := indexer.PruneFromIndexRequest{
+		Generate:          generate,
+		FromIndex:         fromIndex,
+		BinarySourceImage: binaryImage,
+		OutDockerfile:     outDockerfile,
+		Packages:          packages,
+		Tag:               tag,
+		Permissive:        permissive,
+	}
+
+	err = indexPruner.PruneFromIndex(request)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/opm/registry/cmd.go
+++ b/cmd/opm/registry/cmd.go
@@ -23,6 +23,7 @@ func NewOpmRegistryCmd() *cobra.Command {
 	rootCmd.AddCommand(newRegistryServeCmd())
 	rootCmd.AddCommand(newRegistryAddCmd())
 	rootCmd.AddCommand(newRegistryRmCmd())
+	rootCmd.AddCommand(newRegistryPruneCmd())
 
 	return rootCmd
 }

--- a/cmd/opm/registry/prune.go
+++ b/cmd/opm/registry/prune.go
@@ -1,0 +1,69 @@
+package registry
+
+import (
+	"github.com/operator-framework/operator-registry/pkg/lib/registry"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func newRegistryPruneCmd() *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:   "prune",
+		Short: "prune an operator registry DB of all but specified packages",
+		Long:  `prune an operator registry DB of all but specified packages`,
+
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if debug, _ := cmd.Flags().GetBool("debug"); debug {
+				logrus.SetLevel(logrus.DebugLevel)
+			}
+			return nil
+		},
+
+		RunE: runRegistryPruneCmdFunc,
+	}
+
+	rootCmd.Flags().Bool("debug", false, "enable debug logging")
+	rootCmd.Flags().StringP("database", "d", "bundles.db", "relative path to database file")
+	rootCmd.Flags().StringSliceP("packages", "p", []string{}, "comma separated list of package names to be kept")
+	if err := rootCmd.MarkFlagRequired("packages"); err != nil {
+		logrus.Panic("Failed to set required `packages` flag for `registry rm`")
+	}
+	rootCmd.Flags().Bool("permissive", false, "allow registry load errors")
+
+	return rootCmd
+}
+
+func runRegistryPruneCmdFunc(cmd *cobra.Command, args []string) error {
+	fromFilename, err := cmd.Flags().GetString("database")
+	if err != nil {
+		return err
+	}
+	packages, err := cmd.Flags().GetStringSlice("packages")
+	if err != nil {
+		return err
+	}
+	permissive, err := cmd.Flags().GetBool("permissive")
+	if err != nil {
+		return err
+	}
+
+	request := registry.PruneFromRegistryRequest{
+		Packages:      packages,
+		InputDatabase: fromFilename,
+		Permissive:    permissive,
+	}
+
+	logger := logrus.WithFields(logrus.Fields{"packages": packages})
+
+	logger.Info("pruning from the registry")
+
+	registryPruner := registry.NewRegistryPruner(logger)
+
+	err = registryPruner.PruneFromRegistry(request)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/docs/design/opm-tooling.md
+++ b/docs/design/opm-tooling.md
@@ -34,6 +34,14 @@ Great! The existing `test-registry.db` file is updated. Now we have a registry t
 
 Calling this on our existing test registry removes all versions of the prometheus operator entirely from the database.
 
+#### prune
+
+`opm` supports specifying which packages should be kept in an operator database. For example:
+
+`opm registry prune -p "prometheus" -d "test-registry.db"`
+
+Would remove all but the `prometheus` package from the operator database.
+
 #### serve
 
 `opm` also includes a command to connect to an existing database and serve a `gRPC` API that handles requests for data about the registry:
@@ -92,6 +100,14 @@ Like `opm registry rm`, this command will remove all versions an entire operator
 `opm index rm --operators prometheus --tag quay.io/operator-framework/monitoring-index:1.0.2 --binary-image quay.io/$user/my-opm-source`
 
 This will result in the tagged container image `quay.io/operator-framework/monitoring-index:1.0.2` with a registry that no longer contains the `prometheus` operator at all.
+
+#### prune
+
+`opm index prune` allows the user to specify which operator packages should be maintained in an index. For example:
+
+`opm index prune -p "prometheus" --from-index quay.io/operator-framework/example-index:1.0.0 --tag quay.io/operator-framework/example-index:1.0.1`
+
+Would remove all but the `prometheus` package from the index.
 
 #### export
 

--- a/pkg/lib/indexer/interfaces.go
+++ b/pkg/lib/indexer/interfaces.go
@@ -63,3 +63,20 @@ func NewIndexExporter(containerTool containertools.ContainerTool, logger *logrus
 		Logger:              logger,
 	}
 }
+
+// IndexPruner prunes operators out of an index
+type IndexPruner interface {
+	PruneFromIndex(PruneFromIndexRequest) error
+}
+
+func NewIndexPruner(containerTool containertools.ContainerTool, logger *logrus.Entry) IndexPruner {
+	return ImageIndexer{
+		DockerfileGenerator: containertools.NewDockerfileGenerator(logger),
+		CommandRunner:       containertools.NewCommandRunner(containerTool, logger),
+		LabelReader:         containertools.NewLabelReader(containerTool, logger),
+		RegistryPruner:      registry.NewRegistryPruner(logger),
+		ImageReader:         containertools.NewImageReader(containerTool, logger),
+		ContainerTool:       containerTool,
+		Logger:              logger,
+	}
+}

--- a/pkg/lib/registry/interfaces.go
+++ b/pkg/lib/registry/interfaces.go
@@ -26,3 +26,13 @@ func NewRegistryDeleter(logger *logrus.Entry) RegistryDeleter {
 		Logger: logger,
 	}
 }
+
+type RegistryPruner interface {
+	PruneFromRegistry(PruneFromRegistryRequest) error
+}
+
+func NewRegistryPruner(logger *logrus.Entry) RegistryPruner {
+	return RegistryUpdater{
+		Logger: logger,
+	}
+}


### PR DESCRIPTION
**Description of the change:**

This makes it possible for a user to take an index image or a database
referencing a large collection of operator bundles to filter down the
collection.

**Motivation for the change:**

Make it possible to scale down operator collections.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
