### PR TITLE
Update the `-i` help info

### DIFF
--- a/cmd/opm/index/add.go
+++ b/cmd/opm/index/add.go
@@ -53,7 +53,7 @@ func addIndexAddCmd(parent *cobra.Command) {
 	if err := indexCmd.MarkFlagRequired("bundles"); err != nil {
 		logrus.Panic("Failed to set required `bundles` flag for `index add`")
 	}
-	indexCmd.Flags().StringP("binary-image", "i", "", "container image for on-image `opm` command")
+	indexCmd.Flags().StringP("binary-image", "i", "", "base image for the index to serve the catalog. Default: quay.io/operator-framework/upstream-opm-builder:latest")
 	indexCmd.Flags().StringP("container-tool", "c", "", "tool to interact with container images (save, build, etc.). One of: [docker, podman]")
 	indexCmd.Flags().StringP("build-tool", "u", "", "tool to build container images. One of: [docker, podman]. Defaults to podman. Overrides part of container-tool.")
 	indexCmd.Flags().StringP("pull-tool", "p", "", "tool to pull container images. One of: [none, docker, podman]. Defaults to none. Overrides part of container-tool.")

--- a/cmd/opm/index/delete.go
+++ b/cmd/opm/index/delete.go
@@ -35,7 +35,7 @@ func newIndexDeleteCmd() *cobra.Command {
 	if err := indexCmd.MarkFlagRequired("operators"); err != nil {
 		logrus.Panic("Failed to set required `operators` flag for `index delete`")
 	}
-	indexCmd.Flags().StringP("binary-image", "i", "", "container image for on-image `opm` command")
+	indexCmd.Flags().StringP("binary-image", "i", "", "base image for the index to serve the catalog. Default: quay.io/operator-framework/upstream-opm-builder:latest")
 	indexCmd.Flags().StringP("container-tool", "c", "", "tool to interact with container images (save, build, etc.). One of: [none, docker, podman]")
 	indexCmd.Flags().StringP("build-tool", "u", "", "tool to build container images. One of: [docker, podman]. Defaults to podman. Overrides part of container-tool.")
 	indexCmd.Flags().StringP("pull-tool", "p", "", "tool to pull container images. One of: [none, docker, podman]. Defaults to none. Overrides part of container-tool.")

--- a/cmd/opm/index/deprecate.go
+++ b/cmd/opm/index/deprecate.go
@@ -51,7 +51,7 @@ func newIndexDeprecateTruncateCmd() *cobra.Command {
 	if err := indexCmd.MarkFlagRequired("bundles"); err != nil {
 		logrus.Panic("Failed to set required `bundles` flag for `index add`")
 	}
-	indexCmd.Flags().StringP("binary-image", "i", "", "container image for on-image `opm` command")
+	indexCmd.Flags().StringP("binary-image", "i", "", "base image for the index to serve the catalog. Default: quay.io/operator-framework/upstream-opm-builder:latest")
 	indexCmd.Flags().StringP("container-tool", "c", "", "tool to interact with container images (save, build, etc.). One of: [docker, podman]")
 	indexCmd.Flags().StringP("build-tool", "u", "", "tool to build container images. One of: [docker, podman]. Defaults to podman. Overrides part of container-tool.")
 	indexCmd.Flags().StringP("pull-tool", "p", "", "tool to pull container images. One of: [none, docker, podman]. Defaults to none. Overrides part of container-tool.")

--- a/cmd/opm/index/prune.go
+++ b/cmd/opm/index/prune.go
@@ -37,7 +37,7 @@ func newIndexPruneCmd() *cobra.Command {
 	if err := indexCmd.MarkFlagRequired("packages"); err != nil {
 		logrus.Panic("Failed to set required `packages` flag for `index prune`")
 	}
-	indexCmd.Flags().StringP("binary-image", "i", "", "container image for on-image `opm` command")
+	indexCmd.Flags().StringP("binary-image", "i", "", "base image for the index to serve the catalog. Default: quay.io/operator-framework/upstream-opm-builder:latest")
 	indexCmd.Flags().StringP("container-tool", "c", "podman", "tool to interact with container images (save, build, etc.). One of: [docker, podman]")
 	indexCmd.Flags().StringP("tag", "t", "", "custom tag for container image being built")
 	indexCmd.Flags().Bool("permissive", false, "allow registry load errors")

--- a/cmd/opm/index/prunestranded.go
+++ b/cmd/opm/index/prunestranded.go
@@ -33,7 +33,7 @@ func newIndexPruneStrandedCmd() *cobra.Command {
 	if err := indexCmd.MarkFlagRequired("from-index"); err != nil {
 		logrus.Panic("Failed to set required `from-index` flag for `index prune-stranded`")
 	}
-	indexCmd.Flags().StringP("binary-image", "i", "", "container image for on-image `opm` command")
+	indexCmd.Flags().StringP("binary-image", "i", "", "base image for the index to serve the catalog. Default: quay.io/operator-framework/upstream-opm-builder:latest")
 	indexCmd.Flags().StringP("container-tool", "c", "podman", "tool to interact with container images (save, build, etc.). One of: [docker, podman]")
 	indexCmd.Flags().StringP("tag", "t", "", "custom tag for container image being built")
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Many people who not familiar with OLM asked me what's the function of the `--binary-image` flag. So, I update the `-i` help info. Changed the `-i, --binary-image opm        container image for on-image opm command` to `-i, --binary-image string     base image for the index to serve the catalog`

**Motivation for the change:**
More clear for the user. Related bug: https://bugzilla.redhat.com/show_bug.cgi?id=1828811

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
