### PR TITLE
Adding ability to deprecate bundles

### DIFF
--- a/bundles/etcd.0.9.0/metadata/annotations.yaml
+++ b/bundles/etcd.0.9.0/metadata/annotations.yaml
@@ -1,4 +1,5 @@
 annotations:
   operators.operatorframework.io.bundle.package.v1: "etcd"
-  operators.operatorframework.io.bundle.channels.v1: "alpha,stable"
+  operators.operatorframework.io.bundle.channels.v1: "alpha,stable,beta"
   operators.operatorframework.io.bundle.channel.default.v1: "stable"
+  

--- a/cmd/opm/index/cmd.go
+++ b/cmd/opm/index/cmd.go
@@ -25,4 +25,5 @@ func AddCommand(parent *cobra.Command) {
 	addIndexAddCmd(cmd)
 	cmd.AddCommand(newIndexExportCmd())
 	cmd.AddCommand(newIndexPruneCmd())
+	cmd.AddCommand(newIndexDeprecateTruncateCmd())
 }

--- a/cmd/opm/index/deprecate.go
+++ b/cmd/opm/index/deprecate.go
@@ -1,0 +1,133 @@
+package index
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	"github.com/operator-framework/operator-registry/pkg/containertools"
+	"github.com/operator-framework/operator-registry/pkg/lib/indexer"
+)
+
+var deprecateLong = templates.LongDesc(`
+	Deprecate and truncate operator bundles from an index.
+	
+	Deprecated bundles will no longer be installable. Bundles that are replaced by deprecated bundles will be removed enirely from the index.
+	
+	For example:
+
+		Given the update graph in quay.io/my/index:v1
+		1.4.0 -- replaces -> 1.3.0 -- replaces -> 1.2.0 -- replaces -> 1.1.0
+
+		Applying the command:
+		opm index deprecate --bundles "quay.io/my/bundle:1.3.0" --from-index "quay.io/my/index:v1" --tag "quay.io/my/index:v2"
+
+		Produces the following update graph in quay.io/my/index:v2
+		1.4.0 -- replaces -> 1.3.0 [deprecated]
+		
+	Deprecating a bundle that removes the default channel is not allowed. Changing the default channel prior to deprecation is possible by publishing a new bundle to the index.
+	`)
+
+func newIndexDeprecateTruncateCmd() *cobra.Command {
+	indexCmd := &cobra.Command{
+		Hidden: true,
+		Use:    "deprecatetruncate",
+		Short:  "Deprecate and truncate operator bundles from an index.",
+		Long:   deprecateLong,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if debug, _ := cmd.Flags().GetBool("debug"); debug {
+				logrus.SetLevel(logrus.DebugLevel)
+			}
+			return nil
+		},
+		RunE: runIndexDeprecateTruncateCmdFunc,
+	}
+
+	indexCmd.Flags().Bool("debug", false, "enable debug logging")
+	indexCmd.Flags().Bool("generate", false, "if enabled, just creates the dockerfile and saves it to local disk")
+	indexCmd.Flags().StringP("out-dockerfile", "d", "", "if generating the dockerfile, this flag is used to (optionally) specify a dockerfile name")
+	indexCmd.Flags().StringP("from-index", "f", "", "previous index to add to")
+	indexCmd.Flags().StringSliceP("bundles", "b", nil, "comma separated list of bundles to add")
+	if err := indexCmd.MarkFlagRequired("bundles"); err != nil {
+		logrus.Panic("Failed to set required `bundles` flag for `index add`")
+	}
+	indexCmd.Flags().StringP("binary-image", "i", "", "container image for on-image `opm` command")
+	indexCmd.Flags().StringP("container-tool", "c", "", "tool to interact with container images (save, build, etc.). One of: [docker, podman]")
+	indexCmd.Flags().StringP("build-tool", "u", "", "tool to build container images. One of: [docker, podman]. Defaults to podman. Overrides part of container-tool.")
+	indexCmd.Flags().StringP("pull-tool", "p", "", "tool to pull container images. One of: [none, docker, podman]. Defaults to none. Overrides part of container-tool.")
+	indexCmd.Flags().StringP("tag", "t", "", "custom tag for container image being built")
+	indexCmd.Flags().Bool("permissive", false, "allow registry load errors")
+	if err := indexCmd.Flags().MarkHidden("debug"); err != nil {
+		logrus.Panic(err.Error())
+	}
+
+	return indexCmd
+}
+
+func runIndexDeprecateTruncateCmdFunc(cmd *cobra.Command, args []string) error {
+	generate, err := cmd.Flags().GetBool("generate")
+	if err != nil {
+		return err
+	}
+
+	outDockerfile, err := cmd.Flags().GetString("out-dockerfile")
+	if err != nil {
+		return err
+	}
+
+	fromIndex, err := cmd.Flags().GetString("from-index")
+	if err != nil {
+		return err
+	}
+
+	bundles, err := cmd.Flags().GetStringSlice("bundles")
+	if err != nil {
+		return err
+	}
+
+	binaryImage, err := cmd.Flags().GetString("binary-image")
+	if err != nil {
+		return err
+	}
+
+	tag, err := cmd.Flags().GetString("tag")
+	if err != nil {
+		return err
+	}
+
+	permissive, err := cmd.Flags().GetBool("permissive")
+	if err != nil {
+		return err
+	}
+
+	pullTool, buildTool, err := getContainerTools(cmd)
+	if err != nil {
+		return err
+	}
+
+	logger := logrus.WithFields(logrus.Fields{"bundles": bundles})
+
+	logger.Info("deprecating bundles from the index")
+
+	indexDeprecator := indexer.NewIndexDeprecator(
+		containertools.NewContainerTool(buildTool, containertools.PodmanTool),
+		containertools.NewContainerTool(pullTool, containertools.NoneTool),
+		logger)
+
+	request := indexer.DeprecateFromIndexRequest{
+		Generate:          generate,
+		FromIndex:         fromIndex,
+		BinarySourceImage: binaryImage,
+		OutDockerfile:     outDockerfile,
+		Tag:               tag,
+		Bundles:           bundles,
+		Permissive:        permissive,
+	}
+
+	err = indexDeprecator.DeprecateFromIndex(request)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/lib/indexer/interfaces.go
+++ b/pkg/lib/indexer/interfaces.go
@@ -80,3 +80,20 @@ func NewIndexPruner(containerTool containertools.ContainerTool, logger *logrus.E
 		Logger:              logger,
 	}
 }
