### PR TITLE
fix: registry rm orphaned bundles

### DIFF
--- a/pkg/sqlite/load.go
+++ b/pkg/sqlite/load.go
@@ -67,7 +67,7 @@ func (s *sqlLoader) AddOperatorBundle(bundle *registry.Bundle) error {
 }
 
 func (s *sqlLoader) addOperatorBundle(tx *sql.Tx, bundle *registry.Bundle) error {
-	addBundle, err := tx.Prepare("insert into operatorbundle(name, csv, bundle, bundlepath, version, skiprange, replaces, skips) values(?, ?, ?, ?, ?, ?, ?, ?)")
+	addBundle, err := tx.Prepare("insert into operatorbundle(name, csv, bundle, bundlepath, version, skiprange, replaces, skips, package_name) values(?, ?, ?, ?, ?, ?, ?, ?, ?)")
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func (s *sqlLoader) addOperatorBundle(tx *sql.Tx, bundle *registry.Bundle) error
 		return err
 	}
 
-	if _, err := addBundle.Exec(csvName, csvBytes, bundleBytes, bundleImage, version, skiprange, replaces, strings.Join(skips, ",")); err != nil {
+	if _, err := addBundle.Exec(csvName, csvBytes, bundleBytes, bundleImage, version, skiprange, replaces, strings.Join(skips, ","), bundle.Package); err != nil {
 		return err
 	}
 
@@ -558,9 +558,9 @@ func (s *sqlLoader) addAPIs(tx *sql.Tx, bundle *registry.Bundle) error {
 
 func (s *sqlLoader) getCSVNames(tx *sql.Tx, packageName string) ([]string, error) {
 	getID, err := tx.Prepare(`
-	  SELECT DISTINCT channel_entry.operatorbundle_name
-	  FROM channel_entry
-	  WHERE channel_entry.package_name=?`)
+	  SELECT name
+	  FROM operatorbundle
+	  WHERE package_name=?`)
 
 	if err != nil {
 		return nil, err

--- a/pkg/sqlite/migrations/009_bundle_package.go
+++ b/pkg/sqlite/migrations/009_bundle_package.go
@@ -1,0 +1,99 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+)
+
+const BundlePackageMigrationKey = 9
+
+// Register this migration
+func init() {
+	registerMigration(BundlePackageMigrationKey, bundlePackageMigration)
+}
+
+var bundlePackageMigration = &Migration{
+	Id: BundlePackageMigrationKey,
+	Up: func(ctx context.Context, tx *sql.Tx) error {
+		addColumnStmt := `
+		ALTER TABLE operatorbundle
+		ADD COLUMN package_name TEXT;
+		`
+		_, err := tx.ExecContext(ctx, addColumnStmt)
+		if err != nil {
+			return err
+		}
+
+		bundlePkgs, err := getBundlePackages(ctx, tx)
+		if err != nil {
+			return err
+		}
+
+		for bundle, pkgName := range bundlePkgs {
+			err := setPackage(ctx, tx, pkgName, bundle)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	},
+	Down: func(ctx context.Context, tx *sql.Tx) error {
+		foreignKeyOff := `PRAGMA foreign_keys = 0`
+		createTempTable := `CREATE TABLE operatorbundle_backup (name TEXT, csv TEXT, bundle TEXT, bundlepath TEXT, skiprange TEXT, version TEXT, replaces TEXT, skips TEXT)`
+		backupTargetTable := `INSERT INTO operatorbundle_backup SELECT name, csv, bundle, bundlepath, skiprange, version, replaces, skips FROM operatorbundle`
+		dropTargetTable := `DROP TABLE operatorbundle`
+		renameBackUpTable := `ALTER TABLE operatorbundle_backup RENAME TO operatorbundle;`
+		foreignKeyOn := `PRAGMA foreign_keys = 1`
+		_, err := tx.ExecContext(ctx, foreignKeyOff)
+		if err != nil {
+			return err
+		}
+		_, err = tx.ExecContext(ctx, createTempTable)
+		if err != nil {
+			return err
+		}
+		_, err = tx.ExecContext(ctx, backupTargetTable)
+		if err != nil {
+			return err
+		}
+		_, err = tx.ExecContext(ctx, dropTargetTable)
+		if err != nil {
+			return err
+		}
+		_, err = tx.ExecContext(ctx, renameBackUpTable)
+		if err != nil {
+			return err
+		}
+		_, err = tx.ExecContext(ctx, foreignKeyOn)
+		return err
+	},
+}
+
+func setPackage(ctx context.Context, tx *sql.Tx, pkgName, bundle string) error {
+	updateSql := `UPDATE operatorbundle SET package_name = ? WHERE name = ?;`
+	_, err := tx.ExecContext(ctx, updateSql, pkgName, bundle)
+	return err
+}
+
+func getBundlePackages(ctx context.Context, tx *sql.Tx) (map[string]string, error) {
+	bundlePkgMap := make(map[string]string, 0)
+	selectEntryPackageQuery := `SELECT DISTINCT operatorbundle_name, package_name FROM channel_entry`
+	rows, err := tx.QueryContext(ctx, selectEntryPackageQuery)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var bundle, pkgName sql.NullString
+
+		if err = rows.Scan(&bundle, &pkgName); err != nil {
+			return nil, err
+		}
+
+		if bundle.Valid && pkgName.Valid {
+			bundlePkgMap[bundle.String] = pkgName.String
+		}
+	}
+
+	return bundlePkgMap, nil
+}

--- a/pkg/sqlite/migrations/009_bundle_package_test.go
+++ b/pkg/sqlite/migrations/009_bundle_package_test.go
@@ -1,0 +1,65 @@
+package migrations_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/operator-framework/operator-registry/pkg/sqlite/migrations"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBundlePackageUp(t *testing.T) {
+	db, migrator, cleanup := CreateTestDbAt(t, migrations.BundlePackageMigrationKey-1)
+	defer cleanup()
+
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	// Add a bundle
+	insert := "insert into operatorbundle(name) values(?)"
+	_, err = db.Exec(insert, "etcdoperator.v0.6.1")
+	require.NoError(t, err)
+	_, err = tx.Exec("insert into channel_entry(entry_id, package_name, operatorbundle_name) values(?, ?, ?)", 1, "etcd", "etcdoperator.v0.6.1")
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+
+	err = migrator.Up(context.TODO(), migrations.Only(migrations.BundlePackageMigrationKey))
+	require.NoError(t, err)
+
+	pkgQuery := "SELECT package_name FROM operatorbundle WHERE name=?"
+
+	rows, err := db.Query(pkgQuery, "etcdoperator.v0.6.1")
+	require.NoError(t, err)
+	defer rows.Close()
+	rows.Next()
+	var package_name sql.NullString
+	require.NoError(t, rows.Scan(&package_name))
+	require.Equal(t, "etcd", package_name.String)
+	require.NoError(t, rows.Close())
+}
+
+func TestBundlePackageDown(t *testing.T) {
+	db, migrator, cleanup := CreateTestDbAt(t, migrations.BundlePackageMigrationKey)
+	defer cleanup()
+
+	_, err := db.Exec(`PRAGMA foreign_keys = 0`)
+	require.NoError(t, err)
+
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	// Add a bundle
+	insert := "insert into operatorbundle(name, package_name) values(?, ?)"
+	_, err = db.Exec(insert, "etcdoperator.v0.6.1", "etcd")
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+
+	// run down migration
+	err = migrator.Down(context.TODO(), migrations.Only(migrations.BundlePackageMigrationKey))
+	require.NoError(t, err)
+
+	pkgQuery := "SELECT package_name FROM operatorbundle WHERE name=?"
+	rows, err := db.Query(pkgQuery, "etcdoperator.v0.6.1")
+	require.NoError(t, err)
+	defer rows.Close()
+	require.False(t, rows.Next())
+}


### PR DESCRIPTION
In some cases, bundles can be orphaned from channel graphs (for example,
a new bundle could be added as the head of the channel that does not
specify a replacement). When that happens, registry/index rm commands in
opm cannot remove these bundles because the bundles themselves do not
have an association in the database with the package directly.

This commit modifies the operatorbundle table to include the package
name of the bundle so that bundles can be directly referenced when
calling registry rm, rather than being joined on the channel_entry table
(and thus beholden to the graph itself).

This commit includes a migration to update existing bundles to associate
the package name with bundles, however in the case that the bundle has
been orphaned we have no guarantee that a bundle should be associated
with a specific package name. As such, there could be existing indexes
that still include these orphaned bundles and cannot be reassociated
automatically.

Related to https://github.com/operator-framework/operator-registry/issues/367