### PR TITLE
docs: add OPM_VERSION notes to release docs

### DIFF
--- a/docs/contributors/releases.md
+++ b/docs/contributors/releases.md
@@ -4,9 +4,16 @@
 
 Releases of opm are built by travis, see the [travis.yml](../../.travis.yml) for details.
 
+opm follows semantic versioning, with the latest version in the OPM_VERSION file at the top-level of the operator-registry repository. 
+
+
 ## Triggering a release
 
+
 Releases are triggered via tags. Make a new release by tagging a commit with an appropriate semver tag.
+
+Be sure to set the version in the OPM_VERSION file to reflect the new semver tag of opm before cutting the release. This ensures users 
+can accurately check which version of opm they are using via the `opm version` command. 
 
 ## Checking the build
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Add opm versioning information to the release docs. `opm version` was recently added to opm and it's important to keep it up to date so users can know which version of opm they are using. 

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
