### PR TITLE
fix(opm): refactor indexer

### DIFF
--- a/pkg/lib/bundle/exporter.go
+++ b/pkg/lib/bundle/exporter.go
@@ -2,8 +2,6 @@ package bundle
 
 import (
 	"context"
-	"github.com/operator-framework/operator-registry/pkg/image"
-	"github.com/operator-framework/operator-registry/pkg/image/execregistry"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -12,7 +10,9 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/operator-framework/operator-registry/pkg/containertools"
+	"github.com/operator-framework/operator-registry/pkg/image"
 	"github.com/operator-framework/operator-registry/pkg/image/containerdregistry"
+	"github.com/operator-framework/operator-registry/pkg/image/execregistry"
 )
 
 // BundleExporter exports the manifests of a bundle image into a directory
@@ -22,7 +22,7 @@ type BundleExporter struct {
 	containerTool containertools.ContainerTool
 }
 
-func NewSQLExporterForBundle(image, directory string, containerTool containertools.ContainerTool) *BundleExporter {
+func NewExporterForBundle(image, directory string, containerTool containertools.ContainerTool) *BundleExporter {
 	return &BundleExporter{
 		image:         image,
 		directory:     directory,


### PR DESCRIPTION


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
this refactors the indexer to make database extraction re-usable
across indexer actions

it also factors out a helper in the containerd registry to make future
use of manifests simpler

**Motivation for the change:**
This was originally done in response to comments on #283, but inadvertently didn't get pushed. 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
