### PR TITLE
fix(containerd): use the defined request scopes 

### DIFF
--- a/vendor/github.com/containerd/containerd/remotes/docker/authorizer.go
+++ b/vendor/github.com/containerd/containerd/remotes/docker/authorizer.go
@@ -197,7 +197,12 @@ func (a *dockerAuthorizer) generateTokenOptions(ctx context.Context, host string
 
 	scope, ok := c.parameters["scope"]
 	if !ok {
-		return tokenOptions{}, errors.Errorf("no scope specified for token auth challenge")
+		if v := ctx.Value(tokenScopesKey{}); v != nil {
+			scopes := v.([]string)
+			to.scopes = append(to.scopes, scopes...)
+		} else {
+			return tokenOptions{}, errors.Errorf("no scope specified for token auth challenge")
+		}
 	}
 	to.scopes = append(to.scopes, scope)
 


### PR DESCRIPTION


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
use the defined request scopes if the server doesn't respond with a scope

this works around a bug when talking to quay through an nginx proxy

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
