### PR TITLE
fix(index-add): docker index add failing

### DIFF
--- a/pkg/containertools/dockerfilegenerator.go
+++ b/pkg/containertools/dockerfilegenerator.go
@@ -48,7 +48,7 @@ func (g *IndexDockerfileGenerator) GenerateIndexDockerfile(binarySourceImage, da
 	dockerfile += fmt.Sprintf("LABEL %s=%s\n", DbLocationLabel, DefaultDbLocation)
 
 	// Content
-	dockerfile += fmt.Sprintf("ADD %s /database\n", databaseFolder)
+	dockerfile += fmt.Sprintf("ADD %s/index.db %s\n", databaseFolder, DefaultDbLocation)
 	dockerfile += fmt.Sprintf("EXPOSE 50051\n")
 	dockerfile += fmt.Sprintf("ENTRYPOINT [\"/bin/opm\"]\n")
 	dockerfile += fmt.Sprintf("CMD [\"registry\", \"serve\", \"--database\", \"%s\"]\n", DefaultDbLocation)

--- a/pkg/containertools/dockerfilegenerator_test.go
+++ b/pkg/containertools/dockerfilegenerator_test.go
@@ -18,7 +18,7 @@ func TestGenerateDockerfile(t *testing.T) {
 	databaseFolder := "database"
 	expectedDockerfile := `FROM quay.io/operator-framework/builder
 LABEL operators.operatorframework.io.index.database.v1=/database/index.db
-ADD database /database
+ADD database/index.db /database/index.db
 EXPOSE 50051
 ENTRYPOINT ["/bin/opm"]
 CMD ["registry", "serve", "--database", "/database/index.db"]
@@ -41,7 +41,7 @@ func TestGenerateDockerfile_EmptyBaseImage(t *testing.T) {
 	databaseFolder := "database"
 	expectedDockerfile := `FROM quay.io/operator-framework/upstream-registry-builder
 LABEL operators.operatorframework.io.index.database.v1=/database/index.db
-ADD database /database
+ADD database/index.db /database/index.db
 EXPOSE 50051
 ENTRYPOINT ["/bin/opm"]
 CMD ["registry", "serve", "--database", "/database/index.db"]

--- a/pkg/lib/indexer/indexer.go
+++ b/pkg/lib/indexer/indexer.go
@@ -76,6 +76,7 @@ func (i ImageIndexer) AddToIndex(request AddToIndexRequest) error {
 		Permissive:    request.Permissive,
 		Mode:          request.Mode,
 		SkipTLS:       request.SkipTLS,
+		ContainerTool: i.ContainerTool,
 	}
 
 	// Add the bundles to the registry


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Fixes an error in `index add` with docker.

**Motivation for the change:**
This is a quick fix, there are several issues with the current way we do this.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
