### PR TITLE
Use /. as the directory root to copy from.

### DIFF
--- a/pkg/image/execregistry/registry.go
+++ b/pkg/image/execregistry/registry.go
@@ -41,7 +41,7 @@ func (r *Registry) Pull(ctx context.Context, ref image.Reference) error {
 // Unpack writes the unpackaged content of an image to a directory.
 // If the referenced image does not exist in the registry, an error is returned.
 func (r *Registry) Unpack(ctx context.Context, ref image.Reference, dir string) error {
-	return r.cmd.Unpack(ref.String(), "/", dir)
+	return r.cmd.Unpack(ref.String(), "/.", dir)
 }
 
 // Labels gets the labels for an image reference.


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Use `<container>:/.` instead of `<container>:/` to copy out of bundles.

**Motivation for the change:**

A bug in podman makes `cp <container>:/ <existing dir>` create an additional dir and then opm fails:

```
[2020-06-13T11:05:56.384Z] time="2020-06-13T11:05:56Z" level=error msg="permissive mode disabled" bundles="[docker.io/ibmcom/ibm-cp-integration-bundle@sha256:2c29f6f774c18c0ac5be178aa1e0a73833ba42bfe7583b9095bb4bcd9890060b]" error="error loading bundle from image: unable to read directory bundle_tmp682869925/metadata: open bundle_tmp682869925/metadata: no such file or directory"
```

Podman bug is here: https://github.com/containers/libpod/issues/6596

Although I consider it a bug in podman (behaviour differs from docker), the docker documentation actually says that by ending the `SRC_PATH` in `.` we get the contents of the directory, which is actually what we want:
https://docs.docker.com/engine/reference/commandline/cp/

As such, I think this change introduces more correct behaviour.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
