### PR TITLE
Bug 1827906: (fix) Use opm builder image for opm indexes

### DIFF
--- a/configmap-registry.Dockerfile
+++ b/configmap-registry.Dockerfile
@@ -2,8 +2,8 @@ FROM quay.io/operator-framework/upstream-registry-builder:latest as builder
 FROM busybox as userspace
 
 FROM scratch
-COPY --from=builder /build/bin/configmap-server /bin/configmap-server
-COPY --from=builder /build/bin/opm /bin/opm
+COPY --from=builder /bin/configmap-server /bin/configmap-server
+COPY --from=builder /bin/opm /bin/opm
 COPY --from=userspace /bin/cp /bin/cp
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051

--- a/docs/design/opm-tooling.md
+++ b/docs/design/opm-tooling.md
@@ -66,7 +66,7 @@ FROM quay.io/operator-framework/upstream-registry-builder AS builder
 FROM scratch
 LABEL operators.operatorframework.io.index.database.v1=./index.db
 COPY database ./
-COPY --from=builder /build/bin/opm /opm
+COPY --from=builder /bin/opm /opm
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/opm"]

--- a/opm-example.Dockerfile
+++ b/opm-example.Dockerfile
@@ -1,9 +1,9 @@
-FROM quay.io/operator-framework/upstream-registry-builder AS builder
+FROM quay.io/operator-framework/upstream-opm-builder AS builder
 
 FROM scratch
 LABEL operators.operatorframework.io.index.database.v1=./index.db
 COPY database ./
-COPY --from=builder /build/bin/opm /opm
+COPY --from=builder /bin/opm /opm
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
 ENTRYPOINT ["/opm"]

--- a/pkg/containertools/dockerfilegenerator.go
+++ b/pkg/containertools/dockerfilegenerator.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	defaultBinarySourceImage = "quay.io/operator-framework/upstream-registry-builder"
+	defaultBinarySourceImage = "quay.io/operator-framework/upstream-opm-builder"
 	DefaultDbLocation        = "/database/index.db"
 	DbLocationLabel          = "operators.operatorframework.io.index.database.v1"
 )

--- a/pkg/containertools/dockerfilegenerator_test.go
+++ b/pkg/containertools/dockerfilegenerator_test.go
@@ -39,7 +39,7 @@ func TestGenerateDockerfile_EmptyBaseImage(t *testing.T) {
 	defer controller.Finish()
 
 	databasePath := "database/index.db"
-	expectedDockerfile := `FROM quay.io/operator-framework/upstream-registry-builder
+	expectedDockerfile := `FROM quay.io/operator-framework/upstream-opm-builder
 LABEL operators.operatorframework.io.index.database.v1=/database/index.db
 ADD database/index.db /database/index.db
 EXPOSE 50051

--- a/upstream-builder.Dockerfile
+++ b/upstream-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine AS builder
+FROM golang:1.13-alpine
 
 RUN apk update && apk add sqlite build-base git mercurial bash
 WORKDIR /build
@@ -12,11 +12,8 @@ RUN make static
 RUN GRPC_HEALTH_PROBE_VERSION=v0.2.1 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-$(go env GOARCH) && \
     chmod +x /bin/grpc_health_probe
-
-FROM scratch
-COPY --from=builder /build/bin/opm /bin/opm
-COPY --from=builder /build/bin/initializer /bin/initializer
-COPY --from=builder /build/bin/appregistry-server /bin/appregistry-server
-COPY --from=builder /build/bin/configmap-server /bin/configmap-server
-COPY --from=builder /build/bin/registry-server /bin/registry-server
-COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
+RUN cp /build/bin/opm /bin/opm && \
+    cp /build/bin/initializer /bin/initializer && \
+    cp /build/bin/appregistry-server /bin/appregistry-server && \
+    cp /build/bin/configmap-server /bin/configmap-server && \
+    cp /build/bin/registry-server /bin/registry-server


### PR DESCRIPTION
Revert the upstream-builder changes since they break compatibility with
a number of workflows. Instead, just point the dockerfile generator to
new opm-builder image for upstream.

Additionally, update existing docs and dockerfile examples to point to
/bin instead of /build/bin for registry examples