### PR TITLE
Bug 1827738: feat(opm): add version command

### DIFF
--- a/cmd/opm/main.go
+++ b/cmd/opm/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/operator-framework/operator-registry/cmd/opm/alpha"
 	"github.com/operator-framework/operator-registry/cmd/opm/index"
 	"github.com/operator-framework/operator-registry/cmd/opm/registry"
+	"github.com/operator-framework/operator-registry/cmd/opm/version"
 )
 
 func main() {
@@ -26,6 +27,7 @@ func main() {
 
 	rootCmd.AddCommand(registry.NewOpmRegistryCmd(), alpha.NewCmd())
 	index.AddCommand(rootCmd)
+	version.AddCommand(rootCmd)
 
 	rootCmd.Flags().Bool("debug", false, "enable debug logging")
 	if err := rootCmd.Flags().MarkHidden("debug"); err != nil {

--- a/cmd/opm/version/version.go
+++ b/cmd/opm/version/version.go
@@ -1,0 +1,56 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// opmVersion is the constant representing the version of the opm binary
+	opmVersion = "unknown"
+	// gitCommit is a constant representing the source version that
+	// generated this build. It should be set during build via -ldflags.
+	gitCommit string
+	// buildDate in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	buildDate string
+)
+
+type Version struct {
+	OpmVersion string `json:"opmVersion"`
+	GitCommit  string `json:"gitCommit"`
+	BuildDate  string `json:"buildDate"`
+	GoOs       string `json:"goOs"`
+	GoArch     string `json:"goArch"`
+}
+
+func getVersion() Version {
+	return Version{
+		OpmVersion: opmVersion,
+		GitCommit:  gitCommit,
+		BuildDate:  buildDate,
+		GoOs:       runtime.GOOS,
+		GoArch:     runtime.GOARCH,
+	}
+}
+
+func (v Version) Print() {
+	fmt.Printf("Version: %#v\n", v)
+}
+
+func AddCommand(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:     "version",
+		Short:   "Print the opm version",
+		Long:    `Print the opm version`,
+		Example: `kubebuilder version`,
+		Run:     runVersion,
+	}
+
+	parent.AddCommand(cmd)
+}
+
+func runVersion(_ *cobra.Command, _ []string) {
+	getVersion().Print()
+}


### PR DESCRIPTION
**Description of the change:**

Provide an `opm version` command that can be tied into the release
process.

**Motivation for the change:**

Fixes #305 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
