### PR TITLE
Bug 1880127: Parallelize opm index export

### DIFF
--- a/pkg/lib/bundle/exporter.go
+++ b/pkg/lib/bundle/exporter.go
@@ -44,7 +44,7 @@ func (i *BundleExporter) Export() error {
 	var rerr error
 	switch i.containerTool {
 	case containertools.NoneTool:
-		reg, rerr = containerdregistry.NewRegistry(containerdregistry.WithLog(log))
+		reg, rerr = containerdregistry.NewRegistry(containerdregistry.WithLog(log), containerdregistry.WithCacheDir(filepath.Join(tmpDir, "cacheDir")))
 	case containertools.PodmanTool:
 		fallthrough
 	case containertools.DockerTool:

--- a/pkg/lib/indexer/indexer_test.go
+++ b/pkg/lib/indexer/indexer_test.go
@@ -30,10 +30,16 @@ func TestGetBundlesToExport(t *testing.T) {
 		t.Fatalf("creating querier: %s", err)
 	}
 
-	bundleImages, err := getBundlesToExport(dbQuerier, "etcd")
+	bundleMap, err := getBundlesToExport(dbQuerier, []string {"etcd"})
 	if err != nil {
 		t.Fatalf("exporting bundles from db: %s", err)
 	}
+
+	var bundleImages []string
+	for bundlePath, _ := range bundleMap {
+		bundleImages = append(bundleImages, bundlePath)
+	}
+
 	sort.Strings(bundleImages)
 
 	if !reflect.DeepEqual(expected, bundleImages) {


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This PR modifies `opm index export` to ensure exporting is done in parallel with an intent to cut down the overall time taken. It is achieved by the following two changes:
1. Make `--package` flag of the `opm index export` optional and allow comma-separated values
2. Parallelize the `ExportFromIndex` API

With this change, the export is possible by just specifying the index-image

**Motivation for the change:**
Unpacking and exporting of community operators takes >2hrs as it is done synchronously

Signed-off-by: Harish <hgovinda@redhat.com>


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
