### PR TITLE
feat(opm): add alpha bundle unpack command

### DIFF
--- a/cmd/opm/alpha/bundle/cmd.go
+++ b/cmd/opm/alpha/bundle/cmd.go
@@ -15,7 +15,7 @@ func NewCmd() *cobra.Command {
 	runCmd.AddCommand(newBundleBuildCmd())
 	runCmd.AddCommand(newBundleValidateCmd())
 	runCmd.AddCommand(extractCmd)
-	runCmd.AddCommand(unpackCmd)
+	runCmd.AddCommand(newBundleUnpackCmd())
 
 	return runCmd
 }

--- a/cmd/opm/alpha/bundle/cmd.go
+++ b/cmd/opm/alpha/bundle/cmd.go
@@ -15,5 +15,7 @@ func NewCmd() *cobra.Command {
 	runCmd.AddCommand(newBundleBuildCmd())
 	runCmd.AddCommand(newBundleValidateCmd())
 	runCmd.AddCommand(extractCmd)
+	runCmd.AddCommand(unpackCmd)
+
 	return runCmd
 }

--- a/cmd/opm/main.go
+++ b/cmd/opm/main.go
@@ -3,40 +3,15 @@ package main
 import (
 	"os"
 
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
-	"github.com/operator-framework/operator-registry/cmd/opm/alpha"
-	"github.com/operator-framework/operator-registry/cmd/opm/index"
-	"github.com/operator-framework/operator-registry/cmd/opm/registry"
-	"github.com/operator-framework/operator-registry/cmd/opm/version"
+	"github.com/operator-framework/operator-registry/cmd/opm/root"
 	registrylib "github.com/operator-framework/operator-registry/pkg/registry"
 )
 
 func main() {
-	rootCmd := &cobra.Command{
-		Use:   "opm",
-		Short: "operator package manager",
-		Long:  "CLI to interact with operator-registry and build indexes of operator content",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if debug, _ := cmd.Flags().GetBool("debug"); debug {
-				logrus.SetLevel(logrus.DebugLevel)
-			}
-			return nil
-		},
-	}
-
-	rootCmd.AddCommand(registry.NewOpmRegistryCmd(), alpha.NewCmd())
-	index.AddCommand(rootCmd)
-	version.AddCommand(rootCmd)
-
-	rootCmd.Flags().Bool("debug", false, "enable debug logging")
-	if err := rootCmd.Flags().MarkHidden("debug"); err != nil {
-		logrus.Panic(err.Error())
-	}
-
-	if err := rootCmd.Execute(); err != nil {
+	cmd := root.NewCmd()
+	if err := cmd.Execute(); err != nil {
 		agg, ok := err.(utilerrors.Aggregate)
 		if !ok {
 			os.Exit(1)

--- a/cmd/opm/root/cmd.go
+++ b/cmd/opm/root/cmd.go
@@ -1,0 +1,36 @@
+package root
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/operator-framework/operator-registry/cmd/opm/alpha"
+	"github.com/operator-framework/operator-registry/cmd/opm/index"
+	"github.com/operator-framework/operator-registry/cmd/opm/registry"
+	"github.com/operator-framework/operator-registry/cmd/opm/version"
+)
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "opm",
+		Short: "operator package manager",
+		Long:  "CLI to interact with operator-registry and build indexes of operator content",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if debug, _ := cmd.Flags().GetBool("debug"); debug {
+				logrus.SetLevel(logrus.DebugLevel)
+			}
+			return nil
+		},
+	}
+
+	cmd.AddCommand(registry.NewOpmRegistryCmd(), alpha.NewCmd())
+	index.AddCommand(cmd)
+	version.AddCommand(cmd)
+
+	cmd.Flags().Bool("debug", false, "enable debug logging")
+	if err := cmd.Flags().MarkHidden("debug"); err != nil {
+		logrus.Panic(err.Error())
+	}
+
+	return cmd
+}

