### PR TITLE
Adds new log level (WARN) to initializer/main.go

### DIFF
--- a/cmd/initializer/main.go
+++ b/cmd/initializer/main.go
@@ -29,6 +29,7 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.Flags().Bool("debug", false, "enable debug logging")
+	rootCmd.Flags().Bool("warn", false, "enable warnings only logging")
 	rootCmd.Flags().StringP("manifests", "m", "manifests", "relative path to directory of manifests")
 	rootCmd.Flags().StringP("output", "o", "bundles.db", "relative path to a sqlite file to create or overwrite")
 	rootCmd.Flags().Bool("permissive", false, "allow registry load errors")

--- a/cmd/initializer/main.go
+++ b/cmd/initializer/main.go
@@ -18,7 +18,9 @@ var rootCmd = &cobra.Command{
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if debug, _ := cmd.Flags().GetBool("debug"); debug {
 			logrus.SetLevel(logrus.DebugLevel)
-		}
+		} else if warn, _ := cmd.Flags().GetBool("warn"); warn {
+                        logrus.SetLevel(logrus.WarnLevel)
+                }
 		return nil
 	},
 


### PR DESCRIPTION
**Description of the change:**
Adds a _Warning_ log level to the ` initializer/main.go`, using the flag `--warn`

**Motivation for the change:**
This really helps when the operator registry catalog manifest contains a large amount of CSV files. Not having a log level above INFO creates a big dump of logs in the CICD job logs (which makes debugging any errors difficult). Setting it to WARN ensures that only WARNINGS, ERRORS, FATALS and PANICS are reported (in case of actual errors)

