### PR TITLE
fix(query): ListBundles returns all bundles even without dependencies

### DIFF
--- a/pkg/registry/populator.go
+++ b/pkg/registry/populator.go
@@ -351,7 +351,6 @@ func parseDependenciesFile(path string, depFile *DependenciesFile) error {
 	for _, v := range deps.RawMessage {
 		// convert map to json
 		jsonStr, _ := json.Marshal(v)
-		fmt.Println(string(jsonStr))
 
 		// Check dependency type
 		dep := Dependency{}

--- a/pkg/registry/populator_test.go
+++ b/pkg/registry/populator_test.go
@@ -441,6 +441,11 @@ func TestListBundles(t *testing.T) {
 	store, err := createAndPopulateDB(db)
 	require.NoError(t, err)
 
+	var count int
+	row := db.QueryRow("SELECT COUNT(*) FROM operatorbundle")
+	err = row.Scan(&count)
+	require.NoError(t, err)
+
 	expectedDependencies := []*api.Dependency{
 		{
 			Type:  "olm.package",
@@ -456,9 +461,13 @@ func TestListBundles(t *testing.T) {
 	bundles, err := store.ListBundles(context.TODO())
 	require.NoError(t, err)
 	for _, b := range bundles {
-		dep := b.Dependencies
-		dependencies = append(dependencies, dep...)
+		for _, d := range b.Dependencies {
+			if d.GetType() != "" {
+				dependencies = append(dependencies, d)
+			}
+		}
 	}
+	require.Equal(t, count, len(bundles))
 	require.ElementsMatch(t, expectedDependencies, dependencies)
 }
 
@@ -477,7 +486,7 @@ func CheckInvariants(t *testing.T, db *sql.DB) {
 func CheckChannelHeadsHaveDescriptions(t *testing.T, db *sql.DB) {
 	// check channel heads have csv / bundle
 	rows, err := db.Query(`
-		select operatorbundle.name,length(operatorbundle.csv),length(operatorbundle.bundle) from operatorbundle 
+		select operatorbundle.name,length(operatorbundle.csv),length(operatorbundle.bundle) from operatorbundle
 		join channel on channel.head_operatorbundle_name = operatorbundle.name`)
 	require.NoError(t, err)
 
@@ -496,7 +505,7 @@ func CheckChannelHeadsHaveDescriptions(t *testing.T, db *sql.DB) {
 func CheckBundlesHaveContentsIfNoPath(t *testing.T, db *sql.DB) {
 	// check that any bundle entry has csv/bundle content unpacked if there is no bundlepath
 	rows, err := db.Query(`
-		select name,length(csv),length(bundle) from operatorbundle 
+		select name,length(csv),length(bundle) from operatorbundle
 		where bundlepath="" or bundlepath=null`)
 	require.NoError(t, err)
 

--- a/pkg/sqlite/query.go
+++ b/pkg/sqlite/query.go
@@ -788,7 +788,7 @@ func (s *SQLQuerier) ListBundles(ctx context.Context) (bundles []*api.Bundle, er
 	dependencies.type, dependencies.value
 	FROM channel_entry
 	INNER JOIN operatorbundle ON operatorbundle.name = channel_entry.operatorbundle_name
-	INNER JOIN dependencies ON dependencies.operatorbundle_name = channel_entry.operatorbundle_name
+	LEFT OUTER JOIN dependencies ON dependencies.operatorbundle_name = channel_entry.operatorbundle_name
 	INNER JOIN package ON package.name = channel_entry.package_name`
 
 	rows, err := s.db.QueryContext(ctx, query)
@@ -820,6 +820,9 @@ func (s *SQLQuerier) ListBundles(ctx context.Context) (bundles []*api.Bundle, er
 		if ok {
 			// Create new dependency object
 			dep := &api.Dependency{}
+			if !depType.Valid || !depValue.Valid {
+				continue
+			}
 			dep.Type = depType.String
 			dep.Value = depValue.String
 


### PR DESCRIPTION
ListBundles query uses INNER JOIN which only intersection meaning it only
returns bundles with dependencies. Switching to LEFT OUTER JOIN to return
all bundles with or without dependencies.

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
