### PR TITLE
update the help info of the export subcommand

### DIFF
--- a/cmd/opm/index/export.go
+++ b/cmd/opm/index/export.go
@@ -14,7 +14,6 @@ var exportLong = templates.LongDesc(`
 
 	This command will take an index image (specified by the --index option), parse it for the given operator(s) (set by 
 	the --package option) and export the operator metadata into an appregistry compliant format (a package.yaml file). 
-	This command requires access to docker or podman to complete successfully.
 
 	Note: the appregistry format is being deprecated in favor of the new index image and image bundle format. 
 	`)


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Update the help info. Remove this sentence: `This command requires access to docker or podman to complete successfully.` And change the flag `-o` to `-p`. After this change, it looks like:
```console
mac:operator-registry jianzhang$ ./opm index export --help
Export an operator from an index image into the appregistry format.

 This command will take an index image (specified by the --index option), parse it for the given operator (set by the --package option) and export the operator metadata into an appregistry compliant format (a package.yaml file).

 Note: the appregistry format is being deprecated in favor of the new index image and image bundle format.

Usage:
  opm index export [flags]

Flags:
  -c, --container-tool string    tool to interact with container images (save, build, etc.). One of: [none, docker, podman] (default "none")
  -f, --download-folder string   directory where downloaded operator bundle(s) will be stored (default "downloaded")
  -h, --help                     help for export
  -i, --index string             index to get package from
  -p, --package string           the package to export
```

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
