### PR TITLE
Bug 1838756: fix(validation): Fix CRD v1beta int-float conversion error

### DIFF
--- a/pkg/lib/bundle/testdata/validate/valid_bundle/manifests/etcdclusters.etcd.database.coreos.com.crd.yaml
+++ b/pkg/lib/bundle/testdata/validate/valid_bundle/manifests/etcdclusters.etcd.database.coreos.com.crd.yaml
@@ -14,3 +14,13 @@ spec:
     singular: etcdcluster
   scope: Namespaced
   version: v1beta2
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            test:
+              type: integer
+              minimum: 1
+              maximum: 32767

--- a/pkg/lib/bundle/validate.go
+++ b/pkg/lib/bundle/validate.go
@@ -313,10 +313,11 @@ func (i imageValidator) ValidateBundleContent(manifestDir string) error {
 				}
 			}
 		} else if gvk.Kind == CRDKind {
+			dec := k8syaml.NewYAMLOrJSONDecoder(strings.NewReader(string(data)), 30)
 			switch gv := gvk.GroupVersion().String(); gv {
 			case v1CRDapiVersion:
 				crd := &apiextensionsv1.CustomResourceDefinition{}
-				err := runtime.DefaultUnstructuredConverter.FromUnstructured(k8sFile.Object, crd)
+				err := dec.Decode(crd)
 				if err != nil {
 					validationErrors = append(validationErrors, err)
 					continue
@@ -330,7 +331,7 @@ func (i imageValidator) ValidateBundleContent(manifestDir string) error {
 				}
 			case v1beta1CRDapiVersion:
 				crd := &apiextensionsv1beta1.CustomResourceDefinition{}
-				err := runtime.DefaultUnstructuredConverter.FromUnstructured(k8sFile.Object, crd)
+				err := dec.Decode(crd)
 				if err != nil {
 					validationErrors = append(validationErrors, err)
 					continue


### PR DESCRIPTION
During bundle content validation, manifest files are converted to
`unstructured` type and then convert back to CRD type which causes
conversion error between int to float. Shouldn't use `unstructured`
type as an intermediate type.

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
