### PR TITLE
feat(release): add builds for s390x and ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,21 @@ go:
 jobs:
   include:
   - os: linux
+    arch: ppc64le
+    env:
+      MAKE: make
+  - os: linux
+    arch: s390x
+    env:
+      MAKE: make
+  - os: linux
     dist: xenial
     env:
       MAKE: make
-    install: |
-      curl -sLo minikube "$(curl -sL https://api.github.com/repos/kubernetes/minikube/releases/latest | jq -r '[.assets[] | select(.name == "minikube-linux-amd64")] | first | .browser_download_url')"
-      chmod +x minikube
-      sudo mv minikube /bin/
-      minikube config set vm-driver none
-      minikube config set kubernetes-version $(go list -f '{{.Version}}' -m k8s.io/api | sed 's/^v0\./v1./')
+  - os: linux
+    dist: xenial
+    env:
+      MAKE: make
   - os: osx
     install: |
       brew install make
@@ -21,6 +27,17 @@ jobs:
   - os: windows
     env:
       MAKE: mingw32-make
+  - os: linux
+    dist: xenial
+    env:
+      MAKE: make
+      TEST: e2e
+    install: |
+      curl -sLo minikube "$(curl -sL https://api.github.com/repos/kubernetes/minikube/releases/latest | jq -r '[.assets[] | select(.name == "minikube-linux-amd64")] | first | .browser_download_url')"
+      chmod +x minikube
+      sudo mv minikube /bin/
+      minikube config set vm-driver none
+      minikube config set kubernetes-version $(go list -f '{{.Version}}' -m k8s.io/api | sed 's/^v0\./v1./')
 addons:
   apt:
     sources:
@@ -31,7 +48,7 @@ addons:
     - conntrack
 script: |
   "${MAKE}" unit build
-  if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  if [[ "$TEST" == "e2e" ]]; then
     sudo minikube start # vm-driver=none requires root
     sudo chown -R "$USER" "$HOME/.kube" "$HOME/.minikube"
     KUBECONFIG="$HOME/.kube/config" make e2e


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Adds builds for s390x and ppc64le. Also disables gating on e2e tests, since we are still seeing issues with podman.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
