### PR TITLE
feat: index image opm compatibility e2e test

### DIFF
--- a/pkg/lib/indexer/indexer.go
+++ b/pkg/lib/indexer/indexer.go
@@ -696,3 +696,20 @@ func (i ImageIndexer) DeprecateFromIndex(request DeprecateFromIndexRequest) erro
 
 	return nil
 }
+
+// ExtractDatabase is a wrapper around i.extractDatabase that extracts the db to <directory>/database.db
+// TODO add an indexer command to expose this functionality to opm users?
+func ExtractDatabase(index, directory, cert, containerTool string, skipTLS bool) (string, error) {
+	t := containertools.NewCommandContainerTool(containerTool)
+	i := ImageIndexer{
+		Logger:   logrus.WithFields(logrus.Fields{"database": index}),
+		PullTool: t,
+	}
+
+	dbPath, err := i.extractDatabase(directory, index, cert, skipTLS)
+	if err != nil {
+		return "", fmt.Errorf("extracting db from index: %w", err)
+	}
+
+	return dbPath, nil
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -12,6 +12,8 @@ import (
 var (
 	dockerUsername = os.Getenv("DOCKER_USERNAME")
 	dockerPassword = os.Getenv("DOCKER_PASSWORD")
+	redhatRegistryUsername = os.Getenv("REDHAT_REGISTRY_USERNAME")
+	redhatRegistryPassword = os.Getenv("REDHAT_REGISTRY_PASSWORD")
 )
 
 func TestE2E(t *testing.T) {


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This is to help ensure that no changes are introduced into operator-registry that cause a problem for indexes.
The test measures startup success (meaning that the latest production index data can be properly handled by `opm registry serve`)

Test requirements:
* REDHAT_REGISTRY_USERNAME and REDHAT_REGISTRY_PASSWORD environmental variables be added to registry CI. I have tokens associated with my personal redhat account that we could use, or make new ones. 
* Due to https://github.com/moby/moby/issues/35987 we must be root user when copying some read-only files out of the 4.6 index image (which is based off the UBI image). This means having to use `sudo -E <env variables>` when running this test locally, which isn't great. Hopefully in CI we already run the tests as root user. 

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
