### PR TITLE
Add writable workdir to configmap registry image.

### DIFF
--- a/configmap-registry.Dockerfile
+++ b/configmap-registry.Dockerfile
@@ -7,6 +7,8 @@ COPY --from=builder /bin/configmap-server /bin/configmap-server
 COPY --from=builder /bin/opm /bin/opm
 COPY --from=userspace /bin/cp /bin/cp
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
+COPY --from=userspace --chown=1001:1001 ["/tmp", "/work"]
 EXPOSE 50051
 USER 1001
+WORKDIR /work
 ENTRYPOINT ["/bin/configmap-server"]


### PR DESCRIPTION
The configmap registry server expects to be able to write a file to
its working directory. Since it no longer runs as root, it can't write
to /.
