### PR TITLE
Bug 1873916: Display the deprecatetruncate command

### DIFF
--- a/cmd/opm/index/deprecatetruncate.go
+++ b/cmd/opm/index/deprecatetruncate.go
@@ -30,7 +30,7 @@ var deprecateLong = templates.LongDesc(`
 
 func newIndexDeprecateTruncateCmd() *cobra.Command {
 	indexCmd := &cobra.Command{
-		Hidden: true,
+		Hidden: false,
 		Use:    "deprecatetruncate",
 		Short:  "Deprecate and truncate operator bundles from an index.",
 		Long:   deprecateLong,


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
After this PR, it will display the `deprecatetruncate` sub-command in the output of the `opm index --help`
```console
mac:operator-registry jianzhang$ ./bin/opm index --help
generate operator index container images from preexisting operator bundles

Usage:
  opm index [command]

Available Commands:
  add               Add operator bundles to an index.
  deprecatetruncate Deprecate and truncate operator bundles from an index.
  export            Export an operator from an index into the appregistry format
  prune             prune an index of all but specified packages
  prune-stranded    prune an index of stranded bundles
  rm                delete an entire operator from an inde
```

**Motivation for the change:**
Let the end user aware of this command easily.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
