### PR TITLE
Bug 1827992: Clarify log message to indicate that dependencies.yaml is optional.

### DIFF
--- a/pkg/lib/bundle/validate.go
+++ b/pkg/lib/bundle/validate.go
@@ -135,7 +135,7 @@ func (i imageValidator) ValidateBundleFormat(directory string) error {
 	}
 
 	if !dependenciesFound {
-		i.logger.Info("Could not find dependencies file")
+		i.logger.Info("Could not find optional dependencies file")
 	} else {
 		i.logger.Info("Found dependencies file")
 		errs := validateDependencies(dependenciesFile)

--- a/pkg/registry/imageinput.go
+++ b/pkg/registry/imageinput.go
@@ -61,7 +61,7 @@ func NewImageInput(to image.Reference, from string) (*ImageInput, error) {
 	}
 
 	if !dependenciesFound {
-		log.Info("Could not find dependencies file")
+		log.Info("Could not find optional dependencies file")
 	}
 
 	imageInput := &ImageInput{


### PR DESCRIPTION
Tweaked this message so that users do not become concerned that errors are being ignored.