### PR TITLE
pkg/lib/bundle/generate.go: add JSON tag to AnnotationMetadata

### DIFF
--- a/pkg/lib/bundle/generate.go
+++ b/pkg/lib/bundle/generate.go
@@ -33,7 +33,7 @@ const (
 )
 
 type AnnotationMetadata struct {
-	Annotations map[string]string `yaml:"annotations"`
+	Annotations map[string]string `yaml:"annotations" json:"annotations"`
 }
 
 // GenerateFunc builds annotations.yaml with mediatype, manifests &


### PR DESCRIPTION
**Description of the change:** add a ```` `json` ```` tag to `AnnotationMetadata`


**Motivation for the change:** some YAML parsing libraries use JSON under the hood. This change allows both direct and indirect YAML parsers to understand `AnnotationMetadata`.

See https://github.com/operator-framework/operator-sdk/pull/3120#discussion_r438533686 for why this is a nice-to-have.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
