### PR TITLE
Add test to verify empty bundles in addition does not break

### DIFF
--- a/cmd/opm/index/add.go
+++ b/cmd/opm/index/add.go
@@ -49,6 +49,7 @@ func addIndexAddCmd(parent *cobra.Command) {
 	indexCmd.Flags().Bool("generate", false, "if enabled, just creates the dockerfile and saves it to local disk")
 	indexCmd.Flags().StringP("out-dockerfile", "d", "", "if generating the dockerfile, this flag is used to (optionally) specify a dockerfile name")
 	indexCmd.Flags().StringP("from-index", "f", "", "previous index to add to")
+	// adding empty list of strings is a valid value.
 	indexCmd.Flags().StringSliceP("bundles", "b", nil, "comma separated list of bundles to add")
 	if err := indexCmd.MarkFlagRequired("bundles"); err != nil {
 		logrus.Panic("Failed to set required `bundles` flag for `index add`")

--- a/test/e2e/opm_test.go
+++ b/test/e2e/opm_test.go
@@ -332,6 +332,19 @@ var _ = Describe("opm", func() {
 			err = os.Remove(workingDir + "/" + bundle.DockerFile)
 			Expect(err).NotTo(HaveOccurred())
 		})
+		It("build index without bundles", func() {
+
+			indexImage := "quay.io/olmtest/e2e-index:" + rand.String(6)
+
+			By("building an index")
+			err := buildIndexWith(containerTool, indexImage, "", []string{})
+			Expect(err).NotTo(HaveOccurred())
+
+			workingDir, err := os.Getwd()
+			Expect(err).NotTo(HaveOccurred())
+			err = os.Remove(workingDir + "/" + bundle.DockerFile)
+			Expect(err).NotTo(HaveOccurred())
+		})
 	}
 
 	Context("using docker", func() {


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Test to verify the behavior of adding an empty list of bundles

**Motivation for the change:**
Prevent backwards incompatible changes.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
