### PR TITLE
copy .git directory for build tag info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,7 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 WORKDIR /src
 
-COPY vendor vendor
-COPY cmd cmd
-COPY pkg pkg
-COPY Makefile go.mod go.sum ./
+COPY . .
 RUN make build cross
 
 # copy and build vendored grpc_health_probe

--- a/appr-registry.Dockerfile
+++ b/appr-registry.Dockerfile
@@ -3,11 +3,7 @@ FROM golang:1.13-alpine as builder
 RUN apk update && apk add sqlite build-base git mercurial bash
 WORKDIR /go/src/github.com/operator-framework/operator-registry
 
-COPY vendor vendor
-COPY cmd cmd
-COPY pkg pkg
-COPY Makefile Makefile
-COPY go.mod go.mod
+COPY . .
 RUN make static
 
 FROM golang:1.13-alpine as probe-builder

--- a/registry.Dockerfile
+++ b/registry.Dockerfile
@@ -3,11 +3,7 @@ FROM golang:1.13-alpine as builder
 RUN apk update && apk add sqlite build-base git mercurial bash
 WORKDIR /build
 
-COPY vendor vendor
-COPY cmd cmd
-COPY pkg pkg
-COPY Makefile Makefile
-COPY go.mod go.mod
+COPY . .
 RUN make static
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-$(go env GOARCH) && \

--- a/upstream-builder.Dockerfile
+++ b/upstream-builder.Dockerfile
@@ -3,11 +3,7 @@ FROM golang:1.13-alpine as builder
 RUN apk update && apk add sqlite build-base git mercurial bash
 WORKDIR /build
 
-COPY vendor vendor
-COPY cmd cmd
-COPY pkg pkg
-COPY Makefile Makefile
-COPY go.mod go.mod
+COPY . .
 RUN make static
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-$(go env GOARCH) && \

--- a/upstream-opm-builder.Dockerfile
+++ b/upstream-opm-builder.Dockerfile
@@ -3,11 +3,7 @@ FROM golang:1.13-alpine AS builder
 RUN apk update && apk add sqlite build-base git mercurial bash
 WORKDIR /build
 
-COPY vendor vendor
-COPY cmd cmd
-COPY pkg pkg
-COPY Makefile Makefile
-COPY go.mod go.mod
+COPY . .
 RUN make static
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-$(go env GOARCH) && \


### PR DESCRIPTION
Copy .git directory to intermediary build container to provide make with the tag and sha for an opm build.

Closes #507