+
+// IndexDeprecator prunes operators out of an index
+type IndexDeprecator interface {
+	DeprecateFromIndex(DeprecateFromIndexRequest) error
+}
+
+func NewIndexDeprecator(buildTool, pullTool containertools.ContainerTool, logger *logrus.Entry) IndexDeprecator {
+	return ImageIndexer{
+		DockerfileGenerator: containertools.NewDockerfileGenerator(logger),
+		CommandRunner:       containertools.NewCommandRunner(buildTool, logger),
+		LabelReader:         containertools.NewLabelReader(pullTool, logger),
+		RegistryDeprecator:  registry.NewRegistryDeprecator(logger),
+		BuildTool:           buildTool,
+		PullTool:            pullTool,
+		Logger:              logger,
+	}
+}

--- a/pkg/lib/registry/interfaces.go
+++ b/pkg/lib/registry/interfaces.go
@@ -36,3 +36,13 @@ func NewRegistryPruner(logger *logrus.Entry) RegistryPruner {
 		Logger: logger,
 	}
 }
+
+type RegistryDeprecator interface {
+	DeprecateFromRegistry(DeprecateFromRegistryRequest) error
+}
+
+func NewRegistryDeprecator(logger *logrus.Entry) RegistryDeprecator {
+	return RegistryUpdater{
+		Logger: logger,
+	}
+}

