### PR TITLE
chore(travis): add conntrack package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ addons:
     update: true
     packages:
     - podman
+    - conntrack
 script: |
   "${MAKE}" unit build
   if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Install `conntrack` package for travis tests.

**Motivation for the change:**
Minikube failed to start because the [package was missing](https://travis-ci.com/github/operator-framework/operator-registry/jobs/312968962#L1507).


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
