### PR TITLE
fix(validation): Remove default channel validation from bundle lib

### DIFF
--- a/pkg/lib/bundle/generate_test.go
+++ b/pkg/lib/bundle/generate_test.go
@@ -49,43 +49,6 @@ func TestGetMediaType(t *testing.T) {
 	}
 }
 
-func TestValidateChannelDefault(t *testing.T) {
-	tests := []struct {
-		channels       string
-		channelDefault string
-		result         string
-		errorMsg       string
-	}{
-		{
-			"test5,test6",
-			"",
-			"",
-			"",
-		},
-		{
-			"test5,test6",
-			"test7",
-			"test5",
-			`The channel list "test5,test6" doesn't contain channelDefault "test7"`,
-		},
-		{
-			",",
-			"",
-			"",
-			`invalid channels are provided: ,`,
-		},
-	}
-
-	for _, item := range tests {
-		output, err := ValidateChannelDefault(item.channels, item.channelDefault)
-		if item.errorMsg == "" {
-			require.Equal(t, item.result, output)
-		} else {
-			require.Equal(t, item.errorMsg, err.Error())
-		}
-	}
-}
-
 func TestValidateAnnotations(t *testing.T) {
 	tests := []struct {
 		existing []byte

--- a/pkg/lib/bundle/validate.go
+++ b/pkg/lib/bundle/validate.go
@@ -201,20 +201,18 @@ func validateAnnotations(mediaType string, fileAnnotations *AnnotationMetadata) 
 				aErr := fmt.Errorf("Expecting annotation %q to have value %q instead of %q", label, MetadataDir, val)
 				validationErrors = append(validationErrors, aErr)
 			}
-		case ChannelsLabel, ChannelDefaultLabel:
+		case ChannelsLabel:
 			if val == "" {
 				aErr := fmt.Errorf("Expecting annotation %q to have non-empty value", label)
 				validationErrors = append(validationErrors, aErr)
 			} else {
 				annotations[label] = val
 			}
+		case ChannelDefaultLabel:
+			annotations[label] = val
 		}
 	}
 
-	_, err := ValidateChannelDefault(annotations[ChannelsLabel], annotations[ChannelDefaultLabel])
-	if err != nil {
-		validationErrors = append(validationErrors, err)
-	}
 	return validationErrors
 }
 


### PR DESCRIPTION
It is not possible to determine if the default channel value is valid
or not given we can "infer" default channel by using an emptry string.
Also, author can add a default channel that is not listed in the channel
list in some cases. As a result, the default channel is subjective
and there is no methodology to validate it. Therefore, removing this
validation will avoid any false positve.

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
