### PR TITLE
Don't add empty related image references to index.

### DIFF
--- a/pkg/sqlite/db_options.go
+++ b/pkg/sqlite/db_options.go
@@ -2,11 +2,14 @@ package sqlite
 
 import (
 	"database/sql"
+
+	"github.com/sirupsen/logrus"
 )
 
 type DbOptions struct {
 	// MigratorBuilder is a function that returns a migrator instance
 	MigratorBuilder func(*sql.DB) (Migrator, error)
+	logger          logrus.FieldLogger
 }
 
 type DbOption func(*DbOptions)
@@ -14,11 +17,18 @@ type DbOption func(*DbOptions)
 func defaultDBOptions() *DbOptions {
 	return &DbOptions{
 		MigratorBuilder: NewSQLLiteMigrator,
+		logger:          logrus.New(),
 	}
 }
 
 func WithMigratorBuilder(m func(loader *sql.DB) (Migrator, error)) DbOption {
 	return func(o *DbOptions) {
 		o.MigratorBuilder = m
+	}
+}
+
+func WithLogger(logger logrus.FieldLogger) DbOption {
+	return func(o *DbOptions) {
+		o.logger = logger
 	}
 }

--- a/pkg/sqlite/load_test.go
+++ b/pkg/sqlite/load_test.go
@@ -154,6 +154,30 @@ func TestAddPackageChannels(t *testing.T) {
 	}
 }
 
+func TestAddOperatorBundleIgnoresEmptyImageReferences(t *testing.T) {
+	require := require.New(t)
+
+	db, cleanup := CreateTestDb(t)
+	defer cleanup()
+
+	store, err := NewSQLLiteLoader(db)
+	require.NoError(err)
+
+	err = store.Migrate(context.TODO())
+	require.NoError(err)
+
+	b := newBundle(t, "test-bundle", "test-package", nil, newUnstructuredCSV(t, "test-bundle", ""))
+	b.BundleImage = ""
+
+	err = store.AddOperatorBundle(b)
+	require.NoError(err)
+
+	querier := NewSQLLiteQuerierFromDb(db)
+	images, err := querier.GetImagesForBundle(context.TODO(), "test-bundle")
+	require.NoError(err)
+	require.Empty(images)
+}
+
 func TestClearNonHeadBundles(t *testing.T) {
 	db, cleanup := CreateTestDb(t)
 	defer cleanup()

--- a/pkg/sqlite/migrations/009_nonempty_related_image.go
+++ b/pkg/sqlite/migrations/009_nonempty_related_image.go
@@ -1,0 +1,46 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+)
+
+const (
+	NonemptyRelatedImageMigrationKey   = 9
+	NonemptyRelatedImageConstraintName = "nonempty_related_image"
+)
+
+func init() {
+	registerMigration(NonemptyRelatedImageMigrationKey, nonemptyRelatedImageMigration)
+}
+
+var nonemptyRelatedImageMigration = &Migration{
+	Id: NonemptyRelatedImageMigrationKey,
+	Up: func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+ALTER TABLE related_image RENAME TO related_image_migrating;
+CREATE TABLE related_image (
+  image TEXT,
+  operatorbundle_name TEXT,
+  FOREIGN KEY(operatorbundle_name) REFERENCES operatorbundle(name) ON DELETE CASCADE,
+  CONSTRAINT `+NonemptyRelatedImageConstraintName+` CHECK (length(image))
+);
+INSERT INTO related_image
+  SELECT * FROM related_image_migrating
+  WHERE length(image) > 0;
+DROP TABLE related_image_migrating;`)
+		return err
+	},
+	Down: func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+ALTER TABLE related_image RENAME TO related_image_migrating;
+CREATE TABLE related_image (
+  image TEXT,
+  operatorbundle_name TEXT,
+  FOREIGN KEY(operatorbundle_name) REFERENCES operatorbundle(name) ON DELETE CASCADE
+);
+INSERT INTO related_image SELECT * FROM related_image_migrating;
+DROP TABLE related_image_migrating;`)
+		return err
+	},
+}

--- a/pkg/sqlite/migrations/009_nonempty_related_image_test.go
+++ b/pkg/sqlite/migrations/009_nonempty_related_image_test.go
@@ -1,0 +1,86 @@
+package migrations_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/operator-framework/operator-registry/pkg/sqlite/migrations"
+)
+
+func TestNonemptyRelatedImageMigrationUp(t *testing.T) {
+	require := require.New(t)
+
+	db, migrator, cleanup := CreateTestDbAt(t, migrations.NonemptyRelatedImageMigrationKey-1)
+	defer cleanup()
+
+	_, err := db.Exec(`INSERT INTO operatorbundle(name) VALUES(?)`, "test")
+	require.NoError(err)
+
+	for _, image := range []string{"one", "", "three"} {
+		_, err := db.Exec(`INSERT INTO related_image(image, operatorbundle_name) VALUES(?,"test")`, image)
+		require.NoError(err)
+	}
+
+	err = migrator.Up(context.TODO(), migrations.Only(migrations.NonemptyRelatedImageMigrationKey))
+	require.NoError(err)
+
+	rows, err := db.Query(`SELECT image, operatorbundle_name FROM related_image`)
+	require.NoError(err)
+
+	var images []string
+	for rows.Next() {
+		var image, bundle string
+		require.NoError(rows.Scan(&image, &bundle))
+		require.Equal("test", bundle)
+		images = append(images, image)
+	}
+
+	require.ElementsMatch([]string{"one", "three"}, images)
+}
+
+func TestNonemptyRelatedImageMigrationImageConstraint(t *testing.T) {
+	require := require.New(t)
+
+	db, _, cleanup := CreateTestDbAt(t, migrations.NonemptyRelatedImageMigrationKey)
+	defer cleanup()
+
+	_, err := db.Exec(`INSERT INTO operatorbundle(name) VALUES(?)`, "test")
+	require.NoError(err)
+
+	_, err = db.Exec(`INSERT INTO related_image(image, operatorbundle_name) VALUES("","test")`)
+	require.Error(err)
+	require.Contains(err.Error(), migrations.NonemptyRelatedImageConstraintName)
+}
+
+func TestNonemptyRelatedImageMigrationDown(t *testing.T) {
+	require := require.New(t)
+
+	db, migrator, cleanup := CreateTestDbAt(t, migrations.NonemptyRelatedImageMigrationKey)
+	defer cleanup()
+
+	_, err := db.Exec(`INSERT INTO operatorbundle(name) VALUES(?)`, "test")
+	require.NoError(err)
+
+	for _, image := range []string{"one", "two", "three"} {
+		_, err := db.Exec(`INSERT INTO related_image(image, operatorbundle_name) VALUES(?,"test")`, image)
+		require.NoError(err)
+	}
+
+	err = migrator.Down(context.TODO(), migrations.Only(migrations.NonemptyRelatedImageMigrationKey))
+	require.NoError(err)
+
+	rows, err := db.Query(`SELECT image, operatorbundle_name FROM related_image`)
+	require.NoError(err)
+
+	var images []string
+	for rows.Next() {
+		var image, bundle string
+		require.NoError(rows.Scan(&image, &bundle))
+		require.Equal("test", bundle)
+		images = append(images, image)
+	}
+
+	require.ElementsMatch([]string{"one", "two", "three"}, images)
+}


### PR DESCRIPTION
There have been a several instances of CSVs accidentally specifying the empty string in a `relatedImages` entry, which can be confusing to index readers down the line. This change omits the empty image references at index-add time.

Bundle validation to help authors detect this condition is also valuable, but not part of this change.
