### PR TITLE
Use local docker registry for e2e tests on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,22 @@ addons:
     - conntrack
 script: |
   "${MAKE}" unit build
-  if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    sudo minikube start # vm-driver=none requires root
-    sudo chown -R "$USER" "$HOME/.kube" "$HOME/.minikube"
-    KUBECONFIG="$HOME/.kube/config" make e2e
+  if [[ "$TRAVIS_OS_NAME" != "linux" ]]; then
+    echo "skipping e2e tests for ${TRAVIS_OS_NAME}"
+    exit 0
   fi
+
+  if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+    # no Quay.io credentials available for PR tests
+    echo "starting local test docker registry"
+    sudo docker run -d -p 5000:5000 --restart=always --name registry registry:2
+    export DOCKER_REGISTRY_HOST="localhost:5000"
+  fi
+
+  sudo minikube start # vm-driver=none requires root
+  sudo chown -R "$USER" "$HOME/.kube" "$HOME/.minikube"
+
+  KUBECONFIG="$HOME/.kube/config" make e2e
 notifications:
   email: false
 before_deploy:


### PR DESCRIPTION
**Description of the change:**

- Start and use a local docker registry in travis e2e tests for unprivileged branches/PRs.
- Introduce the `$DOCKER_REGISTRY_HOST` environment variable to configure the registry host used in OPM e2e tests.

**Motivation for the change:**

E2E tests requiring Quay creds were being skipped for PR branches, so we wouldn't see the results until it had already merged to master.
