### PR TITLE
Separate build/pull tool for index rm

### DIFF
--- a/pkg/lib/indexer/interfaces.go
+++ b/pkg/lib/indexer/interfaces.go
@@ -35,14 +35,14 @@ type IndexDeleter interface {
 }
 
 // NewIndexDeleter is a constructor that returns an IndexDeleter
-func NewIndexDeleter(containerTool containertools.ContainerTool, logger *logrus.Entry) IndexDeleter {
+func NewIndexDeleter(buildTool, pullTool containertools.ContainerTool, logger *logrus.Entry) IndexDeleter {
 	return ImageIndexer{
 		DockerfileGenerator: containertools.NewDockerfileGenerator(logger),
-		CommandRunner:       containertools.NewCommandRunner(containerTool, logger),
-		LabelReader:         containertools.NewLabelReader(containerTool, logger),
+		CommandRunner:       containertools.NewCommandRunner(buildTool, logger),
+		LabelReader:         containertools.NewLabelReader(pullTool, logger),
 		RegistryDeleter:     registry.NewRegistryDeleter(logger),
-		BuildTool:           containerTool,
-		PullTool:            containerTool,
+		BuildTool:           buildTool,
+		PullTool:            pullTool,
 		Logger:              logger,
 	}
 }


### PR DESCRIPTION
Like the index add command, index rm can separate the tool/lib that
pulls and unpacks index images from the tool that builds them. This
commit introduces that separation to index rm, defaulting pull tool to
none(using internal containerd libs for pulling) from the build tool
that defaults to podman.