### PR TITLE
Make the inability to create /etc/nsswitch.conf non-fatal.

### DIFF
--- a/appr-registry.Dockerfile
+++ b/appr-registry.Dockerfile
@@ -22,6 +22,7 @@ COPY --from=builder /go/src/github.com/operator-framework/operator-registry/vend
 RUN CGO_ENABLED=0 go install -a -tags netgo -ldflags "-w"
 
 FROM scratch
+COPY ["nsswitch.conf", "/etc/nsswitch.conf"]
 COPY --from=builder /go/src/github.com/operator-framework/operator-registry/bin/appregistry-server /bin/appregistry-server
 COPY --from=probe-builder /go/bin/grpc-health-probe /bin/grpc_health_probe
 EXPOSE 50051

--- a/cmd/appregistry-server/main.go
+++ b/cmd/appregistry-server/main.go
@@ -65,7 +65,7 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 	}
 	// Ensure there is a default nsswitch config
 	if err := dns.EnsureNsswitch(); err != nil {
-		return err
+		logrus.WithError(err).Warn("unable to write default nsswitch config")
 	}
 	kubeconfig, err := cmd.Flags().GetString("kubeconfig")
 	if err != nil {

--- a/cmd/configmap-server/main.go
+++ b/cmd/configmap-server/main.go
@@ -71,7 +71,7 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 	}
 	// Ensure there is a default nsswitch config
 	if err := dns.EnsureNsswitch(); err != nil {
-		return err
+		logrus.WithError(err).Warn("unable to write default nsswitch config")
 	}
 	kubeconfig, err := cmd.Flags().GetString("kubeconfig")
 	if err != nil {

--- a/cmd/opm/registry/serve.go
+++ b/cmd/opm/registry/serve.go
@@ -63,7 +63,7 @@ func serveFunc(cmd *cobra.Command, args []string) error {
 
 	// Ensure there is a default nsswitch config
 	if err := dns.EnsureNsswitch(); err != nil {
-		return err
+		logrus.WithError(err).Warn("unable to write default nsswitch config")
 	}
 
 	dbName, err := cmd.Flags().GetString("database")

--- a/cmd/registry-server/main.go
+++ b/cmd/registry-server/main.go
@@ -65,7 +65,7 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 	}
 	// Ensure there is a default nsswitch config
 	if err := dns.EnsureNsswitch(); err != nil {
-		return err
+		logrus.WithError(err).Warn("unable to write default nsswitch config")
 	}
 	dbName, err := cmd.Flags().GetString("database")
 	if err != nil {

--- a/configmap-registry.Dockerfile
+++ b/configmap-registry.Dockerfile
@@ -2,6 +2,7 @@ FROM quay.io/operator-framework/upstream-registry-builder:latest as builder
 FROM busybox as userspace
 
 FROM scratch
+COPY ["nsswitch.conf", "/etc/nsswitch.conf"]
 COPY --from=builder /bin/configmap-server /bin/configmap-server
 COPY --from=builder /bin/opm /bin/opm
 COPY --from=userspace /bin/cp /bin/cp

--- a/index.Dockerfile
+++ b/index.Dockerfile
@@ -2,6 +2,7 @@ FROM quay.io/operator-framework/upstream-registry-builder AS builder
 
 FROM scratch
 LABEL operators.operatorframework.io.index.database.v1=./index.db
+COPY ["nsswitch.conf", "/etc/nsswitch.conf"]
 COPY database ./
 COPY --from=builder /bin/opm /opm
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/nsswitch.conf
+++ b/nsswitch.conf
@@ -1,0 +1,1 @@
+hosts: files dns

--- a/opm-example.Dockerfile
+++ b/opm-example.Dockerfile
@@ -2,6 +2,7 @@ FROM quay.io/operator-framework/upstream-opm-builder AS builder
 
 FROM scratch
 LABEL operators.operatorframework.io.index.database.v1=./index.db
+COPY ["nsswitch.conf", "/etc/nsswitch.conf"]
 COPY database ./
 COPY --from=builder /bin/opm /opm
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/registry.Dockerfile
+++ b/registry.Dockerfile
@@ -14,6 +14,7 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
     chmod +x /bin/grpc_health_probe
 
 FROM scratch
+COPY ["nsswitch.conf", "/etc/nsswitch.conf"]
 COPY --from=builder /build/bin/registry-server /registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051

--- a/upstream-builder.Dockerfile
+++ b/upstream-builder.Dockerfile
@@ -15,6 +15,8 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
 
 FROM alpine:3
 
+COPY ["nsswitch.conf", "/etc/nsswitch.conf"]
+
 RUN chgrp -R 0 /etc && \
     chmod -R g+rwx /etc
 

--- a/upstream-example.Dockerfile
+++ b/upstream-example.Dockerfile
@@ -4,6 +4,7 @@ COPY manifests manifests
 RUN /bin/initializer -o ./bundles.db
 
 FROM scratch
+COPY ["nsswitch.conf", "/etc/nsswitch.conf"]
 COPY --from=builder /build/bundles.db /bundles.db
 COPY --from=builder /bin/registry-server /registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/upstream-opm-builder.Dockerfile
+++ b/upstream-opm-builder.Dockerfile
@@ -15,5 +15,6 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
 
 FROM alpine
 RUN apk update && apk add ca-certificates
+COPY ["nsswitch.conf", "/etc/nsswitch.conf"]
 COPY --from=builder /build/bin/opm /bin/opm
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe


### PR DESCRIPTION
Images run as non-root were not allowed to write to
/etc/nsswitch.conf, which had been considered required. Instead, the
scratch/non-glibc images published by the Operator Framework project
now include a default nsswitch config file, and runtime creation of a
default nsswitch config file is now best-effort.
