### PR TITLE
docs: remove typo from operator-bundle dependencies example

### DIFF
--- a/docs/design/operator-bundle.md
+++ b/docs/design/operator-bundle.md
@@ -76,7 +76,7 @@ An example of a `dependencies.yaml` that specifies Prometheus operator and etcd 
 ```
 dependencies:
   - type: olm.package
-    packgeName: prometheus
+    packageName: prometheus
     version: >0.27.0
   - type: olm.gvk
     group: etcd.database.coreos.com


### PR DESCRIPTION
**Description of the change:**
Remove typo from Operator Bundle documentation

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [X] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

