### PR TITLE
Semver index insert

### DIFF
--- a/cmd/opm/index/add.go
+++ b/cmd/opm/index/add.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/operator-framework/operator-registry/pkg/lib/indexer"
+	"github.com/operator-framework/operator-registry/pkg/registry"
 )
 
 var (
@@ -55,6 +56,7 @@ func addIndexAddCmd(parent *cobra.Command) {
 	indexCmd.Flags().StringP("container-tool", "c", "podman", "tool to interact with container images (save, build, etc.). One of: [docker, podman]")
 	indexCmd.Flags().StringP("tag", "t", "", "custom tag for container image being built")
 	indexCmd.Flags().Bool("permissive", false, "allow registry load errors")
+	indexCmd.Flags().StringP("mode", "", "replaces", "graph update mode that defines how channel graphs are updated. One of: [replaces, semver, semver-skippatch]")
 
 	if err := indexCmd.Flags().MarkHidden("debug"); err != nil {
 		logrus.Panic(err.Error())
@@ -107,6 +109,16 @@ func runIndexAddCmdFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	mode, err := cmd.Flags().GetString("mode")
+	if err != nil {
+		return err
+	}
+
+	modeEnum, err := registry.GetModeFromString(mode)
+	if err != nil {
+		return err
+	}
+
 	logger := logrus.WithFields(logrus.Fields{"bundles": bundles})
 
 	logger.Info("building the index")
@@ -121,6 +133,7 @@ func runIndexAddCmdFunc(cmd *cobra.Command, args []string) error {
 		Tag:               tag,
 		Bundles:           bundles,
 		Permissive:        permissive,
+		Mode:              modeEnum,
 	}
 
 	err = indexAdder.AddToIndex(request)

--- a/pkg/lib/bundle/validate.go
+++ b/pkg/lib/bundle/validate.go
@@ -272,7 +272,7 @@ func (i imageValidator) ValidateBundleContent(manifestDir string) error {
 
 	// Validate the bundle object
 	if len(unstObjs) > 0 {
-		bundle := registry.NewBundle(csvName, "", "", unstObjs...)
+		bundle := registry.NewBundle(csvName, "", nil, unstObjs...)
 		bundleValidator := v.BundleValidator
 		results := bundleValidator.Validate(bundle)
 		if len(results) > 0 {

--- a/pkg/lib/indexer/indexer.go
+++ b/pkg/lib/indexer/indexer.go
@@ -49,6 +49,7 @@ type AddToIndexRequest struct {
 	OutDockerfile     string
 	Bundles           []string
 	Tag               string
+	Mode              pregistry.Mode
 }
 
 // AddToIndex is an aggregate API used to generate a registry index image with additional bundles
@@ -89,6 +90,7 @@ func (i ImageIndexer) AddToIndex(request AddToIndexRequest) error {
 		Bundles:       request.Bundles,
 		InputDatabase: databaseFile,
 		Permissive:    request.Permissive,
+		Mode:          request.Mode,
 	}
 
 	// Add the bundles to the registry

--- a/pkg/registry/bundle.go
+++ b/pkg/registry/bundle.go
@@ -31,22 +31,22 @@ type Bundle struct {
 	Name        string
 	Objects     []*unstructured.Unstructured
 	Package     string
-	Channel     string
+	Channels    []string
 	BundleImage string
 	csv         *ClusterServiceVersion
 	crds        []*v1beta1.CustomResourceDefinition
 	cacheStale  bool
 }
 
-func NewBundle(name, pkgName, channelName string, objs ...*unstructured.Unstructured) *Bundle {
-	bundle := &Bundle{Name: name, Package: pkgName, Channel: channelName, cacheStale: false}
+func NewBundle(name, pkgName string, channels []string, objs ...*unstructured.Unstructured) *Bundle {
+	bundle := &Bundle{Name: name, Package: pkgName, Channels: channels, cacheStale: false}
 	for _, o := range objs {
 		bundle.Add(o)
 	}
 	return bundle
 }
 
-func NewBundleFromStrings(name, pkgName, channelName string, objs []string) (*Bundle, error) {
+func NewBundleFromStrings(name, pkgName string, channels []string, objs []string) (*Bundle, error) {
 	unstObjs := []*unstructured.Unstructured{}
 	for _, o := range objs {
 		dec := yaml.NewYAMLOrJSONDecoder(strings.NewReader(o), 10)
@@ -56,7 +56,7 @@ func NewBundleFromStrings(name, pkgName, channelName string, objs []string) (*Bu
 		}
 		unstObjs = append(unstObjs, unst)
 	}
-	return NewBundle(name, pkgName, channelName, unstObjs...), nil
+	return NewBundle(name, pkgName, channels, unstObjs...), nil
 }
 
 func (b *Bundle) Size() int {

--- a/pkg/registry/bundlegraphloader.go
+++ b/pkg/registry/bundlegraphloader.go
@@ -1,0 +1,147 @@
+package registry
+
+import (
+	"fmt"
+
+	"github.com/blang/semver"
+)
+
+// BundleGraphLoader generates updated graphs by adding bundles to them, updating
+// the graph implicitly via semantic version of each bundle
+type BundleGraphLoader struct {
+}
+
+// AddBundleToGraph takes a bundle and an existing graph and updates the graph to insert the new bundle
+// into each channel it is included in
+func (g *BundleGraphLoader) AddBundleToGraph(bundle *Bundle, graph *Package, newDefaultChannel string, skippatch bool) (*Package, error) {
+	bundleVersion, err := bundle.Version()
+	if err != nil {
+		return nil, fmt.Errorf("Unable to extract bundle version from bundle %s, can't insert in semver mode", bundle.BundleImage)
+	}
+
+	versionToAdd, err := semver.Make(bundleVersion)
+	if err != nil {
+		return nil, fmt.Errorf("Bundle version %s is not valid", bundleVersion)
+	}
+
+	newBundleKey := BundleKey{
+		CsvName:    bundle.Name,
+		Version:    versionToAdd.String(),
+		BundlePath: bundle.BundleImage,
+	}
+
+	// initialize the graph if it started empty
+	if graph.Name == "" {
+		graph.Name = bundle.Package
+	}
+	if newDefaultChannel != "" {
+		graph.DefaultChannel = newDefaultChannel
+	}
+
+	// generate the DAG for each channel the new bundle is being insert into
+	for _, channel := range bundle.Channels {
+		replaces := make(map[BundleKey]struct{}, 0)
+
+		// If the channel doesn't exist yet, initialize it
+		if !graph.HasChannel(channel) {
+			// create the channel and add a single node
+			newChannelGraph := Channel{
+				Head: newBundleKey,
+				Nodes: map[BundleKey]map[BundleKey]struct{}{
+					newBundleKey: nil,
+				},
+			}
+			if graph.Channels == nil {
+				graph.Channels = make(map[string]Channel, 1)
+			}
+			graph.Channels[channel] = newChannelGraph
+			continue
+		}
+
+		// find the version(s) it should sit between
+		channelGraph := graph.Channels[channel]
+		if channelGraph.Nodes == nil {
+			channelGraph.Nodes = make(map[BundleKey]map[BundleKey]struct{}, 1)
+		}
+
+		lowestAhead := BundleKey{}
+		greatestBehind := BundleKey{}
+		skipPatchCandidates := []BundleKey{}
+
+		// Iterate over existing nodes and compare the new node's version to find the
+		// lowest version above it and highest version below it (to insert between these nodes)
+		for node := range channelGraph.Nodes {
+			nodeVersion, err := semver.Make(node.Version)
+			if err != nil {
+				return nil, fmt.Errorf("Unable to parse existing bundle version stored in index %s %s %s",
+					node.CsvName, node.Version, node.BundlePath)
+			}
+
+			switch comparison := nodeVersion.Compare(versionToAdd); comparison {
+			case 0:
+				return nil, fmt.Errorf("Bundle version %s already added to index", bundleVersion)
+			case 1:
+				if lowestAhead.IsEmpty() {
+					lowestAhead = node
+				} else {
+					lowestAheadSemver, _ := semver.Make(lowestAhead.Version)
+					if nodeVersion.LT(lowestAheadSemver) {
+						lowestAhead = node
+					}
+				}
+			case -1:
+				if greatestBehind.IsEmpty() {
+					greatestBehind = node
+				} else {
+					greatestBehindSemver, _ := semver.Make(greatestBehind.Version)
+					if nodeVersion.GT(greatestBehindSemver) {
+						greatestBehind = node
+					}
+				}
+			}
+
+			// if skippatch mode is enabled, check each node to determine if z-updates should
+			// be replaced as well. Keep track of them to delete those nodes from the graph itself,
+			// just be aware of them for replacements
+			if skippatch {
+				if isSkipPatchCandidate(versionToAdd, nodeVersion) {
+					skipPatchCandidates = append(skipPatchCandidates, node)
+					replaces[node] = struct{}{}
+				}
+			}
+		}
+
+		// If we found a node behind the one we're adding, make the new node replace it
+		if !greatestBehind.IsEmpty() {
+			replaces[greatestBehind] = struct{}{}
+		}
+
+		// If we found a node ahead of the one we're adding, make the lowest to replace
+		// the new node. If we didn't find a node semantically ahead, the new node is
+		// the new channel head
+		if !lowestAhead.IsEmpty() {
+			channelGraph.Nodes[lowestAhead] = map[BundleKey]struct{}{
+				newBundleKey: struct{}{},
+			}
+		} else {
+			channelGraph.Head = newBundleKey
+		}
+
+		if skippatch {
+			// Remove the nodes that are now being skipped by a new patch version update
+			for _, candidate := range skipPatchCandidates {
+				delete(channelGraph.Nodes, candidate)
+			}
+		}
+
+		// add the node and update the graph
+		channelGraph.Nodes[newBundleKey] = replaces
+		graph.Channels[channel] = channelGraph
+	}
+
+	return graph, nil
+}
+
+func isSkipPatchCandidate(version, toCompare semver.Version) bool {
+	return (version.Major == toCompare.Major) && (version.Minor == toCompare.Minor) && (version.Patch > toCompare.Patch)
+}

--- a/pkg/registry/bundlegraphloader_test.go
+++ b/pkg/registry/bundlegraphloader_test.go
@@ -1,0 +1,310 @@
+package registry
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBundleGraphLoader(t *testing.T) {
+	tests := []struct {
+		name              string
+		fail              bool
+		graph             Package
+		bundle            Bundle
+		newDefaultChannel string
+		expectedGraph     *Package
+		skipPatch         bool
+	}{
+		{
+			name: "Add bundle to head of channels",
+			fail: false,
+			graph: Package{
+				Name:           "etcd",
+				DefaultChannel: "alpha",
+				Channels: map[string]Channel{
+					"alpha": {Head: BundleKey{CsvName: "etcdoperator.v0.9.2", Version: "0.9.2"},
+						Nodes: map[BundleKey]map[BundleKey]struct{}{
+							BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
+							BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {}},
+							BundleKey{CsvName: "etcdoperator.v0.9.2", Version: "0.9.2"}: {BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {},
+								BundleKey{CsvName: "etcdoperator.v0.9.1"}: {}},
+						}},
+
+					"beta": {Head: BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"},
+						Nodes: map[BundleKey]map[BundleKey]struct{}{
+							BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
+							BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {}},
+						}},
+
+					"stable": {Head: BundleKey{CsvName: "etcdoperator.v0.9.2", Version: "0.9.2"},
+						Nodes: map[BundleKey]map[BundleKey]struct{}{
+							BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
+							BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {}},
+							BundleKey{CsvName: "etcdoperator.v0.9.2", Version: "0.9.2"}: {BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {},
+								BundleKey{CsvName: "etcdoperator.v0.9.1"}: {}},
+						}},
+				},
+			},
+			bundle: Bundle{
+				Name:    "etcdoperator.v0.9.3",
+				Package: "etcd",
+				csv: &ClusterServiceVersion{
+					Spec: json.RawMessage(`
+							{
+							"version": "0.9.3"
+							}`),
+				},
+				Channels: []string{"alpha", "stable"},
+			},
+			expectedGraph: &Package{
+				Name:           "etcd",
+				DefaultChannel: "alpha",
+				Channels: map[string]Channel{
+					"alpha": {Head: BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"},
+						Nodes: map[BundleKey]map[BundleKey]struct{}{
+							BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
+							BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {}},
+							BundleKey{CsvName: "etcdoperator.v0.9.2", Version: "0.9.2"}: {BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {},
+								BundleKey{CsvName: "etcdoperator.v0.9.1"}: {}},
+							BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"}: {BundleKey{CsvName: "etcdoperator.v0.9.2", Version: "0.9.2"}: {}},
+						}},
+
+					"beta": {Head: BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"},
+						Nodes: map[BundleKey]map[BundleKey]struct{}{
+							BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
+							BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {}},
+						}},
+
+					"stable": {Head: BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"},
+						Nodes: map[BundleKey]map[BundleKey]struct{}{
+							BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
+							BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {}},
+							BundleKey{CsvName: "etcdoperator.v0.9.2", Version: "0.9.2"}: {BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {},
+								BundleKey{CsvName: "etcdoperator.v0.9.1"}: {}},
+							BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"}: {BundleKey{CsvName: "etcdoperator.v0.9.2", Version: "0.9.2"}: {}},
+						}},
+				},
+			},
+			newDefaultChannel: "",
+		},
+		{
+			name: "Add a bundle already in the graph, expect an error",
+			fail: true,
+			graph: Package{
+				Name:           "etcd",
+				DefaultChannel: "beta",
+				Channels: map[string]Channel{
+					"beta": {Head: BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"},
+						Nodes: map[BundleKey]map[BundleKey]struct{}{
+							BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
+						}},
+				},
+			},
+			bundle: Bundle{
+				Name:    "etcdoperator.v0.6.1",
+				Package: "etcd",
+				csv: &ClusterServiceVersion{
+					Spec: json.RawMessage(`
+						{ 
+						"version": "0.6.1"
+						}`),
+				},
+				Channels: []string{"beta"},
+			},
+			newDefaultChannel: "",
+		},
+		{
+			name: "Add a bundle behind the head of a channel",
+			fail: false,
+			graph: Package{
+				Name:           "etcd",
+				DefaultChannel: "beta",
+				Channels: map[string]Channel{
+					"beta": {Head: BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"},
+						Nodes: map[BundleKey]map[BundleKey]struct{}{
+							BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"}: {},
+						}},
+				},
+			},
+			bundle: Bundle{
+				Name:    "etcdoperator.v0.6.1",
+				Package: "etcd",
+				csv: &ClusterServiceVersion{
+					Spec: json.RawMessage(`
+						{ 
+						"version": "0.6.1"
+						}`),
+				},
+				Channels: []string{"beta"},
+			},
+			expectedGraph: &Package{
+				Name:           "etcd",
+				DefaultChannel: "beta",
+				Channels: map[string]Channel{
+					"beta": {Head: BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"},
+						Nodes: map[BundleKey]map[BundleKey]struct{}{
+							BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
+							BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"}: {BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {}},
+						}},
+				},
+			},
+			newDefaultChannel: "",
+		},
+		{
+			name: "Add a bundle to a new channel",
+			fail: false,
+			graph: Package{
+				Name:           "etcd",
+				DefaultChannel: "beta",
+				Channels: map[string]Channel{
+					"beta": {Head: BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"},
+						Nodes: map[BundleKey]map[BundleKey]struct{}{
+							BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
+						}},
+				},
+			},
+			bundle: Bundle{
+				Name:    "etcdoperator.v0.9.3",
+				Package: "etcd",
+				csv: &ClusterServiceVersion{
+					Spec: json.RawMessage(`
+						{ 
+						"version": "0.9.3"
+						}`),
+				},
+				Channels: []string{"alpha"},
+			},
+			expectedGraph: &Package{
+				Name:           "etcd",
+				DefaultChannel: "alpha",
+				Channels: map[string]Channel{
+					"beta": {Head: BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"},
+						Nodes: map[BundleKey]map[BundleKey]struct{}{
+							BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
+						}},
+					"alpha": {Head: BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"},
+						Nodes: map[BundleKey]map[BundleKey]struct{}{
+							BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"}: nil,
+						}},
+				},
+			},
+			newDefaultChannel: "alpha",
+		},
+		{
+			name:  "Add a bundle to an empty graph",
+			fail:  false,
+			graph: Package{},
+			bundle: Bundle{
+				Name:    "etcdoperator.v0.9.3",
+				Package: "etcd",
+				csv: &ClusterServiceVersion{
+					Spec: json.RawMessage(`
+						{ 
+						"version": "0.9.3"
+						}`),
+				},
+				Channels: []string{"alpha"},
+			},
+			expectedGraph: &Package{
+				Name:           "etcd",
+				DefaultChannel: "alpha",
+				Channels: map[string]Channel{
+					"alpha": {Head: BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"},
+						Nodes: map[BundleKey]map[BundleKey]struct{}{
+							BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"}: nil,
+						}},
+				},
+			},
+			newDefaultChannel: "alpha",
+		},
+		{
+			name: "Add a bundle in skippatch mode",
+			fail: false,
+			graph: Package{
+				Name:           "etcd",
+				DefaultChannel: "alpha",
+				Channels: map[string]Channel{
+					"alpha": {Head: BundleKey{CsvName: "etcdoperator.v0.9.2", Version: "0.9.2"},
+						Nodes: map[BundleKey]map[BundleKey]struct{}{
+							BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
+							BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {}},
+							BundleKey{CsvName: "etcdoperator.v0.9.2", Version: "0.9.2"}: {BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {},
+								BundleKey{CsvName: "etcdoperator.v0.9.1"}: {}},
+						}},
+
+					"beta": {Head: BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"},
+						Nodes: map[BundleKey]map[BundleKey]struct{}{
+							BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
+							BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {}},
+						}},
+
+					"stable": {Head: BundleKey{CsvName: "etcdoperator.v0.9.2", Version: "0.9.2"},
+						Nodes: map[BundleKey]map[BundleKey]struct{}{
+							BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
+							BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {}},
+							BundleKey{CsvName: "etcdoperator.v0.9.2", Version: "0.9.2"}: {BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {},
+								BundleKey{CsvName: "etcdoperator.v0.9.1"}: {}},
+						}},
+				},
+			},
+			bundle: Bundle{
+				Name:    "etcdoperator.v0.9.3",
+				Package: "etcd",
+				csv: &ClusterServiceVersion{
+					Spec: json.RawMessage(`
+							{
+							"version": "0.9.3"
+							}`),
+				},
+				Channels: []string{"alpha", "stable"},
+			},
+			skipPatch: true,
+			expectedGraph: &Package{
+				Name:           "etcd",
+				DefaultChannel: "alpha",
+				Channels: map[string]Channel{
+					"alpha": {Head: BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"},
+						Nodes: map[BundleKey]map[BundleKey]struct{}{
+							BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
+							BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"}: {BundleKey{CsvName: "etcdoperator.v0.9.2", Version: "0.9.2"}: {},
+								BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {},
+							},
+						}},
+
+					"beta": {Head: BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"},
+						Nodes: map[BundleKey]map[BundleKey]struct{}{
+							BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
+							BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {}},
+						}},
+
+					"stable": {Head: BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"},
+						Nodes: map[BundleKey]map[BundleKey]struct{}{
+							BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
+							BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"}: {BundleKey{CsvName: "etcdoperator.v0.9.2", Version: "0.9.2"}: {},
+								BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {},
+							},
+						}},
+				},
+			},
+			newDefaultChannel: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			graphLoader := BundleGraphLoader{}
+
+			newGraph, err := graphLoader.AddBundleToGraph(&tt.bundle, &tt.graph, tt.newDefaultChannel, tt.skipPatch)
+			if tt.fail {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.EqualValues(t, tt.expectedGraph.Name, newGraph.Name)
+			assert.EqualValues(t, tt.expectedGraph, newGraph)
+		})
+	}
+}

