### PR TITLE
(enhancement) This commit adds a version command to the root parent c…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 GO := GOFLAGS="-mod=vendor" go
 CMDS := $(addprefix bin/, $(shell ls ./cmd))
 SPECIFIC_UNIT_TEST := $(if $(TEST),-run $(TEST),)
+REPO = github.com/operator-framework/operator-registry
+VERSION=$(shell git describe --tags --abbrev=0)
+COMMIT=$(shell git rev-parse HEAD)
 
 .PHONY: all
 all: clean test build
 
 $(CMDS):
-	$(GO) build $(extra_flags) -o $@ ./cmd/$(notdir $@)
+	$(GO) build $(extra_flags) -ldflags "-X ${REPO}/cmd/opm/version.version=${VERSION} -X ${REPO}/cmd/opm/version.commit=${COMMIT}" -o $@ ./cmd/$(notdir $@)
 
 .PHONY: build
 build: clean $(CMDS)

--- a/cmd/opm/main.go
+++ b/cmd/opm/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/operator-framework/operator-registry/cmd/opm/alpha"
 	"github.com/operator-framework/operator-registry/cmd/opm/index"
 	"github.com/operator-framework/operator-registry/cmd/opm/registry"
+	"github.com/operator-framework/operator-registry/cmd/opm/version"
 )
 
 func main() {
@@ -24,7 +25,7 @@ func main() {
 		},
 	}
 
-	rootCmd.AddCommand(registry.NewOpmRegistryCmd(), alpha.NewCmd())
+	rootCmd.AddCommand(registry.NewOpmRegistryCmd(), alpha.NewCmd(), version.NewVersionCommand())
 	index.AddCommand(rootCmd)
 
 	rootCmd.Flags().Bool("debug", false, "enable debug logging")

--- a/cmd/opm/version/version.go
+++ b/cmd/opm/version/version.go
@@ -1,0 +1,55 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+type opmVersionInfo struct {
+	Commit    string
+	FallBack  string 
+	GoVersion string
+	Version   string
+}
+
+const (
+	FALLBACK_VERSION string = "v1.12.2"
+)
+
+var (
+	version string
+	commit string
+
+	versionWrapper *opmVersionInfo = &opmVersionInfo{
+		Commit: commit,
+		FallBack : FALLBACK_VERSION,
+		Version: version, 
+		GoVersion: fmt.Sprintf("%s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH),
+	}
+)
+
+// AddVersionCommand adds the version command to the given parent command.
+func NewVersionCommand() *cobra.Command {
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Prints the version of opm",
+		Run: func(cmd *cobra.Command, args []string) {
+			c := versionWrapper.Commit
+			v := versionWrapper.Version
+			g := versionWrapper.GoVersion
+
+			if v == "" {
+				v = versionWrapper.FallBack
+			}
+
+			logger := logrus.WithFields(logrus.Fields{"Version": v, "commit": c, "GoVersion": g})
+
+			logger.Info("opm version")
+		},
+	}
+
+	return versionCmd
+}


### PR DESCRIPTION
…ommand in the opm CLI framework.  The version information is generated dynamically when the opm release is built using ldflags.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

This change implements an `$ opm version` command.  The structure for generating the version information is adapted from the operator-sdk repository versioning strategy.

Example Output:

```
$ opm version
INFO[0000] opm version                                   GoVersion="go1.14.2 darwin/amd64" Version=v1.9.0 commit=bf0c8f1590d21e54e97c1446b09fae72ade51280
```

**Motivation for the change:**

It would be nice if `opm` had a version command, so that I do not need to keep saving the binary releases as `opm-<version>`, and can use the version command instead.   

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->

Closes: https://github.com/operator-framework/operator-registry/issues/231
