### PR TITLE
Build upstream releases with Go 1.14 instead of 1.15.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.15'
+          go-version: '^1.14'
       - run: |
           echo "asset_path=bin/opm" >> $GITHUB_ENV
           echo "asset_name=$(go env GOOS)-$(go env GOARCH)-opm$(go env GOEXE)" >> $GITHUB_ENV


### PR DESCRIPTION
Darwin builds are broken by a bug that should be fixed in 1.15.4.
