### PR TITLE
Bug 1875557: add mac and windows binaries to the amd64 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.6 as builder
-
-RUN yum update -y && \
-    yum install -y sqlite && \
-    yum groupinstall -y "Development Tools"
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.6-clang as builder
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
@@ -13,25 +9,15 @@ COPY vendor vendor
 COPY cmd cmd
 COPY pkg pkg
 COPY Makefile go.mod go.sum ./
-RUN make build
+RUN make build cross
 
 # copy and build vendored grpc_health_probe
 RUN CGO_ENABLED=0 go build -mod=vendor -tags netgo -ldflags "-w" ./vendor/github.com/grpc-ecosystem/grpc-health-probe/...
 
 FROM registry.svc.ci.openshift.org/ocp/4.6:base
 
-RUN mkdir /registry
-WORKDIR /registry
-
-COPY --from=builder /src/bin/initializer /bin/initializer
-COPY --from=builder /src/bin/registry-server /bin/registry-server
-COPY --from=builder /src/bin/configmap-server /bin/configmap-server
-COPY --from=builder /src/bin/appregistry-server /bin/appregistry-server
-COPY --from=builder /src/bin/opm /bin/opm
+COPY --from=builder /src/bin /bin
 COPY --from=builder /src/grpc-health-probe /bin/grpc_health_probe
-
-RUN chgrp -R 0 /registry && \
-    chmod -R g+rwx /registry
 
 # This image doesn't need to run as root user
 USER 1001
@@ -42,6 +28,6 @@ ENTRYPOINT ["/bin/registry-server"]
 CMD ["--database", "/bundles.db"]
 
 LABEL io.k8s.display-name="OpenShift Operator Registry" \
-    io.k8s.description="This is a component of OpenShift Operator Lifecycle Manager and is the base for operator catalog API containers." \
-    maintainer="Odin Team <aos-odin@redhat.com>" \
-    summary="Operator Registry runs in a Kubernetes or OpenShift cluster to provide operator catalog data to Operator Lifecycle Manager."
+      io.k8s.description="This is a component of OpenShift Operator Lifecycle Manager and is the base for operator catalog API containers." \
+      maintainer="Odin Team <aos-odin@redhat.com>" \
+      summary="Operator Registry runs in a Kubernetes or OpenShift cluster to provide operator catalog data to Operator Lifecycle Manager."

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,14 @@ $(OPM):
 .PHONY: build
 build: clean $(CMDS) $(OPM)
 
+.PHONY: cross
+cross: opm_version_flags=-ldflags "-X '$(PKG)/cmd/opm/version.gitCommit=$(GIT_COMMIT)' -X '$(PKG)/cmd/opm/version.opmVersion=$(OPM_VERSION)' -X '$(PKG)/cmd/opm/version.buildDate=$(BUILD_DATE)'"
+cross:
+ifeq ($(shell go env GOARCH),amd64)
+	GOOS=darwin CC=o64-clang CXX=o64-clang++ CGO_ENABLED=1 $(GO) build $(opm_version_flags) $(TAGS) -o "$(PKG)/bin/darwin-amd64-opm" --ldflags "-extld=o64-clang" ./cmd/opm
+	GOOS=windows CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ CGO_ENABLED=1 $(GO) build $(opm_version_flags) $(TAGS)  -o "$(PKG)/bin/windows-amd64-opm" --ldflags "-extld=x86_64-w64-mingw32-gcc" ./cmd/opm
+endif
+
 .PHONY: static
 static: extra_flags=-ldflags '-w -extldflags "-static"' -tags "json1"
 static: build


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Adds mac and windows builds of `opm` to the downstream image.

**Motivation for the change:**
This will allow publishing downstream binaries of `opm`

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
