### PR TITLE
bug(opm): use db dir when modifying existing index

### DIFF
--- a/pkg/lib/indexer/indexer.go
+++ b/pkg/lib/indexer/indexer.go
@@ -26,6 +26,7 @@ const (
 	defaultImageTag       = "operator-registry-index:latest"
 	defaultDatabaseFolder = "database"
 	defaultDatabaseFile   = "index.db"
+	tmpDirPrefix          = "index_tmp"
 )
 
 // ImageIndexer is a struct implementation of the Indexer interface
@@ -53,36 +54,18 @@ type AddToIndexRequest struct {
 
 // AddToIndex is an aggregate API used to generate a registry index image with additional bundles
 func (i ImageIndexer) AddToIndex(request AddToIndexRequest) error {
-	databaseFile := defaultDatabaseFile
-
 	// set a temp directory
-	workingDir, err := ioutil.TempDir("./", "index_tmp")
+	tmpDir, err := ioutil.TempDir("./", tmpDirPrefix)
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(workingDir)
+	defer os.RemoveAll(tmpDir)
 
-	// Pull the fromIndex
-	if request.FromIndex != "" {
-		i.Logger.Infof("Pulling previous image %s to get metadata", request.FromIndex)
-
-		// Get the old index image's dbLocationLabel to find this path
-		labels, err := i.LabelReader.GetLabelsFromImage(request.FromIndex)
-		if err != nil {
-			return err
-		}
-		if dbLocation, ok := labels[containertools.DbLocationLabel]; ok {
-			// extract the database to the file
-			err = i.ImageReader.GetImageData(request.FromIndex, workingDir)
-			if err != nil {
-				return err
-			}
-
-			databaseFile = path.Join(workingDir, dbLocation)
-		}
-	} else {
-		databaseFile = path.Join(workingDir, databaseFile)
+	databaseFile, err := i.getDatabaseFile(tmpDir, request.FromIndex)
+	if err != nil {
+		return err
 	}
+	workingDir := path.Dir(databaseFile)
 
 	// Run opm registry add on the database
 	addToRegistryReq := registry.AddToRegistryRequest{
@@ -127,38 +110,18 @@ type DeleteFromIndexRequest struct {
 // DeleteFromIndex is an aggregate API used to generate a registry index image
 // without specific operators
 func (i ImageIndexer) DeleteFromIndex(request DeleteFromIndexRequest) error {
-	databaseFile := defaultDatabaseFile
-
 	// set a temp directory
-	workingDir, err := ioutil.TempDir("./", "index_tmp")
+	tmpDir, err := ioutil.TempDir("./", tmpDirPrefix)
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(workingDir)
+	defer os.RemoveAll(tmpDir)
 
-	// Pull the fromIndex
-	if request.FromIndex != "" {
-		i.Logger.Infof("Pulling previous image %s to get metadata", request.FromIndex)
-
-		// Get the old index image's dbLocationLabel to find this path
-		labels, err := i.LabelReader.GetLabelsFromImage(request.FromIndex)
-		if err != nil {
-			return err
-		}
-		if dbLocation, ok := labels[containertools.DbLocationLabel]; ok {
-			i.Logger.Infof("Previous db location %s", dbLocation)
-
-			// extract the database to the file
-			err = i.ImageReader.GetImageData(request.FromIndex, workingDir)
-			if err != nil {
-				return err
-			}
-
-			databaseFile = path.Join(workingDir, dbLocation)
-		}
-	} else {
-		databaseFile = path.Join(workingDir, databaseFile)
+	databaseFile, err := i.getDatabaseFile(tmpDir, request.FromIndex)
+	if err != nil {
+		return err
 	}
+	workingDir := path.Dir(databaseFile)
 
 	// Run opm registry add on the database
 	deleteFromRegistryReq := registry.DeleteFromRegistryRequest{
@@ -257,6 +220,33 @@ func (i ImageIndexer) buildDockerfile(binarySourceImage, workingDir, tag string)
 	return nil
 }
 
+func (i ImageIndexer) getDatabaseFile(workingDir, fromIndex string) (string, error) {
+	if fromIndex == "" {
+		return path.Join(workingDir, defaultDatabaseFile), nil
+	}
+
+	// Pull the fromIndex
+	i.Logger.Infof("Pulling previous image %s to get metadata", fromIndex)
+
+	// Get the old index image's dbLocationLabel to find this path
+	labels, err := i.LabelReader.GetLabelsFromImage(fromIndex)
+	if err != nil {
+		return "", err
+	}
+	dbLocation, ok := labels[containertools.DbLocationLabel]
+	if !ok {
+		return "", fmt.Errorf("Index image %s missing label %s", fromIndex, containertools.DbLocationLabel)
+	}
+
+	// extract the database to the working directory
+	err = i.ImageReader.GetImageData(fromIndex, workingDir)
+	if err != nil {
+		return "", err
+	}
+
+	return path.Join(workingDir, dbLocation), nil
+}
+
 func build(dockerfileText, imageTag string, commandRunner containertools.CommandRunner, logger *logrus.Entry) error {
 	if imageTag == "" {
 		imageTag = defaultImageTag
@@ -304,7 +294,7 @@ type ExportFromIndexRequest struct {
 // an index image
 func (i ImageIndexer) ExportFromIndex(request ExportFromIndexRequest) error {
 	// set a temp directory
-	workingDir, err := ioutil.TempDir("./", "index_tmp")
+	workingDir, err := ioutil.TempDir("./", tmpDirPrefix)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Description of the change:**

This makes it possible to add to an index image using `--from-index`.

**Motivation for the change:**

Squash :bug: 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


Fixes: #221 