### PR TITLE
fix(add): allow containertool to be specified for registry add

### DIFF
--- a/cmd/opm/index/delete.go
+++ b/cmd/opm/index/delete.go
@@ -1,9 +1,11 @@
 package index
 
 import (
+	"fmt"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/operator-framework/operator-registry/pkg/containertools"
 	"github.com/operator-framework/operator-registry/pkg/lib/indexer"
 )
 
@@ -35,7 +37,7 @@ func newIndexDeleteCmd() *cobra.Command {
 		logrus.Panic("Failed to set required `operators` flag for `index delete`")
 	}
 	indexCmd.Flags().StringP("binary-image", "i", "", "container image for on-image `opm` command")
-	indexCmd.Flags().StringP("container-tool", "c", "podman", "tool to interact with container images (save, build, etc.). One of: [docker, podman]")
+	indexCmd.Flags().StringP("container-tool", "c", "podman", "tool to interact with container images (save, build, etc.). One of: [none, docker, podman]")
 	indexCmd.Flags().StringP("tag", "t", "", "custom tag for container image being built")
 	indexCmd.Flags().Bool("permissive", false, "allow registry load errors")
 
@@ -78,6 +80,10 @@ func runIndexDeleteCmdFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if containerTool == "none" {
+		return fmt.Errorf("none is not a valid container-tool for index add")
+	}
+
 	tag, err := cmd.Flags().GetString("tag")
 	if err != nil {
 		return err
@@ -92,7 +98,7 @@ func runIndexDeleteCmdFunc(cmd *cobra.Command, args []string) error {
 
 	logger.Info("building the index")
 
-	indexDeleter := indexer.NewIndexDeleter(containerTool, logger)
+	indexDeleter := indexer.NewIndexDeleter(containertools.NewContainerTool(containerTool, containertools.PodmanTool), logger)
 
 	request := indexer.DeleteFromIndexRequest{
 		Generate:          generate,

--- a/pkg/containertools/containertool.go
+++ b/pkg/containertools/containertool.go
@@ -1,0 +1,46 @@
+package containertools
+
+type ContainerTool int
+
+const (
+	NoneTool ContainerTool = iota
+	PodmanTool
+	DockerTool
+)
+
+func (t ContainerTool) String() (s string) {
+	switch t {
+	case NoneTool:
+		s = "none"
+	case PodmanTool:
+		s = "podman"
+	case DockerTool:
+		s = "docker"
+	}
+	return
+}
+
+func NewContainerTool(s string, defaultTool ContainerTool) (t ContainerTool) {
+	switch s {
+	case "podman":
+		t = PodmanTool
+	case "docker":
+		t = DockerTool
+	case "none":
+		t = NoneTool
+	default:
+		t = defaultTool
+	}
+	return
+}
+
+// NewCommandContainerTool returns a tool that can be used in `exec` statements.
+func NewCommandContainerTool(s string) (t ContainerTool) {
+	switch s {
+	case "docker":
+		t = DockerTool
+	default:
+		t = PodmanTool
+	}
+	return
+}

--- a/pkg/containertools/dockerfilegenerator.go
+++ b/pkg/containertools/dockerfilegenerator.go
@@ -24,7 +24,7 @@ type IndexDockerfileGenerator struct {
 }
 
 // NewDockerfileGenerator is a constructor that returns a DockerfileGenerator
-func NewDockerfileGenerator(containerTool string, logger *logrus.Entry) DockerfileGenerator {
+func NewDockerfileGenerator(logger *logrus.Entry) DockerfileGenerator {
 	return &IndexDockerfileGenerator{
 		Logger: logger,
 	}

--- a/pkg/containertools/imagereader.go
+++ b/pkg/containertools/imagereader.go
@@ -33,7 +33,7 @@ type ImageLayerReader struct {
 	Logger *logrus.Entry
 }
 
-func NewImageReader(containerTool string, logger *logrus.Entry) ImageReader {
+func NewImageReader(containerTool ContainerTool, logger *logrus.Entry) ImageReader {
 	cmd := NewCommandRunner(containerTool, logger)
 
 	return &ImageLayerReader{

--- a/pkg/containertools/labelreader.go
+++ b/pkg/containertools/labelreader.go
@@ -17,7 +17,7 @@ type ImageLabelReader struct {
 	Cmd    CommandRunner
 }
 
-func NewLabelReader(containerTool string, logger *logrus.Entry) LabelReader {
+func NewLabelReader(containerTool ContainerTool, logger *logrus.Entry) LabelReader {
 	cmd := NewCommandRunner(containerTool, logger)
 
 	return ImageLabelReader{

--- a/pkg/image/execregistry/registry.go
+++ b/pkg/image/execregistry/registry.go
@@ -1,0 +1,44 @@
+package execregistry
+
+import (
+	"context"
+	"github.com/operator-framework/operator-registry/pkg/containertools"
+	"github.com/sirupsen/logrus"
+
+	"github.com/operator-framework/operator-registry/pkg/image"
+)
+
+// Registry enables manipulation of images via exec podman/docker commands.
+type Registry struct {
+	log      *logrus.Entry
+	cmd      containertools.CommandRunner
+}
+
+// Adapt the cmd interface to the registry interface
+var _ image.Registry = &Registry{}
+
+func NewRegistry(tool containertools.ContainerTool, logger *logrus.Entry) (registry *Registry, err error) {
+	return &Registry{
+		log: logger,
+		cmd: containertools.NewCommandRunner(tool, logger),
+	}, nil
+}
+
+// Pull fetches and stores an image by reference.
+func (r *Registry) Pull(ctx context.Context, ref image.Reference) error {
+	return r.cmd.Pull(ref.String())
+}
+
+// Unpack writes the unpackaged content of an image to a directory.
+// If the referenced image does not exist in the registry, an error is returned.
+func (r *Registry) Unpack(ctx context.Context, ref image.Reference, dir string) error {
+	return containertools.ImageLayerReader{
+		Cmd:    r.cmd,
+		Logger: r.log,
+	}.GetImageData(ref.String(), dir)
+}
+
+// Destroy is no-op for exec tools
+func (r *Registry) Destroy() error {
+	return nil
+}

--- a/pkg/image/registry.go
+++ b/pkg/image/registry.go
@@ -18,6 +18,9 @@ type Registry interface {
 	// If the referenced image does not exist in the registry, an error is returned.
 	Unpack(ctx context.Context, ref Reference, dir string) error
 
+	// Destroy cleans up any on-disk resources used to track images
+	Destroy() error
+
 	// Pack creates and stores an image based on the given reference and returns a reference to the new image.
 	// If the referenced image does not exist in the registry, a new image is created from scratch.
 	// If it exists, it's used as the base image.

--- a/pkg/lib/bundle/exporter.go
+++ b/pkg/lib/bundle/exporter.go
@@ -15,14 +15,14 @@ import (
 type BundleExporter struct {
 	image         string
 	directory     string
-	containerTool string
+	containerTool containertools.ContainerTool
 }
 
 func NewSQLExporterForBundle(image, directory, containerTool string) *BundleExporter {
 	return &BundleExporter{
 		image:         image,
 		directory:     directory,
-		containerTool: containerTool,
+		containerTool: containertools.NewContainerTool(containerTool, containertools.NoneTool),
 	}
 }
 

--- a/pkg/lib/bundle/interfaces.go
+++ b/pkg/lib/bundle/interfaces.go
@@ -23,7 +23,7 @@ type BundleImageValidator interface {
 // NewImageValidator is a constructor that returns an ImageValidator
 func NewImageValidator(containerTool string, logger *logrus.Entry) BundleImageValidator {
 	return imageValidator{
-		imageReader: containertools.NewImageReader(containerTool, logger),
+		imageReader: containertools.NewImageReader(containertools.NewContainerTool(containerTool, containertools.NoneTool), logger),
 		logger:      logger,
 	}
 }

--- a/pkg/lib/image/registry.go
+++ b/pkg/lib/image/registry.go
@@ -1,8 +1,23 @@
 package image
 
 import (
+	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
 	"time"
 
 	"github.com/docker/distribution/configuration"
@@ -15,14 +30,45 @@ import (
 // RunDockerRegistry runs a docker registry on an available port and returns its host string if successful, otherwise it returns an error.
 // If the rootDir argument isn't empty, the registry is configured to use this as the root directory for persisting image data to the filesystem.
 // If the rootDir argument is empty, the registry is configured to keep image data in memory.
-func RunDockerRegistry(ctx context.Context, rootDir string) (string, error) {
+func RunDockerRegistry(ctx context.Context, rootDir string) (string, string, error) {
 	dockerPort, err := freeport.GetFreePort()
 	if err != nil {
-		return "", err
+		return "", "", err
+	}
+	host := fmt.Sprintf("localhost:%d", dockerPort)
+	certPool := x509.NewCertPool()
+
+	cafile, err := ioutil.TempFile("", "ca")
+	if err != nil {
+		return "", "", err
+	}
+	certfile, err := ioutil.TempFile("", "cert")
+	if err != nil {
+		return "", "", err
+	}
+	keyfile, err := ioutil.TempFile("", "key")
+	if err != nil {
+		return "", "", err
+	}
+	if err := GenerateCerts(cafile, certfile, keyfile, certPool); err != nil {
+		return "", "", err
+	}
+	if err := cafile.Close(); err != nil {
+		return "", "", err
+	}
+	if err := certfile.Close(); err != nil {
+		return "", "", err
+	}
+	if err := keyfile.Close(); err != nil {
+		return "", "", err
 	}
 
 	config := &configuration.Configuration{}
-	config.HTTP.Addr = fmt.Sprintf(":%d", dockerPort)
+	config.HTTP.Addr = host
+	config.HTTP.TLS.Certificate = certfile.Name()
+	config.HTTP.TLS.Key = keyfile.Name()
+	config.Log.Level = "debug"
+
 	if rootDir != "" {
 		config.Storage = map[string]configuration.Parameters{"filesystem": map[string]interface{}{
 			"rootdirectory": rootDir,
@@ -34,15 +80,131 @@ func RunDockerRegistry(ctx context.Context, rootDir string) (string, error) {
 
 	dockerRegistry, err := registry.NewRegistry(ctx, config)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	go func() {
+		defer func() {
+			os.Remove(cafile.Name())
+			os.Remove(certfile.Name())
+			os.Remove(keyfile.Name())
+		}()
 		if err := dockerRegistry.ListenAndServe(); err != nil {
 			panic(fmt.Errorf("docker registry stopped listening: %v", err))
 		}
 	}()
 
+	err = wait.Poll(100*time.Millisecond, 10*time.Second, func() (done bool, err error) {
+		tr := &http.Transport{TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: false,
+			RootCAs:            certPool,
+		}}
+		client := &http.Client{Transport: tr}
+		r, err := client.Get("https://"+host+"/v2/")
+		if err != nil {
+			return false, nil
+		}
+		if r.StatusCode == http.StatusOK {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return "", "", err
+	}
+
 	// Return the registry host string
-	return fmt.Sprintf("localhost:%d", dockerPort), nil
+	return host, cafile.Name(), nil
+}
+
+func certToPem(der []byte) ([]byte, error) {
+	out := &bytes.Buffer{}
+	if err := pem.Encode(out, &pem.Block{Type: "CERTIFICATE", Bytes: der}); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+func keyToPem(key *ecdsa.PrivateKey) ([]byte, error) {
+	b, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, fmt.Errorf( "unable to marshal private key: %v", err)
+	}
+	out := &bytes.Buffer{}
+	if err := pem.Encode(out, &pem.Block{Type: "EC PRIVATE KEY", Bytes: b}); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+func GenerateCerts(caWriter, certWriter, keyWriter io.Writer, pool *x509.CertPool ) error {
+	priv, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	if err != nil {
+		return err
+	}
+	ca := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"test ca"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Hour),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA: true,
+	}
+	cert := x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			Organization: []string{"test cert"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Hour),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IPAddresses: []net.IP{
+			net.ParseIP("127.0.0.1"),
+			net.ParseIP("::1"),
+		},
+		DNSNames: []string{"localhost"},
+	}
+
+	caBytes, err := x509.CreateCertificate(rand.Reader, &ca, &ca, &priv.PublicKey, priv)
+	if err != nil {
+		return err
+	}
+
+	caFile, err := certToPem(caBytes)
+	if err != nil {
+		return err
+	}
+	if _, err := caWriter.Write(caFile); err != nil {
+		return err
+	}
+	pool.AppendCertsFromPEM(caFile)
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, &cert, &ca, &priv.PublicKey, priv)
+	if err != nil {
+		return err
+	}
+	certFile, err := certToPem(certBytes)
+	if err != nil {
+		return err
+	}
+	if _, err := certWriter.Write(certFile); err != nil {
+		return err
+	}
+
+	keyFile, err := keyToPem(priv)
+	if err != nil {
+		return err
+	}
+	if _, err := keyWriter.Write(keyFile); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/lib/indexer/indexer.go
+++ b/pkg/lib/indexer/indexer.go
@@ -37,7 +37,7 @@ type ImageIndexer struct {
 	ImageReader         containertools.ImageReader
 	RegistryAdder       registry.RegistryAdder
 	RegistryDeleter     registry.RegistryDeleter
-	ContainerTool       string
+	ContainerTool       containertools.ContainerTool
 	Logger              *logrus.Entry
 }
 
@@ -51,6 +51,7 @@ type AddToIndexRequest struct {
 	Bundles           []string
 	Tag               string
 	Mode              pregistry.Mode
+	SkipTLS           bool
 }
 
 // AddToIndex is an aggregate API used to generate a registry index image with additional bundles
@@ -74,6 +75,7 @@ func (i ImageIndexer) AddToIndex(request AddToIndexRequest) error {
 		InputDatabase: databaseFile,
 		Permissive:    request.Permissive,
 		Mode:          request.Mode,
+		SkipTLS:       request.SkipTLS,
 	}
 
 	// Add the bundles to the registry

--- a/pkg/lib/indexer/interfaces.go
+++ b/pkg/lib/indexer/interfaces.go
@@ -4,7 +4,6 @@ package indexer
 import (
 	"github.com/operator-framework/operator-registry/pkg/containertools"
 	"github.com/operator-framework/operator-registry/pkg/lib/registry"
-
 	"github.com/sirupsen/logrus"
 )
 
@@ -16,9 +15,9 @@ type IndexAdder interface {
 }
 
 // NewIndexAdder is a constructor that returns an IndexAdder
-func NewIndexAdder(containerTool string, logger *logrus.Entry) IndexAdder {
+func NewIndexAdder(containerTool containertools.ContainerTool, logger *logrus.Entry) IndexAdder {
 	return ImageIndexer{
-		DockerfileGenerator: containertools.NewDockerfileGenerator(containerTool, logger),
+		DockerfileGenerator: containertools.NewDockerfileGenerator(logger),
 		CommandRunner:       containertools.NewCommandRunner(containerTool, logger),
 		LabelReader:         containertools.NewLabelReader(containerTool, logger),
 		RegistryAdder:       registry.NewRegistryAdder(logger),
@@ -36,9 +35,9 @@ type IndexDeleter interface {
 }
 
 // NewIndexDeleter is a constructor that returns an IndexDeleter
-func NewIndexDeleter(containerTool string, logger *logrus.Entry) IndexDeleter {
+func NewIndexDeleter(containerTool containertools.ContainerTool, logger *logrus.Entry) IndexDeleter {
 	return ImageIndexer{
-		DockerfileGenerator: containertools.NewDockerfileGenerator(containerTool, logger),
+		DockerfileGenerator: containertools.NewDockerfileGenerator(logger),
 		CommandRunner:       containertools.NewCommandRunner(containerTool, logger),
 		LabelReader:         containertools.NewLabelReader(containerTool, logger),
 		RegistryDeleter:     registry.NewRegistryDeleter(logger),
@@ -54,9 +53,9 @@ type IndexExporter interface {
 }
 
 // NewIndexExporter is a constructor that returns an IndexExporter
-func NewIndexExporter(containerTool string, logger *logrus.Entry) IndexExporter {
+func NewIndexExporter(containerTool containertools.ContainerTool, logger *logrus.Entry) IndexExporter {
 	return ImageIndexer{
-		DockerfileGenerator: containertools.NewDockerfileGenerator(containerTool, logger),
+		DockerfileGenerator: containertools.NewDockerfileGenerator(logger),
 		CommandRunner:       containertools.NewCommandRunner(containerTool, logger),
 		LabelReader:         containertools.NewLabelReader(containerTool, logger),
 		ImageReader:         containertools.NewImageReader(containerTool, logger),

--- a/test/e2e/opm_test.go
+++ b/test/e2e/opm_test.go
@@ -3,6 +3,7 @@ package e2e_test
 import (
 	"context"
 	"database/sql"
+	"github.com/operator-framework/operator-registry/pkg/containertools"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -86,7 +87,7 @@ func buildIndexWith(containerTool string) error {
 		bundleImage + ":" + bundleTag2,
 	}
 	logger := logrus.WithFields(logrus.Fields{"bundles": bundles})
-	indexAdder := indexer.NewIndexAdder(containerTool, logger)
+	indexAdder := indexer.NewIndexAdder(containertools.NewContainerTool(containerTool, containertools.NoneTool), logger)
 
 	request := indexer.AddToIndexRequest{
 		Generate:          false,
@@ -106,7 +107,7 @@ func buildFromIndexWith(containerTool string) error {
 		bundleImage + ":" + bundleTag3,
 	}
 	logger := logrus.WithFields(logrus.Fields{"bundles": bundles})
-	indexAdder := indexer.NewIndexAdder(containerTool, logger)
+	indexAdder := indexer.NewIndexAdder(containertools.NewContainerTool(containerTool, containertools.NoneTool), logger)
 
 	request := indexer.AddToIndexRequest{
 		Generate:          false,
@@ -141,7 +142,7 @@ func pushBundles(containerTool string) error {
 
 func exportWith(containerTool string) error {
 	logger := logrus.WithFields(logrus.Fields{"package": packageName})
-	indexExporter := indexer.NewIndexExporter(containerTool, logger)
+	indexExporter := indexer.NewIndexExporter(containertools.NewContainerTool(containerTool, containertools.NoneTool), logger)
 
 	request := indexer.ExportFromIndexRequest{
 		Index:         indexImage2,


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Registry add by default will use containerd, but we continue to support
podman and docker.

**Motivation for the change:**
This is to continue supporting registries.conf for users relying on podman for registry add.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
