### PR TITLE
Bug 1827612: fix(server): make a copy of the db before migrating it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 WORKDIR /src
 
+COPY OPM_VERSION OPM_VERSION
 COPY vendor vendor
 COPY cmd cmd
 COPY pkg pkg

--- a/cmd/registry-server/main.go
+++ b/cmd/registry-server/main.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net"
+	"os"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -15,6 +16,7 @@ import (
 	health "github.com/operator-framework/operator-registry/pkg/api/grpc_health_v1"
 	"github.com/operator-framework/operator-registry/pkg/lib/dns"
 	"github.com/operator-framework/operator-registry/pkg/lib/log"
+	"github.com/operator-framework/operator-registry/pkg/lib/tmp"
 	"github.com/operator-framework/operator-registry/pkg/server"
 	"github.com/operator-framework/operator-registry/pkg/sqlite"
 )
@@ -76,7 +78,14 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 
 	logger := logrus.WithFields(logrus.Fields{"database": dbName, "port": port})
 
-	db, err := sql.Open("sqlite3", dbName)
+	// make a writable copy of the db for migrations
+	tmpdb, err := tmp.CopyTmpDB(dbName)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmpdb)
+
+	db, err := sql.Open("sqlite3", tmpdb)
 	if err != nil {
 		return err
 	}
@@ -133,3 +142,4 @@ func migrate(cmd *cobra.Command, db *sql.DB) error {
 
 	return migrator.Migrate(context.TODO())
 }
+

--- a/pkg/lib/tmp/copy.go
+++ b/pkg/lib/tmp/copy.go
@@ -1,0 +1,54 @@
+package tmp
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+// CopyTmpDB reads the file at the given path and copies it to a tmp directory, returning the copied file path or an err
+func CopyTmpDB(original string) (path string, err error) {
+	dst, err := ioutil.TempFile("", "db-")
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if cerr := dst.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+
+	src, err := OpenRegularFile(original)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if cerr := src.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+
+	_, err = io.Copy(dst, src)
+	if err != nil {
+		return "", err
+	}
+
+	return dst.Name(), nil
+}
+
+// OpenRegularFile opens the file at path and returns an error if it is not regular, does not exist, or cannot be opened
+func OpenRegularFile(path string) (*os.File, error) {
+	fd, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	fi, err := fd.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !fi.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s is not a regular file", path)
+	}
+	return fd, nil
+}


### PR DESCRIPTION

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
`opm registry server` and `registry-server` now make a copy of the db before migrating it

Note that this is currently implemented twice (once for each binary) to ease backports. I expect we will deprecate registry-server in favor of `opm registry serve` at some point, and the duplication will be removed.

**Motivation for the change:**
if the server is run when it has read-only access to a database, it will
fail to migrate. this commit will cause the server to always copy the
database on start, so that it is always rw and can be migrated.

**Testing Notes**
We currently lack e2e testing that runs against the built binaries. I tested this by building the `Dockerfile` with this change (which has a non-root user), using that as a base image for a registry image, and running the image. 

Running it doesn't have the "migration error log"
```bash
$ docker run a7b0b3543fa4
time="2020-05-20T17:38:38Z" level=warning msg="unable to set termination log path" error="open /dev/termination-log: permission denied"
time="2020-05-20T17:38:38Z" level=info msg="serving registry" database=/bundles.db port=50051
```

and to confirm, I checked that the tmpdb file was created with the correct permissions:

```bash
$ docker exec -ti 19db7d0d829f /bin/bash
bash-4.2$ ls -al /tmp/db682566081
-rw------- 1 1001 root 118784 May 20 17:38 db682566081
```
Note that the file is owner `rw` with 1001, the userid set by the dockerfile.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
