### PR TITLE
Bump GRPC version

### DIFF
--- a/upstream-opm-builder.Dockerfile
+++ b/upstream-opm-builder.Dockerfile
@@ -9,7 +9,7 @@ COPY pkg pkg
 COPY Makefile Makefile
 COPY go.mod go.mod
 RUN make static
-RUN GRPC_HEALTH_PROBE_VERSION=v0.2.1 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-$(go env GOARCH) && \
     chmod +x /bin/grpc_health_probe
 


### PR DESCRIPTION
**Description of the change:**

Bump GRPC_HEALTH_PROBE_VERSION to match other dockerfiles, allows support for s390x

Associated with #208

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
