### PR TITLE
feat: generate a bundle with configmap and secret objects

### DIFF
--- a/pkg/lib/bundle/supported_resources.go
+++ b/pkg/lib/bundle/supported_resources.go
@@ -6,6 +6,7 @@ const (
 	SecretKind             = "Secret"
 	ClusterRoleKind        = "ClusterRole"
 	ClusterRoleBindingKind = "ClusterRoleBinding"
+	ConfigMapKind          = "ConfigMap"
 	ServiceAccountKind     = "ServiceAccount"
 	ServiceKind            = "Service"
 	RoleKind               = "Role"
@@ -14,28 +15,28 @@ const (
 	ServiceMonitorKind     = "ServiceMonitor"
 )
 
-var supportedResources map[string]bool
+// Namespaced indicates whether the resource is namespace scoped (true) or cluster-scoped (false).
+type Namespaced bool
 
-// Add a list of supported resources to the map
 // Key: Kind name
-// Value: If namaspaced kind, true. Otherwise, false
-func init() {
-	supportedResources = make(map[string]bool, 11)
-
-	supportedResources[CSVKind] = true
-	supportedResources[CRDKind] = false
-	supportedResources[ClusterRoleKind] = false
-	supportedResources[ClusterRoleBindingKind] = false
-	supportedResources[ServiceKind] = true
-	supportedResources[ServiceAccountKind] = true
-	supportedResources[RoleKind] = true
-	supportedResources[RoleBindingKind] = true
-	supportedResources[PrometheusRuleKind] = true
-	supportedResources[ServiceMonitorKind] = true
+// Value: If namespaced kind, true. Otherwise, false
+var supportedResources = map[string]Namespaced{
+	CSVKind:                true,
+	CRDKind:                false,
+	ClusterRoleKind:        false,
+	ClusterRoleBindingKind: false,
+	ServiceKind:            true,
+	ServiceAccountKind:     true,
+	RoleKind:               true,
+	RoleBindingKind:        true,
+	PrometheusRuleKind:     true,
+	ServiceMonitorKind:     true,
+	SecretKind:             true,
+	ConfigMapKind:          true,
 }
 
 // IsSupported checks if the object kind is OLM-supported and if it is namespaced
-func IsSupported(kind string) (bool, bool) {
+func IsSupported(kind string) (bool, Namespaced) {
 	namespaced, ok := supportedResources[kind]
 	return ok, namespaced
 }

--- a/pkg/lib/bundle/testdata/validate/valid_bundle/manifests/etcdconfigmap.yaml
+++ b/pkg/lib/bundle/testdata/validate/valid_bundle/manifests/etcdconfigmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "my-config-map"
+data:
+  allowed: '"true"'
+  enemies: aliens
+  lives: "3"

--- a/pkg/lib/bundle/testdata/validate/valid_bundle/manifests/etcdsecret.yaml
+++ b/pkg/lib/bundle/testdata/validate/valid_bundle/manifests/etcdsecret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysecret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm


### PR DESCRIPTION

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Adds support for users putting configmap and secret objects inside their bundle. Part of the work to increase the flexibility of OLM for users. OLM knows how to install secrets from an install plan currently, but support for configmaps will be added as well. 

Currently no validation for these new objects is done (outside of them being valid kube objects) but they are whitelisted and will be installed when OLM installs the bundle. 

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
