### PR TITLE
Add GetPackage to the client interface.

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -18,6 +18,7 @@ type Interface interface {
 	GetReplacementBundleInPackageChannel(ctx context.Context, currentName, packageName, channelName string) (*api.Bundle, error)
 	GetBundleThatProvides(ctx context.Context, group, version, kind string) (*api.Bundle, error)
 	ListBundles(ctx context.Context) (*BundleIterator, error)
+	GetPackage(ctx context.Context, packageName string) (*api.Package, error)
 	HealthCheck(ctx context.Context, reconnectTimeout time.Duration) (bool, error)
 	Close() error
 }
@@ -83,6 +84,10 @@ func (c *Client) ListBundles(ctx context.Context) (*BundleIterator, error) {
 		return nil, err
 	}
 	return NewBundleIterator(stream), nil
+}
+
+func (c *Client) GetPackage(ctx context.Context, packageName string) (*api.Package, error) {
+	return c.Registry.GetPackage(ctx, &api.GetPackageRequest{Name: packageName})
 }
 
 func (c *Client) Close() error {


### PR DESCRIPTION
GetPackage already exists in the gRPC service, but wasn't directly accessible via the client package. The new resolver needs to be able to retrieve default channel information, and GetPackage enables that without requiring updated catalog images. There will eventually need to be a more efficient way to fetch bulk default channel information over the registry API.