### PR TITLE
Bug 1829994: Index generate dameonless

### DIFF
--- a/pkg/lib/indexer/indexer.go
+++ b/pkg/lib/indexer/indexer.go
@@ -42,7 +42,8 @@ type ImageIndexer struct {
 	RegistryAdder       registry.RegistryAdder
 	RegistryDeleter     registry.RegistryDeleter
 	RegistryPruner      registry.RegistryPruner
-	ContainerTool       containertools.ContainerTool
+	BuildTool           containertools.ContainerTool
+	PullTool            containertools.ContainerTool
 	Logger              *logrus.Entry
 }
 
@@ -99,7 +100,7 @@ func (i ImageIndexer) AddToIndex(request AddToIndexRequest) error {
 		Permissive:    request.Permissive,
 		Mode:          request.Mode,
 		SkipTLS:       request.SkipTLS,
-		ContainerTool: i.ContainerTool,
+		ContainerTool: i.PullTool,
 	}
 
 	// Add the bundles to the registry
@@ -292,13 +293,13 @@ func (i ImageIndexer) getDatabaseFile(workingDir, fromIndex string) (string, err
 
 	var reg image.Registry
 	var rerr error
-	switch i.ContainerTool {
+	switch i.PullTool {
 	case containertools.NoneTool:
 		reg, rerr = containerdregistry.NewRegistry(containerdregistry.WithLog(i.Logger))
 	case containertools.PodmanTool:
 		fallthrough
 	case containertools.DockerTool:
-		reg, rerr = execregistry.NewRegistry(i.ContainerTool, i.Logger)
+		reg, rerr = execregistry.NewRegistry(i.PullTool, i.Logger)
 	}
 	if rerr != nil {
 		return "", rerr

--- a/pkg/lib/indexer/indexer.go
+++ b/pkg/lib/indexer/indexer.go
@@ -71,7 +71,7 @@ func (i ImageIndexer) AddToIndex(request AddToIndexRequest) error {
 	// this is in its own function context so that the deferred cleanup runs before we do a docker build
 	// which prevents the full contents of the previous image from being in the build context
 	var databasePath string
-	if err := func () error {
+	if err := func() error {
 		tmpDir, err := ioutil.TempDir("./", tmpDirPrefix)
 		if err != nil {
 
@@ -152,7 +152,7 @@ func (i ImageIndexer) DeleteFromIndex(request DeleteFromIndexRequest) error {
 	// this is in its own function context so that the deferred cleanup runs before we do a docker build
 	// which prevents the full contents of the previous image from being in the build context
 	var databasePath string
-	if err := func () error {
+	if err := func() error {
 		tmpDir, err := ioutil.TempDir("./", tmpDirPrefix)
 		if err != nil {
 
@@ -228,7 +228,7 @@ func (i ImageIndexer) PruneFromIndex(request PruneFromIndexRequest) error {
 	// this is in its own function context so that the deferred cleanup runs before we do a docker build
 	// which prevents the full contents of the previous image from being in the build context
 	var databasePath string
-	if err := func () error {
+	if err := func() error {
 		tmpDir, err := ioutil.TempDir("./", tmpDirPrefix)
 		if err != nil {
 
@@ -339,7 +339,7 @@ func copyDatabaseTo(databaseFile, targetDir string) (string, error) {
 		if err := os.MkdirAll(targetDir, 0777); err != nil {
 			return "", err
 		}
-	} else {
+	} else if err != nil {
 		return "", err
 	}
 
@@ -353,7 +353,7 @@ func copyDatabaseTo(databaseFile, targetDir string) (string, error) {
 	dbFile := path.Join(targetDir, defaultDatabaseFile)
 
 	// define the path to copy to the database/index.db file
-	to, err := os.OpenFile(dbFile, os.O_RDWR|os.O_CREATE, 0666)
+	to, err := os.OpenFile(dbFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/lib/indexer/interfaces.go
+++ b/pkg/lib/indexer/interfaces.go
@@ -15,14 +15,15 @@ type IndexAdder interface {
 }
 
 // NewIndexAdder is a constructor that returns an IndexAdder
-func NewIndexAdder(containerTool containertools.ContainerTool, logger *logrus.Entry) IndexAdder {
+func NewIndexAdder(buildTool, pullTool containertools.ContainerTool, logger *logrus.Entry) IndexAdder {
 	return ImageIndexer{
 		DockerfileGenerator: containertools.NewDockerfileGenerator(logger),
-		CommandRunner:       containertools.NewCommandRunner(containerTool, logger),
-		LabelReader:         containertools.NewLabelReader(containerTool, logger),
+		CommandRunner:       containertools.NewCommandRunner(buildTool, logger),
+		LabelReader:         containertools.NewLabelReader(pullTool, logger),
 		RegistryAdder:       registry.NewRegistryAdder(logger),
-		ImageReader:         containertools.NewImageReader(containerTool, logger),
-		ContainerTool:       containerTool,
+		ImageReader:         containertools.NewImageReader(pullTool, logger),
+		BuildTool:           buildTool,
+		PullTool:            pullTool,
 		Logger:              logger,
 	}
 }
@@ -42,7 +43,8 @@ func NewIndexDeleter(containerTool containertools.ContainerTool, logger *logrus.
 		LabelReader:         containertools.NewLabelReader(containerTool, logger),
 		RegistryDeleter:     registry.NewRegistryDeleter(logger),
 		ImageReader:         containertools.NewImageReader(containerTool, logger),
-		ContainerTool:       containerTool,
+		BuildTool:           containerTool,
+		PullTool:            containerTool,
 		Logger:              logger,
 	}
 }
@@ -59,7 +61,8 @@ func NewIndexExporter(containerTool containertools.ContainerTool, logger *logrus
 		CommandRunner:       containertools.NewCommandRunner(containerTool, logger),
 		LabelReader:         containertools.NewLabelReader(containerTool, logger),
 		ImageReader:         containertools.NewImageReader(containerTool, logger),
-		ContainerTool:       containerTool,
+		BuildTool:           containerTool,
+		PullTool:            containerTool,
 		Logger:              logger,
 	}
 }
@@ -76,7 +79,8 @@ func NewIndexPruner(containerTool containertools.ContainerTool, logger *logrus.E
 		LabelReader:         containertools.NewLabelReader(containerTool, logger),
 		RegistryPruner:      registry.NewRegistryPruner(logger),
 		ImageReader:         containertools.NewImageReader(containerTool, logger),
-		ContainerTool:       containerTool,
+		BuildTool:           containerTool,
+		PullTool:            containerTool,
 		Logger:              logger,
 	}
 }

--- a/test/e2e/opm_test.go
+++ b/test/e2e/opm_test.go
@@ -89,7 +89,7 @@ func buildIndexWith(containerTool string) error {
 		bundleImage + ":" + bundleTag2,
 	}
 	logger := logrus.WithFields(logrus.Fields{"bundles": bundles})
-	indexAdder := indexer.NewIndexAdder(containertools.NewContainerTool(containerTool, containertools.NoneTool), logger)
+	indexAdder := indexer.NewIndexAdder(containertools.NewContainerTool(containerTool, containertools.NoneTool), containertools.NewContainerTool(containerTool, containertools.NoneTool), logger)
 
 	request := indexer.AddToIndexRequest{
 		Generate:          false,
@@ -109,7 +109,7 @@ func buildFromIndexWith(containerTool string) error {
 		bundleImage + ":" + bundleTag3,
 	}
 	logger := logrus.WithFields(logrus.Fields{"bundles": bundles})
-	indexAdder := indexer.NewIndexAdder(containertools.NewContainerTool(containerTool, containertools.NoneTool), logger)
+	indexAdder := indexer.NewIndexAdder(containertools.NewContainerTool(containerTool, containertools.NoneTool), containertools.NewContainerTool(containerTool, containertools.NoneTool), logger)
 
 	request := indexer.AddToIndexRequest{
 		Generate:          false,


### PR DESCRIPTION
Enable daemonless index add when `--generate` is specified.

This also fixes a bug where, on multiple runs with --generate specified, the database would fail to build.

Doing this with a partial implementation to unblock podman users to be able to generate the database without shelling out to podman and hitting this bug https://github.com/containers/libpod/issues/5234. In the future, this implementation should be fleshed out so that all of the registry and index commands make this distinction between pull and build runners.