### PR TITLE
Bug 1883329: Bundle validation shouldn't fail if default channel is not provided

### DIFF
--- a/pkg/lib/bundle/testdata/validate/invalid_annotations_bundle/metadata/annotations.yaml
+++ b/pkg/lib/bundle/testdata/validate/invalid_annotations_bundle/metadata/annotations.yaml
@@ -1,5 +1,4 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: stable
   operators.operatorframework.io.bundle.channels.v1: stable,beta
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v2

--- a/pkg/lib/bundle/validate.go
+++ b/pkg/lib/bundle/validate.go
@@ -207,7 +207,7 @@ func validateAnnotations(mediaType string, fileAnnotations *AnnotationMetadata) 
 				validationErrors = append(validationErrors, aErr)
 			}
 		case ChannelDefaultLabel:
-			if val == "" {
+			if ok && val == "" {
 				aErr := fmt.Errorf("Expecting annotation %q to have non-empty value", label)
 				validationErrors = append(validationErrors, aErr)
 			}


### PR DESCRIPTION
Default channel annotation is now optional. It is only needed if
there is an intention to update default channel in the index.
As a result, bundle validation will allow default channel annotation
to be missing.

Signed-off-by: Vu Dinh <vdinh@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
