### PR TITLE
Bug 1889388: Reconstruct replaces and skips for ListBundles from channel_entry.

### DIFF
--- a/pkg/sqlite/query_sql_test.go
+++ b/pkg/sqlite/query_sql_test.go
@@ -21,8 +21,8 @@ func TestListBundlesQuery(t *testing.T) {
 					`insert into package (name, default_channel) values ("package", "channel")`,
 					`insert into channel (name, package_name, head_operatorbundle_name) values ("channel", "package", "bundle")`,
 					`insert into operatorbundle (name) values ("bundle-a"), ("bundle-b")`,
-					`insert into channel_entry (package_name, channel_name, operatorbundle_name, entry_id, replaces) values ("package", "channel", "bundle-a", 1, 2)`,
-					`insert into channel_entry (package_name, channel_name, operatorbundle_name, entry_id) values ("package", "channel", "bundle-b", 2)`,
+					`insert into channel_entry (package_name, channel_name, operatorbundle_name, entry_id, depth, replaces) values ("package", "channel", "bundle-a", 1, 0, 2)`,
+					`insert into channel_entry (package_name, channel_name, operatorbundle_name, entry_id, depth) values ("package", "channel", "bundle-b", 2, 1)`,
 				} {
 					if _, err := db.Exec(stmt); err != nil {
 						t.Fatalf("unexpected error executing setup statements: %v", err)
@@ -32,8 +32,8 @@ func TestListBundlesQuery(t *testing.T) {
 			},
 			Expect: func(t *testing.T, rows *sql.Rows) {
 				replacements := map[sql.NullString]sql.NullString{
-					sql.NullString{String: "bundle-a", Valid: true}: sql.NullString{String: "bundle-b", Valid: true},
-					sql.NullString{String: "bundle-b", Valid: true}: sql.NullString{Valid: false},
+					{String: "bundle-a", Valid: true}: {String: "bundle-b", Valid: true},
+					{String: "bundle-b", Valid: true}: {Valid: false},
 				}
 				for rows.Next() {
 					var (
@@ -56,6 +56,71 @@ func TestListBundlesQuery(t *testing.T) {
 				}
 				for replacer, replacee := range replacements {
 					t.Errorf("missing expected result row: %v replaces %v", replacer, replacee)
+				}
+			},
+		},
+		{
+			Name: "skips populated from multiple channel entries",
+			Setup: func(t *testing.T, db *sql.DB) {
+				for _, stmt := range []string{
+					`insert into package (name, default_channel) values ("package", "channel")`,
+					`insert into channel (name, package_name, head_operatorbundle_name) values ("channel", "package", "bundle")`,
+					`insert into operatorbundle (name) values ("bundle-a"), ("bundle-b"), ("bundle-c")`,
+					`insert into channel_entry (package_name, channel_name, operatorbundle_name, entry_id, replaces) values ("package", "channel", "bundle-a", 1, 2)`,
+					`insert into channel_entry (package_name, channel_name, operatorbundle_name, entry_id) values ("package", "channel", "bundle-b", 2)`,
+					`insert into channel_entry (package_name, channel_name, operatorbundle_name, entry_id, replaces) values ("package", "channel", "bundle-a", 3, 4)`,
+					`insert into channel_entry (package_name, channel_name, operatorbundle_name, entry_id) values ("package", "channel", "bundle-c", 4)`,
+				} {
+					if _, err := db.Exec(stmt); err != nil {
+						t.Fatalf("unexpected error executing setup statements: %v", err)
+					}
+				}
+
+			},
+			Expect: func(t *testing.T, rows *sql.Rows) {
+				type result struct {
+					Name     sql.NullString
+					Replaces sql.NullString
+					Skips    sql.NullString
+				}
+				expected := map[sql.NullString]result{
+					{String: "bundle-a", Valid: true}: {
+						Name:     sql.NullString{String: "bundle-a", Valid: true},
+						Replaces: sql.NullString{Valid: false},
+						Skips:    sql.NullString{String: "bundle-b,bundle-c", Valid: true},
+					},
+					{String: "bundle-b", Valid: true}: {
+						Name:     sql.NullString{String: "bundle-b", Valid: true},
+						Replaces: sql.NullString{Valid: false},
+						Skips:    sql.NullString{Valid: false},
+					},
+					{String: "bundle-c", Valid: true}: {
+						Name:     sql.NullString{String: "bundle-c", Valid: true},
+						Replaces: sql.NullString{Valid: false},
+						Skips:    sql.NullString{Valid: false},
+					},
+				}
+				for rows.Next() {
+					var (
+						c      interface{}
+						actual result
+					)
+					if err := rows.Scan(&c, &c, &c, &actual.Name, &c, &c, &actual.Replaces, &actual.Skips, &c, &c, &c, &c, &c, &c); err != nil {
+						t.Fatalf("unexpected error during row scan: %v", err)
+					}
+					r, ok := expected[actual.Name]
+					if !ok {
+						t.Errorf("unexpected name: %v", actual.Name)
+						continue
+					}
+					delete(expected, actual.Name)
+					if actual != r {
+						t.Errorf("got row %v, expected %v for name %v", actual, r, actual.Name)
+						continue
+					}
+				}
+				for _, e := range expected {
+					t.Errorf("missing expected result row: %v", e)
 				}
 			},
 		},


### PR DESCRIPTION
The channel_entry table is authoritative on incoming upgrade edges to
a bundle, so the "skips" and "replaces" fields in bundles returned by
the ListBundles endpoint should be derived from channel_entry rather
than from operatorbundle.
