### PR TITLE
(feat): Bundle commutativity

### DIFF
--- a/pkg/lib/registry/registry.go
+++ b/pkg/lib/registry/registry.go
@@ -20,7 +20,7 @@ import (
 )
 
 type RegistryUpdater struct {
-	Logger   *logrus.Entry
+	Logger *logrus.Entry
 }
 
 type AddToRegistryRequest struct {
@@ -89,38 +89,54 @@ func (r RegistryUpdater) AddToRegistry(request AddToRegistryRequest) error {
 		}
 	}()
 
-	// TODO(njhale): Parallelize this once bundle add is commutative
+	simpleRefs := make([]image.Reference, 0)
 	for _, ref := range request.Bundles {
-		if err := populate(context.TODO(), dbLoader, graphLoader, dbQuerier, reg, image.SimpleReference(ref), request.Mode); err != nil {
-			err = fmt.Errorf("error loading bundle from image: %s", err)
-			if !request.Permissive {
-				r.Logger.WithError(err).Error("permissive mode disabled")
-				errs = append(errs, err)
-			} else {
-				r.Logger.WithError(err).Warn("permissive mode enabled")
-			}
+		simpleRefs = append(simpleRefs, image.SimpleReference(ref))
+	}
+
+	if err := populate(context.TODO(), dbLoader, graphLoader, dbQuerier, reg, simpleRefs, request.Mode); err != nil {
+		err = fmt.Errorf("error loading bundle from image: %s", err)
+		if !request.Permissive {
+			r.Logger.WithError(err).Error("permissive mode disabled")
+			errs = append(errs, err)
+		} else {
+			r.Logger.WithError(err).Warn("permissive mode enabled")
 		}
 	}
 
 	return utilerrors.NewAggregate(errs) // nil if no errors
 }
 
