### PR TITLE
Fix panic in registry add

### DIFF
--- a/pkg/registry/populator.go
+++ b/pkg/registry/populator.go
@@ -126,7 +126,9 @@ func loadBundle(csvName string, dir string) (*Bundle, error) {
 		return nil, err
 	}
 
-	bundle := &Bundle{}
+	bundle := &Bundle{
+		Name: csvName,
+	}
 	for _, f := range files {
 		log = log.WithField("file", f.Name())
 		if f.IsDir() {

--- a/pkg/registry/populator.go
+++ b/pkg/registry/populator.go
@@ -44,7 +44,7 @@ func (i *DirectoryPopulator) Populate() error {
 	// manifests of the bundle should be loaded into the database.
 	annotationsFile := &AnnotationsFile{}
 	for _, f := range files {
-		err = decodeFile(filepath.Join(metadata, f.Name()), err)
+		err = decodeFile(filepath.Join(metadata, f.Name()), annotationsFile)
 		if err != nil || *annotationsFile == (AnnotationsFile{}) {
 			continue
 		}
@@ -239,6 +239,10 @@ func translateAnnotationsIntoPackage(annotations *AnnotationsFile, csv *ClusterS
 
 // decodeFile decodes the file at a path into the given interface.
 func decodeFile(path string, into interface{}) error {
+	if into == nil {
+		panic("programmer error: decode destination must be instantiated before decode")
+	}
+
 	fileReader, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("unable to read file %s: %s", path, err)


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

- Fix panic during `registry add`
- Set missing bundle name to prevent `registry add` from failing

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
