### PR TITLE
bug(opm): packages flag on registry rm required

### DIFF
--- a/cmd/opm/registry/rm.go
+++ b/cmd/opm/registry/rm.go
@@ -25,7 +25,10 @@ func newRegistryRmCmd() *cobra.Command {
 
 	rootCmd.Flags().Bool("debug", false, "enable debug logging")
 	rootCmd.Flags().StringP("database", "d", "bundles.db", "relative path to database file")
-	rootCmd.Flags().StringSliceP("packages", "o", []string{}, "comma separated list of package names to be deleted")
+	rootCmd.Flags().StringSliceP("packages", "o", nil, "comma separated list of package names to be deleted")
+	if err := rootCmd.MarkFlagRequired("packages"); err != nil {
+		logrus.Panic("Failed to set required `packages` flag for `registry rm`")
+	}
 	rootCmd.Flags().Bool("permissive", false, "allow registry load errors")
 
 	return rootCmd
@@ -53,7 +56,7 @@ func rmFunc(cmd *cobra.Command, args []string) error {
 
 	logger := logrus.WithFields(logrus.Fields{"packages": packages})
 
-	logger.Info("adding to the registry")
+	logger.Info("removing from the registry")
 
 	registryDeleter := registry.NewRegistryDeleter(logger)
 


### PR DESCRIPTION
**Description of the change:**

The packages flag on `opm registry rm` is necessary in order for work to
be done. This update marks the flag as required so the usage can be
printed when the flag is ommitted.

**Motivation for the change:**

:boom::bug:

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

Closes #250 
