### PR TITLE
Drive default index base image with CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
 GO := GOFLAGS="-mod=vendor" go
+PKG := github.com/operator-framework/operator-registry
 CMDS := $(addprefix bin/, $(shell ls ./cmd))
 SPECIFIC_UNIT_TEST := $(if $(TEST),-run $(TEST),)
 
 .PHONY: all
 all: clean test build
 
+GIT_COMMIT := $(shell git rev-parse --short HEAD)
+
+$(CMDS): version_flags=-ldflags "-X $(PKG)/pkg/version.GitCommit=$(GIT_COMMIT)"
 $(CMDS):
-	$(GO) build $(extra_flags) -o $@ ./cmd/$(notdir $@)
+	$(GO) build $(version_flags) $(extra_flags) -o $@ ./cmd/$(notdir $@)
 
 .PHONY: build
 build: clean $(CMDS)

--- a/docs/contributors/releases.md
+++ b/docs/contributors/releases.md
@@ -19,7 +19,8 @@ Builds are also triggered for the following docker images. The tags in Quay.io w
  - [quay.io/operator-framework/operator-registry-server](https://quay.io/repository/operator-framework/operator-registry-server)
  - [quay.io/operator-framework/configmap-operator-registry](https://quay.io/repository/operator-framework/configmap-operator-registry)
  - [quay.io/operator-framework/upstream-registry-builder](https://quay.io/repository/operator-framework/upstream-registry-builder?tab=tags)
- 
+ - [quay.io/operator-framework/upstream-opm-builder](https://quay.io/repository/operator-framework/upstream-opm-builder?tab=tags)
+
  Images are also built to track master with `latest` tags. It is recommended that you always pull by digest, and only use images that are tagged with a version.
  
  

--- a/pkg/containertools/dockerfilegenerator.go
+++ b/pkg/containertools/dockerfilegenerator.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/sirupsen/logrus"
+
+	"github.com/operator-framework/operator-registry/pkg/version"
 )
 
 const (
@@ -35,11 +37,16 @@ func NewDockerfileGenerator(logger *logrus.Entry) DockerfileGenerator {
 func (g *IndexDockerfileGenerator) GenerateIndexDockerfile(binarySourceImage, databasePath string) string {
 	var dockerfile string
 
-	if binarySourceImage == "" {
-		binarySourceImage = defaultBinarySourceImage
-	}
-
 	g.Logger.Info("Generating dockerfile")
+
+	if binarySourceImage == "" {
+		imageTag := "latest"
+		if version.GitCommit != "" {
+			imageTag = version.GitCommit
+		}
+
+		binarySourceImage = fmt.Sprintf("%s:%s", defaultBinarySourceImage, imageTag)
+	}
 
 	// From
 	dockerfile += fmt.Sprintf("FROM %s\n", binarySourceImage)

--- a/pkg/containertools/dockerfilegenerator_test.go
+++ b/pkg/containertools/dockerfilegenerator_test.go
@@ -39,7 +39,7 @@ func TestGenerateDockerfile_EmptyBaseImage(t *testing.T) {
 	defer controller.Finish()
 
 	databasePath := "database/index.db"
-	expectedDockerfile := `FROM quay.io/operator-framework/upstream-opm-builder
+	expectedDockerfile := `FROM quay.io/operator-framework/upstream-opm-builder:latest
 LABEL operators.operatorframework.io.index.database.v1=/database/index.db
 ADD database/index.db /database/index.db
 EXPOSE 50051

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,11 @@
+package version
+
+import "fmt"
+
+// GitCommit indicates which git commit the binary was built from
+var GitCommit string
+
+// String returns a pretty string concatenation of GitCommit
+func String() string {
+	return fmt.Sprintf("Registry latest git commit: %s\n", GitCommit)
+}

--- a/upstream-builder.Dockerfile
+++ b/upstream-builder.Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.13-alpine
 RUN apk update && apk add sqlite build-base git mercurial bash
 WORKDIR /build
 
+COPY .git .git
 COPY vendor vendor
 COPY cmd cmd
 COPY pkg pkg

--- a/upstream-opm-builder.Dockerfile
+++ b/upstream-opm-builder.Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.13-alpine AS builder
 RUN apk update && apk add sqlite build-base git mercurial bash
 WORKDIR /build
 
+COPY .git .git
 COPY vendor vendor
 COPY cmd cmd
 COPY pkg pkg


### PR DESCRIPTION
Now that the upstream opm builder is built and tagged on each commit,
introduce the short hash of the commit as a build parameter. This drives
the default base image that opm index commands use in order to tie
a built binary to a specific version of the image rathern than always
using the latest version