### PR TITLE
pkg/lib/bundle/generate.go: do not compare number of annotations

### DIFF
--- a/pkg/lib/bundle/generate_test.go
+++ b/pkg/lib/bundle/generate_test.go
@@ -117,7 +117,7 @@ func TestValidateAnnotations(t *testing.T) {
 					"test1": "stable",
 					"test2": "stable,beta",
 				}),
-			fmt.Errorf("Unmatched number of fields. Expected (2) vs existing (3)"),
+			nil,
 		},
 		{
 			buildTestAnnotations("annotations",


### PR DESCRIPTION
**Description of the change:**
* pkg/lib/bundle/generate.go: `ValidateAnnotations` does not compare number of annotations in existing vs expected

**Motivation for the change:** `ValidateAnnotations` should not error when arbitrary annotations exist in `annotations.yaml`.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


/cc @ecordell @kevinrizza @dinhxuanvu 