--- a/pkg/registry/interface.go
+++ b/pkg/registry/interface.go
@@ -12,6 +12,7 @@ type Load interface {
 	AddPackageChannels(manifest PackageManifest) error
 	AddBundlePackageChannels(manifest PackageManifest, bundle *Bundle) error
 	RemovePackage(packageName string) error
+	DeprecateBundle(path string) error
 	ClearNonHeadBundles() error
 }
 

--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -12,6 +12,13 @@ import (
 var (
 	// ErrPackageNotInDatabase is an error that describes a package not found error when querying the registry
 	ErrPackageNotInDatabase = errors.New("Package not in database")
+
+	// ErrBundleImageNotInDatabase is an error that describes a bundle image not found when querying the registry
+	ErrBundleImageNotInDatabase = errors.New("Bundle Image not in database")
+
+	// ErrRemovingDefaultChannelDuringDeprecation is an error that describes a bundle deprecation causing the deletion
+	// of the default channel
+	ErrRemovingDefaultChannelDuringDeprecation = errors.New("Bundle deprecation causing default channel removal")
 )
 
 // BundleImageAlreadyAddedErr is an error that describes a bundle is already added
@@ -33,8 +40,9 @@ func (e PackageVersionAlreadyAddedErr) Error() string {
 }
 
 const (
-	GVKType     = "olm.gvk"
-	PackageType = "olm.package"
+	GVKType        = "olm.gvk"
+	PackageType    = "olm.package"
+	DeprecatedType = "olm.deprecated"
 )
 
 // APIKey stores GroupVersionKind for use as map keys
@@ -202,6 +210,10 @@ type PackageProperty struct {
 
 	// The version of package in semver format
 	Version string `json:"version" yaml:"version"`
+}
+
+type DeprecatedProperty struct {
+	// Whether the bundle is deprecated
 }
 
 // Validate will validate GVK dependency type and return error(s)

--- a/pkg/sqlite/deprecate.go
+++ b/pkg/sqlite/deprecate.go
@@ -1,0 +1,49 @@
+package sqlite
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"github.com/operator-framework/operator-registry/pkg/registry"
+)
+
+type SQLDeprecator interface {
+	Deprecate() error
+}
+
+// BundleDeprecator removes bundles from the database
+type BundleDeprecator struct {
+	store   registry.Load
+	bundles []string
+}
+
+var _ SQLDeprecator = &BundleDeprecator{}
+
+func NewSQLDeprecatorForBundles(store registry.Load, bundles []string) *BundleDeprecator {
+	return &BundleDeprecator{
+		store:   store,
+		bundles: bundles,
+	}
+}
+
+func (d *BundleDeprecator) Deprecate() error {
+	log := logrus.WithField("bundles", d.bundles)
+
+	log.Info("deprecating bundles")
+
+	var errs []error
+
+	for _, bundlePath := range d.bundles {
+		if err := d.store.DeprecateBundle(bundlePath); err != nil {
+			if !errors.Is(err, registry.ErrBundleImageNotInDatabase) && !errors.Is(err, registry.ErrRemovingDefaultChannelDuringDeprecation) {
+				return utilerrors.NewAggregate(append(errs, fmt.Errorf("error deprecating bundle %s: %s", bundlePath, err)))
+			}
+			errs = append(errs, fmt.Errorf("error deprecating bundle %s: %s", bundlePath, err))
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
+}

--- a/pkg/sqlite/query.go
+++ b/pkg/sqlite/query.go
@@ -779,7 +779,7 @@ func (s *SQLQuerier) GetBundleVersion(ctx context.Context, image string) (string
 	if version.Valid {
 		return version.String, nil
 	}
-	return "", fmt.Errorf("bundle %s not found", image)
+	return "", nil
 }
 
 func (s *SQLQuerier) GetBundlePathsForPackage(ctx context.Context, pkgName string) ([]string, error) {


### PR DESCRIPTION
Adding support marking versions as deprecated and truncating the update
graph of a given package. Deprecated versions will not be installable.
If a deprecated version is installed prior to upgrade appropriate alerts
will be fired on cluster.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Described in [this enhancement](https://github.com/operator-framework/enhancements/blob/master/enhancements/deprecated-bundles.md)

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
