### PR TITLE
Bug 1826766: fix(types): Fix GetDependencies func that returns duplicate items

### DIFF
--- a/bundles/prometheus.0.22.2/metadata/dependencies.yaml
+++ b/bundles/prometheus.0.22.2/metadata/dependencies.yaml
@@ -2,3 +2,7 @@ dependencies:
   - type: olm.package
     packageName: testoperator
     version: "> 0.2.0"
+  - type: olm.gvk
+    group: testprometheus.coreos.com
+    kind: testtestprometheus
+    version: v1

--- a/pkg/registry/populator_test.go
+++ b/pkg/registry/populator_test.go
@@ -428,6 +428,10 @@ func TestQuerierForDependencies(t *testing.T) {
 			Type:  "olm.gvk",
 			Value: `{"group":"etcd.database.coreos.com","kind":"EtcdCluster","type":"olm.gvk","version":"v1beta2"}`,
 		},
+		{
+			Type:  "olm.gvk",
+			Value: `{"group":"testprometheus.coreos.com","kind":"testtestprometheus","type":"olm.gvk","version":"v1"}`,
+		},
 	}
 
 	type operatorbundle struct {
@@ -483,6 +487,10 @@ func TestListBundles(t *testing.T) {
 		{
 			Type:  "olm.gvk",
 			Value: `{"group":"etcd.database.coreos.com","kind":"EtcdCluster","type":"olm.gvk","version":"v1beta2"}`,
+		},
+		{
+			Type:  "olm.gvk",
+			Value: `{"group":"testprometheus.coreos.com","kind":"testtestprometheus","type":"olm.gvk","version":"v1"}`,
 		},
 	}
 

--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -196,7 +196,8 @@ func (pd *PackageDependency) Validate() []error {
 func (d *DependenciesFile) GetDependencies() []*Dependency {
 	var dependencies []*Dependency
 	for _, item := range d.Dependencies {
-		dependencies = append(dependencies, &item)
+		dep := item
+		dependencies = append(dependencies, &dep)
 	}
 	return dependencies
 }


### PR DESCRIPTION
The iterator loop reuses item pointer which leads to duplicate of the
same dependencies while other dependencies are missing out.

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
