### PR TITLE
Fix listbundles property bug

### DIFF
--- a/pkg/sqlite/query.go
+++ b/pkg/sqlite/query.go
@@ -943,30 +943,29 @@ func (s *SQLQuerier) ListBundles(ctx context.Context) (bundles []*api.Bundle, er
 		bundleItem, ok := bundlesMap[bundleKey]
 		if ok {
 			// Create new dependency object
-			dep := &api.Dependency{}
-			if !depType.Valid || !depValue.Valid {
-				continue
-			}
-			dep.Type = depType.String
-			dep.Value = depValue.String
+			if depType.Valid && depValue.Valid {
+				dep := &api.Dependency{}
+				dep.Type = depType.String
+				dep.Value = depValue.String
 
-			// Add new dependency to the existing list
-			existingDeps := bundleItem.Dependencies
-			existingDeps = append(existingDeps, dep)
-			bundleItem.Dependencies = existingDeps
+				// Add new dependency to the existing list
+				existingDeps := bundleItem.Dependencies
+				existingDeps = append(existingDeps, dep)
+				bundleItem.Dependencies = existingDeps
+			}
+
 
 			// Create new property object
-			prop := &api.Property{}
-			if !propType.Valid || !propValue.Valid {
-				continue
-			}
-			prop.Type = propType.String
-			prop.Value = propValue.String
+			if propType.Valid && propValue.Valid {
+				prop := &api.Property{}
+				prop.Type = propType.String
+				prop.Value = propValue.String
 
-			// Add new property to the existing list
-			existingProps := bundleItem.Properties
-			existingProps = append(existingProps, prop)
-			bundleItem.Properties = existingProps
+				// Add new property to the existing list
+				existingProps := bundleItem.Properties
+				existingProps = append(existingProps, prop)
+				bundleItem.Properties = existingProps
+			}
 		} else {
 			// Create new bundle
 			out := &api.Bundle{}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This fixes a bug where only one property would be returned for a bundle.

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
