### PR TITLE
Add ConsoleYamlSamples to the supported resources

### DIFF
--- a/pkg/lib/bundle/supported_resources.go
+++ b/pkg/lib/bundle/supported_resources.go
@@ -16,6 +16,7 @@ const (
 	PodDisruptionBudgetKind   = "PodDisruptionBudget"
 	PriorityClassKind         = "PriorityClass"
 	VerticalPodAutoscalerKind = "VerticalPodAutoscaler"
+	ConsoleYamlSampleKind     = "ConsoleYamlSample"
 )
 
 // Namespaced indicates whether the resource is namespace scoped (true) or cluster-scoped (false).
@@ -39,6 +40,7 @@ var supportedResources = map[string]Namespaced{
 	PodDisruptionBudgetKind:   true,
 	PriorityClassKind:         false,
 	VerticalPodAutoscalerKind: false,
+	ConsoleYamlSampleKind:     false,
 }
 
 // IsSupported checks if the object kind is OLM-supported and if it is namespaced


### PR DESCRIPTION
**Description of the change:**
Allow the inclusion of samples in the bundle manifest

https://github.com/operator-framework/operator-lifecycle-manager/issues/1615

**Motivation for the change:**
Ease of deployment of samples for the console

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

