### PR TITLE
Add timeout to opm registry serve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 
 
 .PHONY: all
-all: clean test build sanity-check
+all: clean test build
 
 $(CMDS):
 	$(GO) build $(extra_flags) -o $@ ./cmd/$(notdir $@)

--- a/cmd/opm/registry/serve.go
+++ b/cmd/opm/registry/serve.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -42,8 +44,9 @@ func newRegistryServeCmd() *cobra.Command {
 	rootCmd.Flags().StringP("port", "p", "50051", "port number to serve on")
 	rootCmd.Flags().StringP("termination-log", "t", "/dev/termination-log", "path to a container termination log file")
 	rootCmd.Flags().Bool("skip-migrate", false, "do  not attempt to migrate to the latest db revision when starting")
-	return rootCmd
+	rootCmd.Flags().String("timeout-seconds", "infinite", "Timeout in seconds. This flag will be removed later.")
 
+	return rootCmd
 }
 
 func serveFunc(cmd *cobra.Command, args []string) error {
@@ -106,7 +109,27 @@ func serveFunc(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		logger.Fatalf("failed to listen: %s", err)
 	}
+
+	timeout, err := cmd.Flags().GetString("timeout-seconds")
+	if err != nil {
+		return err
+	}
+
 	s := grpc.NewServer()
+	logger.Printf("Keeping server open for %s seconds", timeout)
+	if timeout != "infinite" {
+		timeoutSeconds, err := strconv.ParseUint(timeout, 10, 16)
+		if err != nil {
+			return err
+		}
+
+		timeoutDuration := time.Duration(timeoutSeconds) * time.Second
+		timer := time.AfterFunc(timeoutDuration, func() {
+			logger.Info("Timeout expired. Gracefully stopping.")
+			s.GracefulStop()
+		})
+		defer timer.Stop()
+	}
 
 	api.RegisterRegistryServer(s, server.NewRegistryServer(store))
 	health.RegisterHealthServer(s, server.NewHealthServer())


### PR DESCRIPTION
This relates to our project to serve operator metadata via pyxis:
CLOUDWF-1739

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Add new flag `--timeout-seconds/-s` to `opm registry serve`
which allows specifying that the server should be shut down
after a number of seconds.

The server is gracefully shut down.

**Motivation for the change:**

We are extracting information from the iib container and normally need this container up for a very short time
(1 min or less). Having a daemon complicates our setup (i.e. we'd need to handle server start/stop manually).

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


Some manual testing done:

```bash
[opm (master *%=)]$ ./bin/opm registry serve --database scratchpad/database/index.db -s 1
WARN[0000] unable to set termination log path            error="open /dev/termination-log: permission denied"
INFO[0000] Keeping server open for 1 seconds             database=scratchpad/database/index.db port=50051
INFO[0000] serving registry                              database=scratchpad/database/index.db port=50051
INFO[0001] Timeout expired. Gracefully stopping.         database=scratchpad/database/index.db port=50051

[opm (master *%=)]$ ./bin/opm registry serve --database scratchpad/database/index.db -s 2
WARN[0000] unable to set termination log path            error="open /dev/termination-log: permission denied"
INFO[0000] Keeping server open for 2 seconds             database=scratchpad/database/index.db port=50051
INFO[0000] serving registry                              database=scratchpad/database/index.db port=50051
INFO[0002] Timeout expired. Gracefully stopping.         database=scratchpad/database/index.db port=50051

[opm (master *%=)]$ ./bin/opm registry serve --database scratchpad/database/index.db
WARN[0000] unable to set termination log path            error="open /dev/termination-log: permission denied"
INFO[0000] Keeping server open for infinite seconds      database=scratchpad/database/index.db port=50051
INFO[0000] serving registry                              database=scratchpad/database/index.db port=50051
^C

[opm (master *%=)]$ ./bin/opm registry serve --database scratchpad/database/index.db --timeout-seconds infinite
WARN[0000] unable to set termination log path            error="open /dev/termination-log: permission denied"
INFO[0000] Keeping server open for infinite seconds      database=scratchpad/database/index.db port=50051
INFO[0000] serving registry                              database=scratchpad/database/index.db port=50051
^C

[opm (master *%=)]$ ./bin/opm registry serve --database scratchpad/database/index.db --timeout-seconds 1
WARN[0000] unable to set termination log path            error="open /dev/termination-log: permission denied"
INFO[0000] Keeping server open for 1 seconds             database=scratchpad/database/index.db port=50051
INFO[0000] serving registry                              database=scratchpad/database/index.db port=50051
INFO[0001] Timeout expired. Gracefully stopping.         database=scratchpad/database/index.db port=50051

[opm (master *%=)]$ ./bin/opm registry serve --database scratchpad/database/index.db
WARN[0000] unable to set termination log path            error="open /dev/termination-log: permission denied"
INFO[0000] Keeping server open for infinite seconds      database=scratchpad/database/index.db port=50051
INFO[0000] serving registry                              database=scratchpad/database/index.db port=50051
```
