### PR TITLE
Add USER for non-root image usage

### DIFF
--- a/configmap-registry.Dockerfile
+++ b/configmap-registry.Dockerfile
@@ -7,4 +7,5 @@ COPY --from=builder /bin/opm /bin/opm
 COPY --from=userspace /bin/cp /bin/cp
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
+USER 1001
 ENTRYPOINT ["/bin/configmap-server"]


### PR DESCRIPTION
Fixes https://github.com/operator-framework/operator-registry/issues/424

**Description of the change:**

run the configmap operator registry image with non-root user account

**Motivation for the change:**

Using root is a potential security violation

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage **N/A**
- [x] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs`  **N/A**
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
