### PR TITLE
Bug 1883560: fix(dockerfile): clean out tmp directory after binaries are placed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM registry.svc.ci.openshift.org/ocp/4.6:base
 COPY --from=builder /src/bin/* /tmp/bin/
 COPY --from=builder /src/grpc-health-probe /bin/grpc_health_probe
 
-RUN cp -avr /tmp/bin/. /bin/
+RUN cp -avr /tmp/bin/. /bin/ && rm -rf /tmp/bin
 
 RUN mkdir /registry
 RUN chgrp -R 0 /registry && \


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Remove bins from /tmp after they've been moved into the correct location

**Motivation for the change:**
The image was much larger than it needed to be.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
