### PR TITLE
Bug 1885425: fix(indexing): include skips in bulk add order

### DIFF
--- a/pkg/registry/replacesgraphloader.go
+++ b/pkg/registry/replacesgraphloader.go
@@ -2,29 +2,197 @@ package registry
 
 import (
 	"fmt"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
-type ReplacesGraphLoader struct {
+type ReplacesInputStream struct {
+	graph    GraphLoader
+	packages map[string]map[string]*ImageInput
 }
 
-// CanAdd checks that a new bundle can be added in replaces mode (i.e. the replaces
-// defined for the bundle already exists)
-func (r *ReplacesGraphLoader) CanAdd(bundle *Bundle, graph *Package) (bool, error) {
-	replaces, err := bundle.Replaces()
-	if err != nil {
-		return false, fmt.Errorf("Invalid content, unable to parse bundle")
+func NewReplacesInputStream(graph GraphLoader, toAdd []*ImageInput) (*ReplacesInputStream, error) {
+	stream := &ReplacesInputStream{
+		graph:    graph,
+		packages: map[string]map[string]*ImageInput{},
 	}
 
-	// adding the first bundle in the graph
-	if replaces == "" {
+	// Sort the bundle images into buckets by package
+	for _, image := range toAdd {
+		pkg := image.Bundle.Package
+		if _, ok := stream.packages[pkg]; !ok {
+			stream.packages[pkg] = map[string]*ImageInput{}
+		}
+		stream.packages[pkg][image.Bundle.Name] = image
+	}
+
+	// Validate each package, dropping any invalid packages so that the stream can still be used with remaining packages.
+	var errs []error
+	for pkg, images := range stream.packages {
+		// Multiple input images require some ordering between them -- using skips and replaces -- to ensure an index add operation is deterministic
+		connected, err := graphConnected(images)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("Error determining connectedness of package graph %s: %s", pkg, err))
+			delete(stream.packages, pkg)
+			continue
+		}
+		if !connected {
+			errs = append(errs, fmt.Errorf("Given images for package %s do not form a connected graph, index add will be nondeterministic", pkg))
+			delete(stream.packages, pkg)
+		}
+	}
+
+	return stream, utilerrors.NewAggregate(errs)
+}
+
+// connected returns true if the given set of bundles forms a connected graph.
+func graphConnected(graph map[string]*ImageInput) (bool, error) {
+	if len(graph) <= 1 {
+		// Zero or one bundles will result in a deterministic add, and should be considered connected
 		return true, nil
 	}
 
-	// check that the bundle can be added
-	if !graph.HasCsv(replaces) {
-		return false, fmt.Errorf("Invalid bundle %s, bundle specifies a non-existent replacement %s", bundle.Name, replaces)
+	// For every bundle in the input, there should be at least one that we can traverse to all others from
+	for _, node := range graph {
+		size, err := graphSize(node.Bundle.Name, graph, map[string]struct{}{})
+		if err != nil {
+			return false, err
+		}
+		if size == len(graph) {
+			return true, nil
+		}
 	}
 
-	return true, nil
+	return false, nil
+}
 
+// graphSize performs a depth-first search of a graph and returns the number of nodes reachable from a starting node.
+// This is analogous to the "size" of the subgraph containing the starting node.
+func graphSize(current string, graph map[string]*ImageInput, visited map[string]struct{}) (size int, err error) {
+	c, ok := graph[current]
+	if !ok {
+		// The node doesn't exist, which means it's a skips w/o a matching entry or a replaces in the graph
+		// We handle these cases elsewhere, so don't mark them visited
+		return
+	}
+
+	if _, ok := visited[current]; ok {
+		// Cycles don't contribute to the size of a graph
+		return
+	}
+
+	// Discovered a new node, increase the size of the graph
+	visited[current] = struct{}{}
+	size++
+
+	// Gather edges
+	var replaces string
+	replaces, err = c.Bundle.Replaces()
+	if err != nil {
+		return
+	}
+
+	var skips []string
+	skips, err = c.Bundle.Skips()
+	if err != nil {
+		return
+	}
+
+	var (
+		subgraphSize int
+		neighbors    = append(skips, replaces)
+	)
+	for _, neighbor := range neighbors {
+		subgraphSize, err = graphSize(neighbor, graph, visited)
+		if err != nil {
+			return
+		}
+
+		// Incorporate the size of the subgraph
+		size += subgraphSize
+	}
+
+	return
+}
+
+// canAdd checks that a new bundle can be added in replaces mode (i.e. the replaces defined for the bundle already exists)
+func (r *ReplacesInputStream) canAdd(bundle *Bundle, packageGraph *Package) error {
+	replaces, err := bundle.Replaces()
+	if err != nil {
+		return fmt.Errorf("Invalid bundle replaces: %s", err)
+	}
+
+	if replaces != "" && !packageGraph.HasCsv(replaces) {
+		// We can't add this until a replacement exists
+		// TODO(njhale): should this really return an error, or just a boolean?
+		return fmt.Errorf("Invalid bundle %s, bundle specifies a non-existent replacement %s", bundle.Name, replaces)
+	}
+
+	skips, err := bundle.Skips()
+	if err != nil {
+		return fmt.Errorf("Invalid bundle skips: %s", err)
+	}
+
+	images, ok := r.packages[packageGraph.Name]
+	if !ok || images == nil {
+		// This shouldn't happen unless canAdd is being called without the correct setup
+		panic(fmt.Sprintf("Programmer error: package graph %s incorrectly initialized", packageGraph.Name))
+	}
+
+	for _, skip := range skips {
+		if _, ok := images[skip]; ok {
+			// Found an edge to a remaining input bundle, can't add this bundle yet
+			return fmt.Errorf("Invalid index add order for bundle %s, cannot be added before %s", bundle.Name, skip)
+		}
+	}
+
+	// No edges to any remaining input bundles, this bundle can be added
+	return nil
+}
+
+func (r *ReplacesInputStream) Next() (*ImageInput, error) {
+	var errs []error
+	for pkg, images := range r.packages {
+		if len(images) < 1 {
+			// No more images to add for this package, clean up
+			delete(r.packages, pkg)
+			continue
+		}
+
+		packageGraph, err := r.graph.Generate(pkg)
+		if err != nil {
+			// Can't parse this package any further
+			delete(r.packages, pkg)
+			errs = append(errs, err)
+			continue
+		}
+
+		// Find the next viable bundle to add
+		var packageErrs []error
+		for _, image := range images {
+			if err := r.canAdd(image.Bundle, packageGraph); err != nil {
+				// Can't parse this bundle any further right now
+				packageErrs = append(packageErrs, err)
+				continue
+			}
+
+			// Found something we can add
+			delete(r.packages[pkg], image.Bundle.Name)
+			return image, nil
+		}
+
+		// No viable bundle found in the package, can't parse it any further
+		if len(packageErrs) > 0 {
+			delete(r.packages, pkg)
+			errs = append(errs, packageErrs...)
+		}
+	}
+
+	// We've exhausted all valid input bundles, any errors here indicate invalid input of some kind
+	return nil, utilerrors.NewAggregate(errs)
+}
+
+// Empty returns true if there are no bundles in the stream.
+func (r *ReplacesInputStream) Empty() bool {
+	return len(r.packages) < 1
 }


### PR DESCRIPTION
**Description of the change:**

When adding more than one bundle to and index in replaces mode, use the skips field
to determine an insert order in the absence of replaces fields. This ensures a deterministic
update graph for authors who rely soley on the skips field to generate
edges.

**Motivation for the change:**

Some package maintainers rely on the `skip` field to generate graph edges and omit `replaces` entirely. Because of this, no ordering exists between input bundles on bulk index add operations This can lead to non-deterministic update graphs when the list of input bundles isn't given in the desired order for `opm index add`; e.g. OCP 4.6 index refresh jobs which bulk add an opaque set of bundles.