### PR TITLE
Bug 1882103: image missing /etc/nsswitch.conf

### DIFF
--- a/upstream-builder.Dockerfile
+++ b/upstream-builder.Dockerfile
@@ -15,6 +15,8 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
 
 FROM alpine:3
 
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
 COPY --from=builder [ \
     "/bin/grpc_health_probe", \
     "/build/bin/opm", \


### PR DESCRIPTION
**Description of the change:**
Adding a basic `/etc/nsswitch.conf` file to the image.

**Motivation for the change:**
The SDK creates an ephemeral index to facilate running packagemanifests.
We currently use this image to build that ephemeral index. In kind
cluster, it works fine in a kind cluster without the nsswitch file, but
not in OCP.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

