### PR TITLE
Use multi-stage build for registry image.

### DIFF
--- a/upstream-builder.Dockerfile
+++ b/upstream-builder.Dockerfile
@@ -13,7 +13,7 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-$(go env GOARCH) && \
     chmod +x /bin/grpc_health_probe
 
-FROM golang:1.13-alpine
+FROM alpine:3
 
 COPY --from=builder [ \
     "/bin/grpc_health_probe", \

--- a/upstream-builder.Dockerfile
+++ b/upstream-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine
+FROM golang:1.13-alpine as builder
 
 RUN apk update && apk add sqlite build-base git mercurial bash
 WORKDIR /build
@@ -12,8 +12,15 @@ RUN make static
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-$(go env GOARCH) && \
     chmod +x /bin/grpc_health_probe
-RUN cp /build/bin/opm /bin/opm && \
-    cp /build/bin/initializer /bin/initializer && \
-    cp /build/bin/appregistry-server /bin/appregistry-server && \
-    cp /build/bin/configmap-server /bin/configmap-server && \
-    cp /build/bin/registry-server /bin/registry-server
+
+FROM golang:1.13-alpine
+
+COPY --from=builder [ \
+    "/bin/grpc_health_probe", \
+    "/build/bin/opm", \
+    "/build/bin/initializer", \
+    "/build/bin/appregistry-server", \
+    "/build/bin/configmap-server", \
+    "/build/bin/registry-server", \
+    "/bin/" \
+]


### PR DESCRIPTION
The upstream-registry-builder image is bigger than it needs to be, and
about half of its size seems to be coming from unused build
artifacts. Putting all of that in a separate builder stage cuts the
size of the final image by about half.