-func populate(ctx context.Context, loader registry.Load, graphLoader registry.GraphLoader, querier registry.Query, reg image.Registry, ref image.Reference, mode registry.Mode) error {
-	workingDir, err := ioutil.TempDir("./", "bundle_tmp")
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(workingDir)
+func populate(ctx context.Context, loader registry.Load, graphLoader registry.GraphLoader, querier registry.Query, reg image.Registry, refs []image.Reference, mode registry.Mode) error {
+	var errs []error
 
-	if err = reg.Pull(ctx, ref); err != nil {
-		return err
+	unpackedImageMap := make(map[image.Reference]string, 0)
+	for _, ref := range refs {
+		workingDir, err := ioutil.TempDir("./", "bundle_tmp")
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		defer os.RemoveAll(workingDir)
+
+		if err = reg.Pull(ctx, ref); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		if err = reg.Unpack(ctx, ref, workingDir); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		unpackedImageMap[ref] = workingDir
 	}
 
-	if err = reg.Unpack(ctx, ref, workingDir); err != nil {
-		return err
+	if len(errs) > 0 {
+		return utilerrors.NewAggregate(errs)
 	}
 
-	populator := registry.NewDirectoryPopulator(loader, graphLoader, querier, ref, workingDir)
+	populator := registry.NewDirectoryPopulator(loader, graphLoader, querier, unpackedImageMap)
 
 	return populator.Populate(mode)
 }

--- a/pkg/registry/graph.go
+++ b/pkg/registry/graph.go
@@ -37,3 +37,15 @@ func (p *Package) HasChannel(channel string) bool {
 	_, found := p.Channels[channel]
 	return found
 }
+
+func (p *Package) HasCsv(csv string) bool {
+	for _, channelGraph := range p.Channels {
+		for node := range channelGraph.Nodes {
+			if node.CsvName == csv {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/registry/imageinput.go
+++ b/pkg/registry/imageinput.go
@@ -1,0 +1,118 @@
+package registry
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/operator-framework/operator-registry/pkg/image"
+)
+
+type ImageInput struct {
+	manifestsDir     string
+	metadataDir      string
+	to               image.Reference
+	from             string
+	annotationsFile  *AnnotationsFile
+	dependenciesFile *DependenciesFile
+	bundle           *Bundle
+}
+
+func NewImageInput(to image.Reference, from string) (*ImageInput, error) {
+	path := from
+	manifests := filepath.Join(path, "manifests")
+	metadata := filepath.Join(path, "metadata")
+	// Get annotations file
+	log := logrus.WithFields(logrus.Fields{"dir": from, "file": metadata, "load": "annotations"})
+	files, err := ioutil.ReadDir(metadata)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read directory %s: %s", metadata, err)
+	}
+
+	// Look for the metadata and manifests sub-directories to find the annotations.yaml
+	// file that will inform how the manifests of the bundle should be loaded into the database.
+	// If dependencies.yaml which contains operator dependencies in metadata directory
+	// exists, parse and load it into the DB
+	annotationsFile := &AnnotationsFile{}
+	dependenciesFile := &DependenciesFile{}
+	for _, f := range files {
+		err = decodeFile(filepath.Join(metadata, f.Name()), annotationsFile)
+		if err != nil || *annotationsFile == (AnnotationsFile{}) {
+			log.Info("found annotations file searching for csv")
+			continue
+		}
+
+		err = parseDependenciesFile(filepath.Join(metadata, f.Name()), dependenciesFile)
+		if err != nil || len(dependenciesFile.Dependencies) < 1 {
+			continue
+		} else {
+			log.Info("found dependencies file searching for csv")
+		}
+	}
+
+	if *annotationsFile == (AnnotationsFile{}) {
+		return nil, fmt.Errorf("Could not find annotations.yaml file")
+	}
+
+	imageInput := &ImageInput{
+		manifestsDir:     manifests,
+		metadataDir:      metadata,
+		to:               to,
+		from:             from,
+		annotationsFile:  annotationsFile,
+		dependenciesFile: dependenciesFile,
+	}
+
+	err = imageInput.getBundleFromManifests()
+	if err != nil {
+		return nil, err
+	}
+
+	return imageInput, nil
+}
+
+func (i *ImageInput) getBundleFromManifests() error {
+	log := logrus.WithFields(logrus.Fields{"dir": i.from, "file": i.manifestsDir, "load": "bundle"})
+
+	csv, err := i.findCSV(i.manifestsDir)
+	if err != nil {
+		return err
+	}
+
+	if csv.Object == nil {
+		return fmt.Errorf("csv is empty: %s", err)
+	}
+
+	log.Info("found csv, loading bundle")
+
+	csvName := csv.GetName()
+
+	bundle, err := loadBundle(csvName, i.manifestsDir)
+	if err != nil {
+		return fmt.Errorf("error loading objs in directory: %s", err)
+	}
+
+	if bundle == nil || bundle.Size() == 0 {
+		return fmt.Errorf("no bundle objects found")
+	}
+
+	// set the bundleimage on the bundle
+	bundle.BundleImage = i.to.String()
+	// set the dependencies on the bundle
+	bundle.Dependencies = i.dependenciesFile.GetDependencies()
+
+	bundle.Name = csvName
+	bundle.Package = i.annotationsFile.Annotations.PackageName
+	bundle.Channels = strings.Split(i.annotationsFile.Annotations.Channels, ",")
+
+	if err := bundle.AllProvidedAPIsInBundle(); err != nil {
+		return fmt.Errorf("error checking provided apis in bundle %s: %s", bundle.Name, err)
+	}
+
+	i.bundle = bundle
+
+	return nil
+}

--- a/pkg/registry/populator.go
+++ b/pkg/registry/populator.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/operator-framework/operator-registry/pkg/image"
@@ -26,57 +27,36 @@ type DirectoryPopulator struct {
 	loader      Load
 	graphLoader GraphLoader
 	querier     Query
-	to          image.Reference
-	from        string
+	imageDirMap map[image.Reference]string
 }
 
-func NewDirectoryPopulator(loader Load, graphLoader GraphLoader, querier Query, to image.Reference, from string) *DirectoryPopulator {
+func NewDirectoryPopulator(loader Load, graphLoader GraphLoader, querier Query, imageDirMap map[image.Reference]string) *DirectoryPopulator {
 	return &DirectoryPopulator{
 		loader:      loader,
 		graphLoader: graphLoader,
 		querier:     querier,
-		to:          to,
-		from:        from,
+		imageDirMap: imageDirMap,
 	}
 }
 
 func (i *DirectoryPopulator) Populate(mode Mode) error {
-	path := i.from
-	manifests := filepath.Join(path, "manifests")
-	metadata := filepath.Join(path, "metadata")
-	// Get annotations file
-	log := logrus.WithFields(logrus.Fields{"dir": i.from, "file": metadata, "load": "annotations"})
-	files, err := ioutil.ReadDir(metadata)
-	if err != nil {
-		return fmt.Errorf("unable to read directory %s: %s", metadata, err)
-	}
-
-	// Look for the metadata and manifests sub-directories to find the annotations.yaml
-	// file that will inform how the manifests of the bundle should be loaded into the database.
-	// If dependencies.yaml which contains operator dependencies in metadata directory
-	// exists, parse and load it into the DB
-	annotationsFile := &AnnotationsFile{}
-	dependenciesFile := &DependenciesFile{}
-	for _, f := range files {
-		err = decodeFile(filepath.Join(metadata, f.Name()), annotationsFile)
-		if err != nil || *annotationsFile == (AnnotationsFile{}) {
-			log.Info("found annotations file searching for csv")
+	var errs []error
+	imagesToAdd := make([]*ImageInput, 0)
+	for to, from := range i.imageDirMap {
+		imageInput, err := NewImageInput(to, from)
+		if err != nil {
+			errs = append(errs, err)
 			continue
 		}
 
-		err = parseDependenciesFile(filepath.Join(metadata, f.Name()), dependenciesFile)
-		if err != nil || len(dependenciesFile.Dependencies) < 1 {
-			continue
-		} else {
-			log.Info("found dependencies file searching for csv")
-		}
+		imagesToAdd = append(imagesToAdd, imageInput)
 	}
 
-	if *annotationsFile == (AnnotationsFile{}) {
-		return fmt.Errorf("Could not find annotations.yaml file")
+	if len(errs) > 0 {
+		return utilerrors.NewAggregate(errs)
 	}
 
-	err = i.loadManifests(manifests, annotationsFile, dependenciesFile, mode)
+	err := i.loadManifests(imagesToAdd, mode)
 	if err != nil {
 		return err
 	}
@@ -84,66 +64,54 @@ func (i *DirectoryPopulator) Populate(mode Mode) error {
 	return nil
 }
 
-func (i *DirectoryPopulator) loadManifests(manifests string, annotationsFile *AnnotationsFile, dependenciesFile *DependenciesFile, mode Mode) error {
-	log := logrus.WithFields(logrus.Fields{"dir": i.from, "file": manifests, "load": "bundle"})
-
-	csv, err := i.findCSV(manifests)
-	if err != nil {
-		return err
-	}
-
-	if csv.Object == nil {
-		return fmt.Errorf("csv is empty: %s", err)
-	}
-
-	log.Info("found csv, loading bundle")
-
-	csvName := csv.GetName()
-
-	bundle, err := loadBundle(csvName, manifests)
-	if err != nil {
-		return fmt.Errorf("error loading objs in directory: %s", err)
-	}
-
-	if bundle == nil || bundle.Size() == 0 {
-		return fmt.Errorf("no bundle objects found")
-	}
-
-	// set the bundleimage on the bundle
-	bundle.BundleImage = i.to.String()
-	// set the dependencies on the bundle
-	bundle.Dependencies = dependenciesFile.GetDependencies()
-
-	bundle.Name = csvName
-	bundle.Package = annotationsFile.Annotations.PackageName
-	bundle.Channels = strings.Split(annotationsFile.Annotations.Channels, ",")
-
-	if err := bundle.AllProvidedAPIsInBundle(); err != nil {
-		return fmt.Errorf("error checking provided apis in bundle %s: %s", bundle.Name, err)
-	}
-
+func (i *DirectoryPopulator) loadManifests(imagesToAdd []*ImageInput, mode Mode) error {
 	switch mode {
 	case ReplacesMode:
-		err = i.loadManifestsReplaces(bundle, annotationsFile)
-		if err != nil {
-			return err
+		// TODO: This is relatively inefficient. Ideally, we should be able to use a replaces
+		// graph loader to construct what the graph would look like with a set of new bundles
+		// and use that to return an error if it's not valid, rather than insert one at a time
+		// and reinspect the database.
+		//
+		// Additionally, it would be preferrable if there was a single database transaction
+		// that took the updated graph as a whole as input, rather than inserting bundles of the
+		// same package linearly.
+		var err error
+		var validImagesToAdd []*ImageInput
+		for len(imagesToAdd) > 0 {
+			validImagesToAdd, imagesToAdd, err = i.getNextReplacesImagesToAdd(imagesToAdd)
+			if err != nil {
+				return err
+			}
+			for _, image := range validImagesToAdd {
+				err := i.loadManifestsReplaces(image.bundle, image.annotationsFile)
+				if err != nil {
+					return err
+				}
+			}
 		}
 	case SemVerMode:
-		err = i.loadManifestsSemver(bundle, annotationsFile, false)
-		if err != nil {
-			return err
+		for _, image := range imagesToAdd {
+			err := i.loadManifestsSemver(image.bundle, image.annotationsFile, false)
+			if err != nil {
+				return err
+			}
 		}
 	case SkipPatchMode:
-		err = i.loadManifestsSemver(bundle, annotationsFile, true)
+		for _, image := range imagesToAdd {
+			err := i.loadManifestsSemver(image.bundle, image.annotationsFile, true)
+			if err != nil {
+				return err
+			}
+		}
+	default:
+		err := fmt.Errorf("Unsupported update mode")
 		if err != nil {
 			return err
 		}
-	default:
-		err = fmt.Errorf("Unsupported update mode")
 	}
 
 	// Finally let's delete all the old bundles
-	if err = i.loader.ClearNonHeadBundles(); err != nil {
+	if err := i.loader.ClearNonHeadBundles(); err != nil {
 		return fmt.Errorf("Error deleting previous bundles: %s", err)
 	}
 
@@ -176,6 +144,69 @@ func (i *DirectoryPopulator) loadManifestsReplaces(bundle *Bundle, annotationsFi
 	}
 
 	return nil
+}
+
+func (i *DirectoryPopulator) getNextReplacesImagesToAdd(imagesToAdd []*ImageInput) ([]*ImageInput, []*ImageInput, error) {
+	remainingImages := make([]*ImageInput, 0)
+	foundImages := make([]*ImageInput, 0)
+
+	var errs []error
+
+	// Separate these image sets per package, since multiple different packages have
+	// separate graph
+	imagesPerPackage := make(map[string][]*ImageInput, 0)
+	for _, image := range imagesToAdd {
+		pkg := image.bundle.Package
+		if _, ok := imagesPerPackage[pkg]; !ok {
+			newPkgImages := make([]*ImageInput, 0)
+			newPkgImages = append(newPkgImages, image)
+			imagesPerPackage[pkg] = newPkgImages
+		} else {
+			imagesPerPackage[pkg] = append(imagesPerPackage[pkg], image)
+		}
+	}
+
+	for pkg, pkgImages := range imagesPerPackage {
+		// keep a tally of valid and invalid images to ensure at least one
+		// image per package is valid. If not, throw an error
+		pkgRemainingImages := 0
+		pkgFoundImages := 0
+
+		// first, try to pull the existing package graph from the database if it exists
+		graph, err := i.graphLoader.Generate(pkg)
+		if err != nil && !errors.Is(err, ErrPackageNotInDatabase) {
+			return nil, nil, err
+		}
+
+		var pkgErrs []error
+		// then check each image to see if it can be a replacement
+		replacesLoader := ReplacesGraphLoader{}
+		for _, pkgImage := range pkgImages {
+			canAdd, err := replacesLoader.CanAdd(pkgImage.bundle, graph)
+			if err != nil {
+				pkgErrs = append(pkgErrs, err)
+			}
+			if canAdd {
+				pkgFoundImages++
+				foundImages = append(foundImages, pkgImage)
+			} else {
+				pkgRemainingImages++
+				remainingImages = append(remainingImages, pkgImage)
+			}
+		}
+
+		// no new images can be added, the current iteration aggregates all the
+		// errors that describe invalid bundles
+		if pkgFoundImages == 0 && pkgRemainingImages > 0 {
+			errs = append(errs, utilerrors.NewAggregate(pkgErrs))
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, nil, utilerrors.NewAggregate(errs)
+	}
+
+	return foundImages, remainingImages, nil
 }
 
 func (i *DirectoryPopulator) loadManifestsSemver(bundle *Bundle, annotations *AnnotationsFile, skippatch bool) error {
@@ -246,7 +277,7 @@ func loadBundle(csvName string, dir string) (*Bundle, error) {
 }
 
 // findCSV looks through the bundle directory to find a csv
-func (i *DirectoryPopulator) findCSV(manifests string) (*unstructured.Unstructured, error) {
+func (i *ImageInput) findCSV(manifests string) (*unstructured.Unstructured, error) {
 	log := logrus.WithFields(logrus.Fields{"dir": i.from, "find": "csv"})
 
 	files, err := ioutil.ReadDir(manifests)

--- a/pkg/registry/replacesgraphloader.go
+++ b/pkg/registry/replacesgraphloader.go
@@ -1,0 +1,40 @@
+package registry
+
+import (
+	"fmt"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+type ReplacesGraphLoader struct {
+}
+
+// CanAdd checks that a new bundle can be added in replaces mode (i.e. the replaces
+// defined for the bundle already exists)
+func (r *ReplacesGraphLoader) CanAdd(bundle *Bundle, graph *Package) (bool, error) {
+	replaces, err := bundle.Replaces()
+	if err != nil {
+		return false, fmt.Errorf("Invalid content, unable to parse bundle")
+	}
+
+	csvName := bundle.Name
+
+	// adding the first bundle in the graph
+	if replaces == "" {
+		return true, nil
+	}
+
+	var errs []error
+
+	// check that the bundle can be added
+	if !graph.HasCsv(replaces) {
+		err := fmt.Errorf("Invalid bundle %s, bundle specifies a non-existent replacement %s", csvName, replaces)
+		errs = append(errs, err)
+	}
+
+	if len(errs) > 0 {
+		return false, utilerrors.NewAggregate(errs)
+	}
+
+	return true, nil
+}

--- a/pkg/sqlite/remove_test.go
+++ b/pkg/sqlite/remove_test.go
@@ -20,16 +20,20 @@ func TestRemover(t *testing.T) {
 
 	query := NewSQLLiteQuerierFromDb(db)
 
+	graphLoader, err := NewSQLGraphLoaderFromDB(db)
+	require.NoError(t, err)
+
 	populate := func(name string) error {
 		return registry.NewDirectoryPopulator(
 			store,
-			nil,
+			graphLoader,
 			query,
-			image.SimpleReference( "quay.io/test/" + name),
-			"../../bundles/"+name).Populate(registry.ReplacesMode)
+			map[image.Reference]string{
+				image.SimpleReference("quay.io/test/" + name): "../../bundles/" + name,
+			}).Populate(registry.ReplacesMode)
 	}
 	for _, name := range []string{"etcd.0.9.0", "etcd.0.9.2", "prometheus.0.14.0", "prometheus.0.15.0", "prometheus.0.22.2"} {
-		require.NoError(t,  populate(name))
+		require.NoError(t, populate(name))
 	}
 
 	// delete etcd
@@ -59,7 +63,7 @@ func TestRemover(t *testing.T) {
 
 	// and insert again
 	for _, name := range []string{"etcd.0.9.0", "etcd.0.9.2", "prometheus.0.14.0", "prometheus.0.15.0", "prometheus.0.22.2"} {
-		require.NoError(t,  populate(name))
+		require.NoError(t, populate(name))
 	}
 
 	// apis are back


### PR DESCRIPTION
`opm registry add` and `opm index add`, when presented with multiple
bundles, required that those bundles be in version order when inserting
in replaces mode. This requirement existed because bundles are inserted
into the database in order, and if one of these bundles replaces another
the db schema would reject the insert.

This commit updates the replaces mode insert logic to check the existing
package graph and attempt to insert bundles in order.

As a followup to this commit, once we define a method of inserting in
replaces mode based on a graph input, we should be able to reduce this
to a single db transaction by defining the graph as a set of the
existing db + new input bundles. This would also simplify error handling,
which would no longer need any database transactions.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