--- a/pkg/registry/channelupdateoptions.go
+++ b/pkg/registry/channelupdateoptions.go
@@ -1,0 +1,27 @@
+package registry
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Mode int
+
+const (
+	ReplacesMode = iota
+	SemVerMode
+	SkipPatchMode
+)
+
+func GetModeFromString(mode string) (Mode, error) {
+	switch strings.ToLower(mode) {
+	case "replaces":
+		return ReplacesMode, nil
+	case "semver":
+		return SemVerMode, nil
+	case "semver-skippatch":
+		return SkipPatchMode, nil
+	default:
+		return -1, fmt.Errorf("Invalid channel update mode %s specified", mode)
+	}
+}

--- a/pkg/registry/empty.go
+++ b/pkg/registry/empty.go
@@ -80,6 +80,10 @@ func (EmptyQuery) GetBundlePathsForPackage(ctx context.Context, pkgName string) 
 	return nil, errors.New("empty querier: cannot get images")
 }
 
+func (EmptyQuery) GetBundlesForPackage(ctx context.Context, pkgName string) (map[BundleKey]struct{}, error) {
+	return nil, errors.New("empty querier: cannot get bundles")
+}
+
 func (EmptyQuery) GetDefaultChannelForPackage(ctx context.Context, pkgName string) (string, error) {
 	return "", errors.New("empty querier: cannot get default channel")
 }

