### PR TITLE
Add Github Actions release workflow.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,45 @@
+name: release
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+jobs:
+  create:
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.release.outputs.upload_url }}
+    steps:
+      - uses: actions/create-release@v1
+        id: release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          draft: true
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+  assets:
+    needs: create
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.15'
+      - run: |
+          echo "asset_path=bin/opm" >> $GITHUB_ENV
+          echo "asset_name=$(go env GOOS)-$(go env GOARCH)-opm$(go env GOEXE)" >> $GITHUB_ENV
+      - run: make ${{ env.asset_path }}
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ needs.create.outputs.upload_url }}
+          asset_path: ${{ env.asset_path }}
+          asset_name: ${{ env.asset_name }}
+          asset_content_type: application/octet-stream

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,16 +55,3 @@ script: |
   fi
 notifications:
   email: false
-before_deploy:
-- ls bin | xargs -n1 -I{} mv bin/{} "bin/$(go env GOOS)-$(go env GOARCH)-{}"
-deploy:
-  provider: releases
-  edge: true
-  token:
-    secure: 1mcUdIu9BBQloKWHEXIum9XFunDVDtWvbL5HuebsSJOlePTRnccBnhwwyxytkxO8bkWlB7RXRwa2JRKAOtrB2sgyvG4zthQeiyuq3qNRuZPyl/KxcHT5swYhwXaFy2kSmsG3WJy6Yx+Rw82yDelnyUkv2XcJODcU3Sf0CZIaYmCHmT9dFJ97yGd5x/Xbw+ApBIjRYQgL/NCXcvR/7ftIMUGcYc6zSMG9U6eWCvY28gZGhElvywbm51UuwOzK37jNKrp9xe4c+Fbp+7EqEUY4ooxCxX82PmJRDEcdjY0NLdafmPN40TA6oDB1873OEIWCa7+Lfn5k+X+JTcV/rPOfOIRB0vS04m5HWJONu4gNHB5lYl3DRHonbhF4X/hzkujlFGkWB/3XDwSj9X88McL0P7mwZsXV5KsiH7kqH3FTzlH2Fm3OTHhBOEJ1s+OEcwRlBRahh8LfzD6Da7BNncSWi2zdc7erD5WVmeiJngZXzGquo3Ly3GWB9Pfkd0rriclHC0CmIj5EeD7NBnrCu18dwdlKRR5L18dUmoLV1I/IUh0BIn0i7CNt3iw15LVX4Lk6wz2JzEfytGQ3GzfIf4cPjmGqIYwlOUuyiht7AyEUg3QIBiqTbU/PL+krvFhAtf3RkD7/5+NZF6VF4p4hYXJN0sGq3XOsN7Ol1nVvc6RpAlk=
-  file_glob: true
-  file: bin/**/*-opm
-  cleanup: false
-  on:
-    repo: operator-framework/operator-registry
-    tags: true


### PR DESCRIPTION
This also removes the old Travis release config. The new workflow triggers on semver-ish tags and creates releases as unpublished drafts (which require a separate "publish" decision).