### PR TITLE
Use go env to get architecture for building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OPM_VERSION := $(shell cat OPM_VERSION)
 BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 TAGS := -tags "json1"
 # -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-ifeq ($(GOARCH),s390x)
+ifeq ($(shell go env GOARCH),s390x)
 TEST_RACE :=
 else
 TEST_RACE := -race


### PR DESCRIPTION
**Description of the change:**
GOARCH is not an env var, so needs pulling from `go env` instead

**Motivation for the change:**
Fix build for s390x

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