--- a/pkg/registry/graph.go
+++ b/pkg/registry/graph.go
@@ -1,5 +1,9 @@
 package registry
 
+import (
+	"fmt"
+)
+
 type Package struct {
 	Name           string
 	DefaultChannel string
@@ -19,4 +23,17 @@ type BundleKey struct {
 
 func (b *BundleKey) IsEmpty() bool {
 	return b.BundlePath == "" && b.Version == "" && b.CsvName == ""
+}
+
+func (b *BundleKey) String() string {
+	return fmt.Sprintf("%s %s %s", b.CsvName, b.Version, b.BundlePath)
+}
+
+func (p *Package) HasChannel(channel string) bool {
+	if p.Channels == nil {
+		return false
+	}
+
+	_, found := p.Channels[channel]
+	return found
 }

--- a/pkg/registry/interface.go
+++ b/pkg/registry/interface.go
@@ -8,6 +8,7 @@ import (
 
 type Load interface {
 	AddOperatorBundle(bundle *Bundle) error
+	AddBundleSemver(graph *Package, bundle *Bundle) error
 	AddPackageChannels(manifest PackageManifest) error
 	AddBundlePackageChannels(manifest PackageManifest, bundle *Bundle) error
 	RemovePackage(packageName string) error
@@ -42,6 +43,8 @@ type Query interface {
 	GetBundleVersion(ctx context.Context, image string) (string, error)
 	// List Images for Package
 	GetBundlePathsForPackage(ctx context.Context, pkgName string) ([]string, error)
+	// List Bundles for Package
+	GetBundlesForPackage(ctx context.Context, pkgName string) (map[BundleKey]struct{}, error)
 	// Get DefaultChannel for Package
 	GetDefaultChannelForPackage(ctx context.Context, pkgName string) (string, error)
 	// List channels for package
@@ -54,7 +57,7 @@ type Query interface {
 // GraphLoader supports multiple different loading schemes
 // GraphLoader from SQL, GraphLoader from old format (filesystem), GraphLoader from SQL + input bundles
 type GraphLoader interface {
-	Generate() (*Package, error)
+	Generate(packageName string) (*Package, error)
 }
 
 // RegistryPopulator populates a registry.

--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -1,8 +1,14 @@
 package registry
 
 import (
+	"errors"
 	"fmt"
 	"strings"
+)
+
+var (
+	// ErrPackageNotInDatabase is an error that describes a package not found error when querying the registry
+	ErrPackageNotInDatabase = errors.New("Package not in database")
 )
 
 // APIKey stores GroupVersionKind for use as map keys

--- a/pkg/sqlite/configmap.go
+++ b/pkg/sqlite/configmap.go
@@ -127,7 +127,7 @@ func (c *ConfigMapLoader) Populate() error {
 			continue
 		}
 
-		bundle := registry.NewBundle(csv.GetName(), "", "", &unstructured.Unstructured{Object: csvUnst})
+		bundle := registry.NewBundle(csv.GetName(), "", nil, &unstructured.Unstructured{Object: csvUnst})
 		ownedCRDs, _, err := csv.GetCustomResourceDefintions()
 		if err != nil {
 			errs = append(errs, err)

--- a/pkg/sqlite/graphloader_test.go
+++ b/pkg/sqlite/graphloader_test.go
@@ -30,7 +30,6 @@ func TestLoadPackageGraph_Etcd(t *testing.T) {
 			"alpha": {
 				Head: registry.BundleKey{BundlePath: "", Version: "0.9.2", CsvName: "etcdoperator.v0.9.2"},
 				Nodes: map[registry.BundleKey]map[registry.BundleKey]struct{}{
-					registry.BundleKey{BundlePath: "", Version: "", CsvName: "etcdoperator.v0.9.1"}:      {},
 					registry.BundleKey{BundlePath: "", Version: "0.6.1", CsvName: "etcdoperator.v0.6.1"}: {},
 					registry.BundleKey{BundlePath: "", Version: "0.9.0", CsvName: "etcdoperator.v0.9.0"}: {
 						registry.BundleKey{BundlePath: "", Version: "0.6.1", CsvName: "etcdoperator.v0.6.1"}: struct{}{},
@@ -53,7 +52,6 @@ func TestLoadPackageGraph_Etcd(t *testing.T) {
 			"stable": {
 				Head: registry.BundleKey{BundlePath: "", Version: "0.9.2", CsvName: "etcdoperator.v0.9.2"},
 				Nodes: map[registry.BundleKey]map[registry.BundleKey]struct{}{
-					registry.BundleKey{BundlePath: "", Version: "", CsvName: "etcdoperator.v0.9.1"}:      {},
 					registry.BundleKey{BundlePath: "", Version: "0.6.1", CsvName: "etcdoperator.v0.6.1"}: {},
 					registry.BundleKey{BundlePath: "", Version: "0.9.0", CsvName: "etcdoperator.v0.9.0"}: {
 						registry.BundleKey{BundlePath: "", Version: "0.6.1", CsvName: "etcdoperator.v0.6.1"}: struct{}{},
@@ -70,10 +68,10 @@ func TestLoadPackageGraph_Etcd(t *testing.T) {
 	db, cleanup := createLoadedTestDb(t)
 	defer cleanup()
 
-	graphLoader, err := NewSQLGraphLoaderFromDB(db, "etcd")
+	graphLoader, err := NewSQLGraphLoaderFromDB(db)
 	require.NoError(t, err)
 
-	result, err := graphLoader.Generate()
+	result, err := graphLoader.Generate("etcd")
 	require.NoError(t, err)
 
 	require.Equal(t, "etcd", result.Name)
@@ -84,4 +82,16 @@ func TestLoadPackageGraph_Etcd(t *testing.T) {
 		require.Equal(t, expectedChannel.Head, channel.Head)
 		require.EqualValues(t, expectedChannel.Nodes, channel.Nodes)
 	}
+}
+
+func TestLoadPackageGraph_Etcd_NotFound(t *testing.T) {
+	db, cleanup := createLoadedTestDb(t)
+	defer cleanup()
+
+	graphLoader, err := NewSQLGraphLoaderFromDB(db)
+	require.NoError(t, err)
+
+	_, err = graphLoader.Generate("not-a-real-package")
+	require.Error(t, err)
+	require.Equal(t, registry.ErrPackageNotInDatabase, err)
 }

--- a/pkg/sqlite/image_test.go
+++ b/pkg/sqlite/image_test.go
@@ -287,10 +287,10 @@ func TestImageLoading(t *testing.T) {
 			require.NoError(t, tt.addImage.LoadBundleFunc())
 
 			for _, p := range tt.wantPackages {
-				graphLoader, err := NewSQLGraphLoaderFromDB(db, p.Name)
+				graphLoader, err := NewSQLGraphLoaderFromDB(db)
 				require.NoError(t, err)
 
-				result, err := graphLoader.Generate()
+				result, err := graphLoader.Generate(p.Name)
 				require.NoError(t, err)
 				require.Equal(t, p, result)
 			}

--- a/pkg/sqlite/load_test.go
+++ b/pkg/sqlite/load_test.go
@@ -35,10 +35,10 @@ func TestAddPackageChannels(t *testing.T) {
 			description: "DuplicateBundlesInPackage/DBDoesntLock",
 			fields: fields{
 				bundles: []*registry.Bundle{
-					newBundle(t, "csv-a", "pkg-0", "stable", newUnstructuredCSV(t, "csv-a", "")),
-					newBundle(t, "csv-a", "pkg-0", "stable", newUnstructuredCSV(t, "csv-a", "")),
-					newBundle(t, "csv-b", "pkg-0", "alpha", newUnstructuredCSV(t, "csv-b", "")),
-					newBundle(t, "csv-c", "pkg-1", "stable", newUnstructuredCSV(t, "csv-c", "")),
+					newBundle(t, "csv-a", "pkg-0", []string{"stable"}, newUnstructuredCSV(t, "csv-a", "")),
+					newBundle(t, "csv-a", "pkg-0", []string{"stable"}, newUnstructuredCSV(t, "csv-a", "")),
+					newBundle(t, "csv-b", "pkg-0", []string{"alpha"}, newUnstructuredCSV(t, "csv-b", "")),
+					newBundle(t, "csv-c", "pkg-1", []string{"stable"}, newUnstructuredCSV(t, "csv-c", "")),
 				},
 			},
 			args: args{
@@ -80,9 +80,9 @@ func TestAddPackageChannels(t *testing.T) {
 			description: "MissingReplacesInPackage/AggregatesAndContinues",
 			fields: fields{
 				bundles: []*registry.Bundle{
-					newBundle(t, "csv-a", "pkg-0", "stable", newUnstructuredCSV(t, "csv-a", "non-existant")),
-					newBundle(t, "csv-b", "pkg-0", "alpha", newUnstructuredCSV(t, "csv-b", "")),
-					newBundle(t, "csv-c", "pkg-1", "stable", newUnstructuredCSV(t, "csv-c", "")),
+					newBundle(t, "csv-a", "pkg-0", []string{"stable"}, newUnstructuredCSV(t, "csv-a", "non-existant")),
+					newBundle(t, "csv-b", "pkg-0", []string{"alpha"}, newUnstructuredCSV(t, "csv-b", "")),
+					newBundle(t, "csv-c", "pkg-1", []string{"stable"}, newUnstructuredCSV(t, "csv-c", "")),
 				},
 			},
 			args: args{
@@ -164,10 +164,11 @@ func TestClearNonDefaultBundles(t *testing.T) {
 
 	// Create a replaces chain that contains bundles with no bundle path
 	pkg, channel := "pkg", "stable"
-	withoutPath := newBundle(t, "without-path", pkg, channel, newUnstructuredCSV(t, "without-path", ""))
-	withPathInternal := newBundle(t, "with-path-internal", pkg, channel, newUnstructuredCSV(t, "with-path-internal", withoutPath.Name))
+	channels := []string{"stable"}
+	withoutPath := newBundle(t, "without-path", pkg, channels, newUnstructuredCSV(t, "without-path", ""))
+	withPathInternal := newBundle(t, "with-path-internal", pkg, channels, newUnstructuredCSV(t, "with-path-internal", withoutPath.Name))
 	withPathInternal.BundleImage = "this.is/agood@sha256:path"
-	withPath := newBundle(t, "with-path", pkg, channel, newUnstructuredCSV(t, "with-path", withPathInternal.Name))
+	withPath := newBundle(t, "with-path", pkg, channels, newUnstructuredCSV(t, "with-path", withPathInternal.Name))
 	withPath.BundleImage = "this.is/abetter@sha256:path"
 
 	require.NoError(t, store.AddOperatorBundle(withoutPath))
@@ -222,8 +223,8 @@ func newUnstructuredCSV(t *testing.T, name, replaces string) *unstructured.Unstr
 	return &unstructured.Unstructured{Object: out}
 }
 
-func newBundle(t *testing.T, name, pkgName, channelName string, objs ...*unstructured.Unstructured) *registry.Bundle {
-	bundle := registry.NewBundle(name, pkgName, channelName, objs...)
+func newBundle(t *testing.T, name, pkgName string, channels []string, objs ...*unstructured.Unstructured) *registry.Bundle {
+	bundle := registry.NewBundle(name, pkgName, channels, objs...)
 
 	// Bust the bundle cache to set the CSV and CRDs
 	_, err := bundle.ClusterServiceVersion()

--- a/pkg/sqlite/loadprocs.go
+++ b/pkg/sqlite/loadprocs.go
@@ -1,0 +1,146 @@
+package sqlite
+
+import (
+	"database/sql"
+)
+
+// TODO: Finish separating procedures from loader layer: make this a type to make
+// unit tests more granular?
+func addChannelEntry(tx *sql.Tx, channelName, packageName, csvName string, depth int) (int64, error) {
+	addChannelEntry, err := tx.Prepare("insert into channel_entry(channel_name, package_name, operatorbundle_name, depth) values(?, ?, ?, ?)")
+	if err != nil {
+		return 0, err
+	}
+	defer addChannelEntry.Close()
+
+	res, err := addChannelEntry.Exec(channelName, packageName, csvName, depth)
+	if err != nil {
+		return 0, err
+	}
+	currentID, err := res.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+
+	return currentID, err
+}
+
+func addReplaces(tx *sql.Tx, replacesID, entryID int64) error {
+	addReplaces, err := tx.Prepare("update channel_entry set replaces = ? where entry_id = ?")
+	if err != nil {
+		return err
+	}
+	defer addReplaces.Close()
+
+	_, err = addReplaces.Exec(replacesID, entryID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func addPackage(tx *sql.Tx, packageName string) error {
+	addPackage, err := tx.Prepare("insert into package(name) values(?)")
+	if err != nil {
+		return err
+	}
+	defer addPackage.Close()
+
+	_, err = addPackage.Exec(packageName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func addPackageIfNotExists(tx *sql.Tx, packageName string) error {
+	addPackage, err := tx.Prepare("insert or replace into package(name) values(?)")
+	if err != nil {
+		return err
+	}
+	defer addPackage.Close()
+
+	_, err = addPackage.Exec(packageName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func addChannel(tx *sql.Tx, channelName, packageName, headCsvName string) error {
+	addChannel, err := tx.Prepare("insert into channel(name, package_name, head_operatorbundle_name) values(?, ?, ?)")
+	if err != nil {
+		return err
+	}
+	defer addChannel.Close()
+
+	_, err = addChannel.Exec(channelName, packageName, headCsvName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func updateChannel(tx *sql.Tx, channelName, packageName, headCsvName string) error {
+	updateChannel, err := tx.Prepare("update channel set head_operatorbundle_name = ? where name = ? and package_name = ?")
+	if err != nil {
+		return err
+	}
+	defer updateChannel.Close()
+
+	_, err = updateChannel.Exec(channelName, packageName, headCsvName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func addOrUpdateChannel(tx *sql.Tx, channelName, packageName, headCsvName string) error {
+	addChannel, err := tx.Prepare("insert or replace into channel(name, package_name, head_operatorbundle_name) values(?, ?, ?)")
+	if err != nil {
+		return err
+	}
+	defer addChannel.Close()
+
+	_, err = addChannel.Exec(channelName, packageName, headCsvName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func updateDefaultChannel(tx *sql.Tx, channelName, packageName string) error {
+	updateDefaultChannel, err := tx.Prepare("update package set default_channel = ? where name = ?")
+	if err != nil {
+		return err
+	}
+	defer updateDefaultChannel.Close()
+
+	_, err = updateDefaultChannel.Exec(channelName, packageName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func truncChannelGraph(tx *sql.Tx, channelName, packageName string) error {
+	truncChannelGraph, err := tx.Prepare("delete from channel_entry where channel_name = ? and package_name = ?")
+	if err != nil {
+		return err
+	}
+	defer truncChannelGraph.Close()
+
+	_, err = truncChannelGraph.Exec(channelName, packageName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
(feat) Semver insert modes

This adds a new flag to `opm index add` and `opm registry add` which
defines two new insert modes to add bundles to the existing update graph

Rather than rely on parsing the CSV for the replaces field to define the
channel update graph explicitly, in these new modes `opm` implicitly
infers the update graph based on the version attached to the bundle and
semantic versioning rules (https://semver.org/#summary)