### PR TITLE
Bug 1825925: support deamonless export

### DIFF
--- a/cmd/opm/index/export.go
+++ b/cmd/opm/index/export.go
@@ -1,7 +1,6 @@
 package index
 
 import (
-	"fmt"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -46,7 +45,7 @@ func newIndexExportCmd() *cobra.Command {
 		logrus.Panic("Failed to set required `package` flag for `index export`")
 	}
 	indexCmd.Flags().StringP("download-folder", "f", "downloaded", "directory where downloaded operator bundle(s) will be stored")
-	indexCmd.Flags().StringP("container-tool", "c", "podman", "tool to interact with container images (save, build, etc.). One of: [none, docker, podman]")
+	indexCmd.Flags().StringP("container-tool", "c", "none", "tool to interact with container images (save, build, etc.). One of: [none, docker, podman]")
 	if err := indexCmd.Flags().MarkHidden("debug"); err != nil {
 		logrus.Panic(err.Error())
 	}
@@ -76,21 +75,17 @@ func runIndexExportCmdFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if containerTool == "none" {
-		return fmt.Errorf("none is not a valid container-tool for index add")
-	}
-
 	logger := logrus.WithFields(logrus.Fields{"index": index, "package": packageName})
 
 	logger.Info("export from the index")
 
-	indexExporter := indexer.NewIndexExporter(containertools.NewContainerTool(containerTool, containertools.PodmanTool), logger)
+	indexExporter := indexer.NewIndexExporter(containertools.NewContainerTool(containerTool, containertools.NoneTool), logger)
 
 	request := indexer.ExportFromIndexRequest{
 		Index:         index,
 		Package:       packageName,
 		DownloadPath:  downloadPath,
-		ContainerTool: containerTool,
+		ContainerTool: containertools.NewContainerTool(containerTool, containertools.NoneTool),
 	}
 
 	err = indexExporter.ExportFromIndex(request)

--- a/pkg/containertools/dockerfilegenerator.go
+++ b/pkg/containertools/dockerfilegenerator.go
@@ -32,7 +32,7 @@ func NewDockerfileGenerator(logger *logrus.Entry) DockerfileGenerator {
 
 // GenerateIndexDockerfile builds a string representation of a dockerfile to use when building
 // an operator-registry index image
-func (g *IndexDockerfileGenerator) GenerateIndexDockerfile(binarySourceImage, databaseFolder string) string {
+func (g *IndexDockerfileGenerator) GenerateIndexDockerfile(binarySourceImage, databasePath string) string {
 	var dockerfile string
 
 	if binarySourceImage == "" {
@@ -48,7 +48,7 @@ func (g *IndexDockerfileGenerator) GenerateIndexDockerfile(binarySourceImage, da
 	dockerfile += fmt.Sprintf("LABEL %s=%s\n", DbLocationLabel, DefaultDbLocation)
 
 	// Content
-	dockerfile += fmt.Sprintf("ADD %s/index.db %s\n", databaseFolder, DefaultDbLocation)
+	dockerfile += fmt.Sprintf("ADD %s %s\n", databasePath, DefaultDbLocation)
 	dockerfile += fmt.Sprintf("EXPOSE 50051\n")
 	dockerfile += fmt.Sprintf("ENTRYPOINT [\"/bin/opm\"]\n")
 	dockerfile += fmt.Sprintf("CMD [\"registry\", \"serve\", \"--database\", \"%s\"]\n", DefaultDbLocation)

--- a/pkg/containertools/dockerfilegenerator_test.go
+++ b/pkg/containertools/dockerfilegenerator_test.go
@@ -15,7 +15,7 @@ func TestGenerateDockerfile(t *testing.T) {
 	defer controller.Finish()
 
 	binarySourceImage := "quay.io/operator-framework/builder"
-	databaseFolder := "database"
+	databasePath := "database/index.db"
 	expectedDockerfile := `FROM quay.io/operator-framework/builder
 LABEL operators.operatorframework.io.index.database.v1=/database/index.db
 ADD database/index.db /database/index.db
@@ -30,7 +30,7 @@ CMD ["registry", "serve", "--database", "/database/index.db"]
 		Logger: logger,
 	}
 
-	dockerfile := dockerfileGenerator.GenerateIndexDockerfile(binarySourceImage, databaseFolder)
+	dockerfile := dockerfileGenerator.GenerateIndexDockerfile(binarySourceImage, databasePath)
 	require.Equal(t, dockerfile, expectedDockerfile)
 }
 
@@ -38,7 +38,7 @@ func TestGenerateDockerfile_EmptyBaseImage(t *testing.T) {
 	controller := gomock.NewController(t)
 	defer controller.Finish()
 
-	databaseFolder := "database"
+	databasePath := "database/index.db"
 	expectedDockerfile := `FROM quay.io/operator-framework/upstream-registry-builder
 LABEL operators.operatorframework.io.index.database.v1=/database/index.db
 ADD database/index.db /database/index.db
@@ -53,6 +53,6 @@ CMD ["registry", "serve", "--database", "/database/index.db"]
 		Logger: logger,
 	}
 
-	dockerfile := dockerfileGenerator.GenerateIndexDockerfile("", databaseFolder)
+	dockerfile := dockerfileGenerator.GenerateIndexDockerfile("", databasePath)
 	require.Equal(t, dockerfile, expectedDockerfile)
 }

--- a/pkg/image/execregistry/registry.go
+++ b/pkg/image/execregistry/registry.go
@@ -38,6 +38,14 @@ func (r *Registry) Unpack(ctx context.Context, ref image.Reference, dir string) 
 	}.GetImageData(ref.String(), dir)
 }
 
+// Labels gets the labels for an image reference.
+func (r *Registry) Labels(ctx context.Context, ref image.Reference) (map[string]string, error) {
+	return containertools.ImageLabelReader{
+		Cmd: r.cmd,
+		Logger: r.log,
+	}.GetLabelsFromImage(ref.String())
+}
+
 // Destroy is no-op for exec tools
 func (r *Registry) Destroy() error {
 	return nil

--- a/pkg/image/registry.go
+++ b/pkg/image/registry.go
@@ -18,6 +18,9 @@ type Registry interface {
 	// If the referenced image does not exist in the registry, an error is returned.
 	Unpack(ctx context.Context, ref Reference, dir string) error
 
+	// Labels gets the labels for an image that is already stored.
+	Labels(ctx context.Context, ref Reference) (map[string]string, error)
+
 	// Destroy cleans up any on-disk resources used to track images
 	Destroy() error
 
@@ -26,3 +29,4 @@ type Registry interface {
 	// If it exists, it's used as the base image.
 	// Pack(ctx context.Context, ref Reference, from io.Reader) (next string, err error)
 }
+

--- a/test/e2e/opm_test.go
+++ b/test/e2e/opm_test.go
@@ -148,7 +148,7 @@ func exportWith(containerTool string) error {
 		Index:         indexImage2,
 		Package:       packageName,
 		DownloadPath:  "downloaded",
-		ContainerTool: containerTool,
+		ContainerTool: containertools.NewContainerTool(containerTool, containertools.NoneTool),
 	}
 
 	return indexExporter.ExportFromIndex(request)
@@ -221,6 +221,18 @@ var _ = Describe("opm", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("loading manifests from a directory")
+			err = initialize()
+			Expect(err).NotTo(HaveOccurred())
+
+			// clean and try again with containerd
+			err = os.RemoveAll("downloaded")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("exporting an index to disk with containerd")
+			err = exportWith(containertools.NoneTool.String())
+			Expect(err).NotTo(HaveOccurred())
+
+			By("loading manifests from a containerd-extracted directory")
 			err = initialize()
 			Expect(err).NotTo(HaveOccurred())
 		})


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
`opm index extract` can now be used without specifying a containertool. podman and docker can still be used as a fallback.

This also includes a fix that pulls and unpacks the previous index image into a separate directory from where the database is ultimately modified and added to the new images

**Motivation for the change:**
opm index extract is useful to run in image builds, so having an unprivileged way to extract enables that.

Index adds were excruciatingly slow, sending 1GB+ images into the build context.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
