### PR TITLE
Bug 1820438: Slim down upstream builder

### DIFF
--- a/upstream-opm-builder.Dockerfile
+++ b/upstream-opm-builder.Dockerfile
@@ -15,8 +15,4 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.2.1 && \
 
 FROM scratch
 COPY --from=builder /build/bin/opm /bin/opm
-COPY --from=builder /build/bin/initializer /bin/initializer
-COPY --from=builder /build/bin/appregistry-server /bin/appregistry-server
-COPY --from=builder /build/bin/configmap-server /bin/configmap-server
-COPY --from=builder /build/bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe


### PR DESCRIPTION
With the static build fix for index images committed (https://github.com/operator-framework/operator-registry/pull/173),
we introduced a side effect of index images including all the
build layers included in the build image. That bloated the index images
using the default from image by over 1gb in size.

To resolve this, this commit introduces two changes. First, it adds a
multistage build to the upstream builder to just copy the output of the
build into a scratch image rather than include all the layers from the
base alpine image. Second, it adds a new opm dockerfile with the same
format except that only the binaries needed to host index images are
included.

After this commit is merged, a release should be cut and the dockerfile
generator needs to be updated to point to a new opm builder as the
default from index

Partially resolves https://github.com/operator-framework/operator-registry/issues/218, though a followup is needed.