### PR TITLE
Bug 1870378: add quotes to semver range example

### DIFF
--- a/docs/design/operator-bundle.md
+++ b/docs/design/operator-bundle.md
@@ -78,7 +78,7 @@ dependencies:
   - type: olm.package
     value:
       packageName: prometheus
-      version: >0.27.0
+      version: ">0.27.0"
   - type: olm.gvk
     value:
       group: etcd.database.coreos.com


### PR DESCRIPTION
Without that, it's causing a YAML/JSON conversion issue:
Error: error converting YAML to JSON: yaml: line 5: found an indentation indicator equal to 0