### PR TITLE
feat(registry): add graceful shutdown to grpc server

### DIFF
--- a/cmd/appregistry-server/main.go
+++ b/cmd/appregistry-server/main.go
@@ -13,6 +13,7 @@ import (
 	health "github.com/operator-framework/operator-registry/pkg/api/grpc_health_v1"
 	"github.com/operator-framework/operator-registry/pkg/appregistry"
 	"github.com/operator-framework/operator-registry/pkg/lib/dns"
+	"github.com/operator-framework/operator-registry/pkg/lib/graceful"
 	"github.com/operator-framework/operator-registry/pkg/lib/log"
 	"github.com/operator-framework/operator-registry/pkg/registry"
 	"github.com/operator-framework/operator-registry/pkg/server"
@@ -128,9 +129,9 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 	reflection.Register(s)
 
 	logger.Info("serving registry")
-	if err := s.Serve(lis); err != nil {
-		logger.Fatalf("failed to serve: %s", err)
-	}
-
-	return nil
+	return graceful.Shutdown(logger, func() error {
+		return s.Serve(lis)
+	}, func() {
+		s.GracefulStop()
+	})
 }

--- a/cmd/configmap-server/main.go
+++ b/cmd/configmap-server/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/operator-framework/operator-registry/pkg/api"
 	health "github.com/operator-framework/operator-registry/pkg/api/grpc_health_v1"
 	"github.com/operator-framework/operator-registry/pkg/lib/dns"
+	"github.com/operator-framework/operator-registry/pkg/lib/graceful"
 	"github.com/operator-framework/operator-registry/pkg/lib/log"
 	"github.com/operator-framework/operator-registry/pkg/registry"
 	"github.com/operator-framework/operator-registry/pkg/server"
@@ -155,10 +156,11 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 	reflection.Register(s)
 
 	logger.Info("serving registry")
-	if err := s.Serve(lis); err != nil {
-		logger.Fatalf("failed to serve: %s", err)
-	}
-	return nil
+	return graceful.Shutdown(logger, func() error {
+		return s.Serve(lis)
+	}, func() {
+		s.GracefulStop()
+	})
 }
 
 // NewClient creates a kubernetes client or bails out on on failures.

--- a/cmd/opm/registry/serve.go
+++ b/cmd/opm/registry/serve.go
@@ -15,6 +15,7 @@ import (
 	"github.com/operator-framework/operator-registry/pkg/api"
 	health "github.com/operator-framework/operator-registry/pkg/api/grpc_health_v1"
 	"github.com/operator-framework/operator-registry/pkg/lib/dns"
+	"github.com/operator-framework/operator-registry/pkg/lib/graceful"
 	"github.com/operator-framework/operator-registry/pkg/lib/log"
 	"github.com/operator-framework/operator-registry/pkg/lib/tmp"
 	"github.com/operator-framework/operator-registry/pkg/server"
@@ -112,11 +113,11 @@ func serveFunc(cmd *cobra.Command, args []string) error {
 	health.RegisterHealthServer(s, server.NewHealthServer())
 	reflection.Register(s)
 	logger.Info("serving registry")
-	if err := s.Serve(lis); err != nil {
-		logger.Fatalf("failed to serve: %s", err)
-	}
-
-	return nil
+	return graceful.Shutdown(logger, func() error {
+		return s.Serve(lis)
+	}, func() {
+		s.GracefulStop()
+	})
 }
 
 func migrate(cmd *cobra.Command, db *sql.DB) error {

--- a/cmd/registry-server/main.go
+++ b/cmd/registry-server/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/operator-framework/operator-registry/pkg/api"
 	health "github.com/operator-framework/operator-registry/pkg/api/grpc_health_v1"
 	"github.com/operator-framework/operator-registry/pkg/lib/dns"
+	"github.com/operator-framework/operator-registry/pkg/lib/graceful"
 	"github.com/operator-framework/operator-registry/pkg/lib/log"
 	"github.com/operator-framework/operator-registry/pkg/lib/tmp"
 	"github.com/operator-framework/operator-registry/pkg/server"
@@ -116,11 +117,12 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 	health.RegisterHealthServer(s, server.NewHealthServer())
 	reflection.Register(s)
 	logger.Info("serving registry")
-	if err := s.Serve(lis); err != nil {
-		logger.Fatalf("failed to serve: %s", err)
-	}
 
-	return nil
+	return graceful.Shutdown(logger, func() error {
+		return s.Serve(lis)
+	}, func() {
+		s.GracefulStop()
+	})
 }
 
 func migrate(cmd *cobra.Command, db *sql.DB) error {

--- a/pkg/lib/graceful/shutdown.go
+++ b/pkg/lib/graceful/shutdown.go
@@ -1,0 +1,33 @@
+package graceful
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+)
+
+func Shutdown(logger logrus.FieldLogger, run func() error, cleanup func()) error {
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(interrupt)
+
+	g, ctx := errgroup.WithContext(context.Background())
+	g.Go(run)
+
+	select {
+	case <-interrupt:
+		break
+	case <-ctx.Done():
+		break
+	}
+
+	logger.Info("shutting down...")
+
+	cleanup()
+
+	return g.Wait()
+}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
When the server receives `SIGTERM`, this calls `GracefulStop` on the grpc server.

**Motivation for the change:**
This is better for clients, and may improve e2e test time for OLM.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
