### PR TITLE
Bug 1857502: fix(validate): pull bundle images before unpacking

### DIFF
--- a/pkg/image/containerdregistry/options.go
+++ b/pkg/image/containerdregistry/options.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containerd/containerd/metadata"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/remotes"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 	bolt "go.etcd.io/bbolt"
 )
@@ -99,7 +100,10 @@ func NewRegistry(options ...RegistryOption) (registry *Registry, err error) {
 		destroy:  destroy,
 		log:      config.Log,
 		resolver: resolver,
-		platform: platforms.Only(platforms.DefaultSpec()),
+		platform: platforms.Ordered(platforms.DefaultSpec(), specs.Platform{
+			OS:           "linux",
+			Architecture: "amd64",
+		}),
 	}
 	return
 }

--- a/pkg/lib/bundle/validate.go
+++ b/pkg/lib/bundle/validate.go
@@ -48,7 +48,15 @@ type imageValidator struct {
 func (i imageValidator) PullBundleImage(imageTag, directory string) error {
 	i.logger.Debug("Pulling and unpacking container image")
 
-	return i.registry.Unpack(context.Background(), image.SimpleReference(imageTag), directory)
+	var (
+		ctx = context.TODO()
+		ref = image.SimpleReference(imageTag)
+	)
+	if err := i.registry.Pull(ctx, ref); err != nil {
+		return err
+	}
+
+	return i.registry.Unpack(ctx, ref, directory)
 }
 
 // ValidateBundle takes a directory containing the contents of a bundle and validates


### PR DESCRIPTION
Pull bundle images before attempting to unpack in the bundle validator. Prevents validation from erroneously failing with "image not found".
