### PR TITLE
Fix Go version used by release job to 1.14.z.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.14'
+          go-version: '~1.14'
       - run: |
           echo "asset_path=bin/opm" >> $GITHUB_ENV
           echo "asset_name=$(go env GOOS)-$(go env GOARCH)-opm$(go env GOEXE)" >> $GITHUB_ENV


### PR DESCRIPTION
The tilde
range (https://www.npmjs.com/package/semver#tilde-ranges-123-12-1)
should automatically allow for newer patch versions to be used, but
will require a config update to adopt 1.15.
