### PR TITLE
fix(indexer): image indexer shouldn't copy previous index image to database layer

### DIFF
--- a/cmd/opm/index/add.go
+++ b/cmd/opm/index/add.go
@@ -8,7 +8,6 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/operator-framework/operator-registry/pkg/lib/indexer"
-	"github.com/operator-framework/operator-registry/pkg/registry"
 )
 
 var (
@@ -109,16 +108,6 @@ func runIndexAddCmdFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	mode, err := cmd.Flags().GetString("mode")
-	if err != nil {
-		return err
-	}
-
-	modeEnum, err := registry.GetModeFromString(mode)
-	if err != nil {
-		return err
-	}
-
 	logger := logrus.WithFields(logrus.Fields{"bundles": bundles})
 
 	logger.Info("building the index")
@@ -133,7 +122,6 @@ func runIndexAddCmdFunc(cmd *cobra.Command, args []string) error {
 		Tag:               tag,
 		Bundles:           bundles,
 		Permissive:        permissive,
-		Mode:              modeEnum,
 	}
 
 	err = indexAdder.AddToIndex(request)


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Added in a fix that saves the `index.db` file to the `/database/index.db` folder of the final index image when building from a previous index image.  This fix in the PR will only copy over the `index.db` file from the previous index image, and not the entire image to the database folder.  There was also optimization made to only extract this layer of the previous catalog image instead of the entire image.  This greatly enhances the speed of the `opm index add --from-index` command as well.

**Motivation for the change:**
When running a command like the following `opm index add --from-index` with the `--from-index` flag specified there was a bug in the resulting index image created.  The image would double in size almost, and the layer that contained the database would contain an entire copy of the previous image.  The `index.db` file would be saved to `/database/database/index.db` instead of `/database/index.db`.  

Steps to reproduce the bug before fix:

```
$ opm index add -b <bundle_image> -c podman --tag <catalog_tag> --binary-image <up_to_date_version_of_opm_binary_image> --debug

$ opm index add -b <bundle_image> -c podman --tag <catalog_tag> --binary-image <up_to_date_version_of_opm_binary_image> --debug --from-index <previous_index_image>

$ docker save <previous_index_image> -o tmpDir/saved.tar

# Inspect the image layer with the database in it

$ ls -la database/
 
drwxr-xr-x 22 root root  258 Apr  3 06:11 .
drwxr-xr-x  3 root root   66 Apr  3 06:32 ..
drwxr-xr-x  2 root root  161 Apr  3 06:09 bin
drwxr-xr-x  6 root root  103 Apr  3 06:09 build
drwxr-xr-x  2 root root   42 Apr  3 06:09 database
drwxr-xr-x  2 root root    6 Apr  3 06:09 dev
drwxr-xr-x 17 root root 4096 Apr  3 06:09 etc
drwxr-xr-x  4 root root   28 Apr  3 06:09 go
drwxr-xr-x  2 root root    6 Apr  3 06:09 home
drwxr-xr-x  5 root root  139 Apr  3 06:09 lib
drwxr-xr-x  5 root root   44 Apr  3 06:09 media
drwxr-xr-x  2 root root    6 Apr  3 06:09 mnt
drwxr-xr-x  2 root root    6 Apr  3 06:09 opt
drwxr-xr-x  2 root root    6 Apr  3 06:09 proc
drwxr-xr-x  3 root root   20 Apr  3 06:09 root
drwxr-xr-x  2 root root    6 Apr  3 06:09 run
drwxr-xr-x  2 root root   50 Apr  3 06:09 sbin
drwxr-xr-x  2 root root    6 Apr  3 06:09 srv
drwxr-xr-x  2 root root    6 Apr  3 06:09 sys
drwxr-xr-x  2 root root    6 Apr  3 06:09 tmp
drwxr-xr-x 10 root root  128 Apr  3 06:09 usr
drwxr-xr-x 13 root root  137 Apr  3 06:09 var
-rwxr-xr-x  1 root root    0 Dec 31  1969 .wh..wh..opq
```

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


Closes https://github.com/operator-framework/operator-registry/issues/259
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
