### PR TITLE
Provide some initial codecov settings.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+codecov:
+  require_ci_to_pass: no
+  notify:
+    wait_for_ci: no
+coverage:
+  status:
+    patch:
+      default:
+        target: 70%
+        threshold: 0%
+        base: auto
+        branches:
+        - master
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: success
+        only_pulls: true


### PR DESCRIPTION
By default, the codecov project and patch statuses aren't set until
all checks finish. Since this includes the tide check, this means that
in practice the codecov statuses aren't set until they are no longer
useful.

The project check is now configured to always be green, and
the patch check will require at least 70% coverage to pass.
