### PR TITLE
Bug 1835887: upstream-opm-builder.Dockerfile: add ca-certificates

### DIFF
--- a/upstream-opm-builder.Dockerfile
+++ b/upstream-opm-builder.Dockerfile
@@ -14,6 +14,6 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.2.1 && \
     chmod +x /bin/grpc_health_probe
 
 FROM alpine
-RUN apk update && apk add bash ca-certificates
+RUN apk update && apk add ca-certificates
 COPY --from=builder /build/bin/opm /bin/opm
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/upstream-opm-builder.Dockerfile
+++ b/upstream-opm-builder.Dockerfile
@@ -13,6 +13,7 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.2.1 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-$(go env GOARCH) && \
     chmod +x /bin/grpc_health_probe
 
-FROM scratch
+FROM alpine
+RUN apk update && apk add bash ca-certificates
 COPY --from=builder /build/bin/opm /bin/opm
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe


### PR DESCRIPTION
**Description of the change:**
This changes the `upstream-opm-builder` runtime base image from `scratch` to `alpine` and installs `ca-certificates`.

This increases the `upstream-opm-builder` on-disk base image size from 56.8 MB to 64.6 MB. This seems better than using `upstream-registry-builder` which is 1.24 GB.

**Motivation for the change:**
This is essential to make the simple UX for `operator run bundle` work. This is necessary for two reasons.

**Use case 1: `operator-sdk run bundle --bundle-image=my-bundle-image`**

1. When a user runs this command, we will create a pod with `upstream-opm-builder` as the image and override the pod entrypoint to inject the provided bundle image into a new registry database on the fly, and then serve the database.

**Use case 2: `operator-sdk run bundle --bundle=my-bundle-image --index=my-existing-index`**

2. When a user uses `opm` to create an index, it needs to have bash and ca-certificates in the final image. In this mode, instead of using `upstream-opm-builder`, we would use the provided index image.

**Initial assumptions for MVP**:
* The database location is `/database/index.db`. In a future update, we would query the index image label to find the database location.

**Demo**
I built an updated `upstream-opm-builder` with this change (`quay.io/joelanford/upstream-opm-builder:latest`), and created a simple Helm chart that demonstrates a simple set of resources that the operator-sdk could create to exercise this concept.

Helm chart repo: https://github.com/joelanford/bundle-runner
Custom pod with `upstream-opm-builder`: https://github.com/joelanford/bundle-runner/blob/master/templates/registry.yaml

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

@jmrodri is currently working on the full design proposal for `operator-sdk run bundle` and will follow up with a link to that PR when it is posted.
