### PR TITLE
test(e2e): login w/ docker first to prevent failures

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,13 +1,32 @@
 package e2e_test
 
 import (
+	"os"
+	"os/exec"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
+var (
+	dockerUsername = os.Getenv("DOCKER_USERNAME")
+	dockerPassword = os.Getenv("DOCKER_PASSWORD")
+)
+
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "E2E Suite")
 }
+
+var _ = BeforeSuite(func() {
+	// FIXME: Since podman login doesn't work with daemonless image pulling, we need to login with docker first so podman tests don't fail.
+	if dockerUsername == "" || dockerPassword == "" {
+		// Test will be skipped anyway
+		return
+	}
+
+	dockerlogin := exec.Command("docker", "login", "-u", dockerUsername, "-p", dockerPassword, "quay.io")
+	err := dockerlogin.Run()
+	Expect(err).NotTo(HaveOccurred(), "Error logging into quay.io")
+})

--- a/test/e2e/opm_test.go
+++ b/test/e2e/opm_test.go
@@ -160,9 +160,6 @@ func initialize() error {
 var _ = Describe("opm", func() {
 	IncludeSharedSpecs := func(containerTool string) {
 		BeforeEach(func() {
-			dockerUsername := os.Getenv("DOCKER_USERNAME")
-			dockerPassword := os.Getenv("DOCKER_PASSWORD")
-
 			if dockerUsername == "" || dockerPassword == "" {
 				Skip("registry credentials are not available")
 			}


### PR DESCRIPTION
## Description

Login with docker at the start of the e2e test suite to prevent random
failures when podman login is used first. This is a stopgap until
daemonless image pulling is compatible with podman login.

## Motivation

When a travis test fails for a tag, linux binaries aren't added to the release. Upon failure, the tests then need to be retried until successful.