### PR TITLE
fix(build): don't set -race when testing on s390x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,12 @@ GIT_COMMIT := $(shell git rev-parse --short HEAD)
 OPM_VERSION := $(shell cat OPM_VERSION)
 BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 TAGS := -tags "json1"
+# -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
+ifeq ($(GOARCH),s390x)
+TEST_RACE :=
+else
+TEST_RACE := -race
+endif
 
 
 .PHONY: all
@@ -28,7 +34,7 @@ static: build
 
 .PHONY: unit
 unit:
-	$(GO) test $(SPECIFIC_UNIT_TEST) $(TAGS) -count=1 -v -race ./pkg/...
+	$(GO) test $(SPECIFIC_UNIT_TEST) $(TAGS) $(TEST_RACE) -count=1 -v ./pkg/...
 
 .PHONY: image
 image:


### PR DESCRIPTION


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
omits the `-race` flag on s390x tests

**Motivation for the change:**
the race flag is not supported on linux/s390x

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