--- a/pkg/image/containerdregistry/registry.go
+++ b/pkg/image/containerdregistry/registry.go
@@ -42,7 +42,7 @@ func (r *Registry) Pull(ctx context.Context, ref image.Reference) error {
 	if err != nil {
 		return fmt.Errorf("error resolving name %s: %v", name, err)
 	}
-	r.log.Infof("resolved name: %s", name)
+	r.log.Debugf("resolved name: %s", name)
 
 	fetcher, err := r.resolver.Fetcher(ctx, name)
 	if err != nil {
@@ -82,7 +82,7 @@ func (r *Registry) Unpack(ctx context.Context, ref image.Reference, dir string) 
 	}
 
 	for _, layer := range manifest.Layers {
-		r.log.Infof("unpacking layer: %v", layer)
+		r.log.Debugf("unpacking layer: %v", layer)
 		if err := r.unpackLayer(ctx, layer, dir); err != nil {
 			return err
 		}
@@ -153,7 +153,7 @@ func (r *Registry) getImage(ctx context.Context, manifest ocispec.Manifest) (*oc
 
 func (r *Registry) fetch(ctx context.Context, fetcher remotes.Fetcher, root ocispec.Descriptor) error {
 	visitor := images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-		r.log.WithField("digest", desc.Digest).Info("fetched")
+		r.log.WithField("digest", desc.Digest).Debug("fetched")
 		r.log.Debug(desc)
 		return nil, nil
 	})

--- a/pkg/lib/bundle/validate.go
+++ b/pkg/lib/bundle/validate.go
@@ -146,7 +146,7 @@ func (i imageValidator) ValidateBundleFormat(directory string) error {
 	if !annotationsFound {
 		validationErrors = append(validationErrors, fmt.Errorf("Could not find annotations file"))
 	} else {
-		i.logger.Info("Found annotations file")
+		i.logger.Debug("Found annotations file")
 		errs := validateAnnotations(mediaType, fileAnnotations)
 		if errs != nil {
 			validationErrors = append(validationErrors, errs...)
@@ -154,9 +154,9 @@ func (i imageValidator) ValidateBundleFormat(directory string) error {
 	}
 
 	if !dependenciesFound {
-		i.logger.Info("Could not find optional dependencies file")
+		i.logger.Debug("Could not find optional dependencies file")
 	} else {
-		i.logger.Info("Found dependencies file")
+		i.logger.Debug("Found dependencies file")
 		errs := validateDependencies(dependenciesFile)
 		if errs != nil {
 			validationErrors = append(validationErrors, errs...)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -8,6 +8,9 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+
+	opmroot "github.com/operator-framework/operator-registry/cmd/opm/root"
 )
 
 // quay.io is the default registry used if no local registry endpoint is provided
@@ -18,6 +21,9 @@ var (
 	dockerUsername = os.Getenv("DOCKER_USERNAME")
 	dockerPassword = os.Getenv("DOCKER_PASSWORD")
 	dockerHost     = os.Getenv("DOCKER_REGISTRY_HOST") // 'DOCKER_HOST' is reserved for the docker daemon
+
+	// opm command under test.
+	opm *cobra.Command
 )
 
 func TestE2E(t *testing.T) {
@@ -26,6 +32,13 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	// Configure test registry (hostnames, credentials, etc.)
+	configureRegistry()
+
+	opm = opmroot.NewCmd() // Creating multiple instances would cause flag registration conflicts
+})
+
+func configureRegistry() {
 	switch {
 	case dockerUsername == "" && dockerPassword == "" && dockerHost == "":
 		// No registry credentials or local registry host provided
@@ -46,4 +59,4 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred(), "Error logging into %s: %s", dockerHost, out)
 
 	By(fmt.Sprintf("Using container image registry %s", dockerHost))
-})
+}

--- a/test/e2e/opm_bundle_test.go
+++ b/test/e2e/opm_bundle_test.go
@@ -1,0 +1,122 @@
+package e2e_test
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"golang.org/x/mod/sumdb/dirhash"
+
+	libimage "github.com/operator-framework/operator-registry/pkg/lib/image"
+)
+
+var _ = Describe("opm alpha bundle", func() {
+	// out captures opm command output
+	var out bytes.Buffer
+
+	BeforeEach(func() {
+		// Reset the command's output buffer
+		out = bytes.Buffer{}
+		opm.SetOut(&out)
+		opm.SetErr(&out)
+	})
+
+	Context("for an invalid bundle", func() {
+		var (
+			bundleRef      string
+			bundleChecksum string
+			tmpDir         string
+			rootCA         string
+			stopRegistry   func()
+		)
+
+		BeforeEach(func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			stopRegistry = func() {
+				cancel()
+				<-ctx.Done()
+			}
+
+			// Spin up an in-process docker registry with a set of preconfigured test images
+			var (
+				// Directory containing the docker registry filesystem
+				goldenFiles = "../../pkg/image/testdata/golden"
+
+				host string
+				err  error
+			)
+			host, rootCA, err = libimage.RunDockerRegistry(ctx, goldenFiles)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create a bundle ref using the local registry host name and the namespace/name of a bundle we already know the content of
+			bundleRef = host + "/olmtest/kiali@sha256:a1bec450c104ceddbb25b252275eb59f1f1e6ca68e0ced76462042f72f7057d8"
+
+			// Generate a checksum of the expected content for the bundle under test
+			bundleChecksum, err = dirhash.HashDir(filepath.Join(goldenFiles, "bundles/kiali"), "", dirhash.DefaultHash)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Set up a temporary directory that we can use for testing
+			tmpDir, err = ioutil.TempDir("", "opm-alpha-bundle-")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			stopRegistry()
+			if CurrentGinkgoTestDescription().Failed {
+				// Skip additional cleanup
+				return
+			}
+
+			Expect(os.RemoveAll(tmpDir)).To(Succeed())
+		})
+
+		It("fails to unpack", func() {
+			unpackDir := filepath.Join(tmpDir, "unpacked")
+			opm.SetArgs([]string{
+				"alpha",
+				"bundle",
+				"unpack",
+				"--root-ca",
+				rootCA,
+				"--out",
+				unpackDir,
+				bundleRef,
+			})
+
+			Expect(opm.Execute()).ToNot(Succeed())
+			result, err := ioutil.ReadAll(&out)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(result)).To(ContainSubstring("bundle content validation failed"))
+		})
+
+		It("unpacks successfully", func() {
+			By("setting --skip-validation")
+
+			unpackDir := filepath.Join(tmpDir, "unpacked")
+			opm.SetArgs([]string{
+				"alpha",
+				"bundle",
+				"unpack",
+				"--root-ca",
+				rootCA,
+				"--out",
+				unpackDir,
+				bundleRef,
+				"--skip-validation",
+			})
+
+			Expect(opm.Execute()).To(Succeed())
+			result, err := ioutil.ReadAll(&out)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).ToNot(ContainSubstring("bundle content validation failed"))
+
+			checksum, err := dirhash.HashDir(unpackDir, "", dirhash.DefaultHash)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(checksum).To(Equal(bundleChecksum))
+		})
+	})
+})


### PR DESCRIPTION
Add a new command `opm alpha bundle unpack` that pulls and unpacks bundle image content to a local filesystem.

```sh
$ opm alpha bundle unpack --help
Unpacks the content of an operator bundle into a directory

Usage:
  opm alpha bundle unpack BUNDLE_NAME[:TAG|@DIGEST] [flags]

Flags:
  -d, --debug             enable debug log output
  -h, --help              help for unpack
  -o, --out string        directory in which to unpack operator bundle content (default "./")
  -v, --skip-validation   disable bundle validation

Global Flags:
      --skip-tls   skip TLS certificate verification for container image registries while pulling bundles or index

```
