### PR TITLE
Bug 1877603: add workdir permissions back

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,10 @@ RUN CGO_ENABLED=0 go build -mod=vendor -tags netgo -ldflags "-w" ./vendor/github
 
 FROM registry.svc.ci.openshift.org/ocp/4.6:base
 
-COPY --from=builder /src/bin/* /bin/
+COPY --from=builder /src/bin/* /tmp/bin/
 COPY --from=builder /src/grpc-health-probe /bin/grpc_health_probe
+
+RUN cp -avr /tmp/bin/. /bin/
 
 RUN mkdir /registry
 RUN chgrp -R 0 /registry && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,11 @@ FROM registry.svc.ci.openshift.org/ocp/4.6:base
 COPY --from=builder /src/bin/* /bin/
 COPY --from=builder /src/grpc-health-probe /bin/grpc_health_probe
 
+RUN mkdir /registry
+RUN chgrp -R 0 /registry && \
+    chmod -R g+rwx /registry
+WORKDIR /registry
+
 # This image doesn't need to run as root user
 USER 1001
 


### PR DESCRIPTION


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**
configmap-registry-server needs to write a db file to the workdir

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
