### PR TITLE
Bug 1868125: [opm] Add valid bundles to index when `permissive` enabled

### DIFF
--- a/pkg/lib/registry/registry.go
+++ b/pkg/lib/registry/registry.go
@@ -85,7 +85,7 @@ func (r RegistryUpdater) AddToRegistry(request AddToRegistryRequest) error {
 		simpleRefs = append(simpleRefs, image.SimpleReference(ref))
 	}
 
-	if err := populate(context.TODO(), dbLoader, graphLoader, dbQuerier, reg, simpleRefs, request.Mode, request.Overwrite); err != nil {
+	if err := populate(context.TODO(), dbLoader, graphLoader, dbQuerier, reg, simpleRefs, request.Mode, request.Overwrite, request.Permissive); err != nil {
 		r.Logger.Debugf("unable to populate database: %s", err)
 
 		if !request.Permissive {
@@ -125,7 +125,7 @@ func unpackImage(ctx context.Context, reg image.Registry, ref image.Reference) (
 	return ref, workingDir, cleanup, nil
 }
 
-func populate(ctx context.Context, loader registry.Load, graphLoader registry.GraphLoader, querier registry.Query, reg image.Registry, refs []image.Reference, mode registry.Mode, overwrite bool) error {
+func populate(ctx context.Context, loader registry.Load, graphLoader registry.GraphLoader, querier registry.Query, reg image.Registry, refs []image.Reference, mode registry.Mode, overwrite, permissive bool) error {
 	unpackedImageMap := make(map[image.Reference]string, 0)
 	for _, ref := range refs {
 		to, from, cleanup, err := unpackImage(ctx, reg, ref)
@@ -195,7 +195,7 @@ func populate(ctx context.Context, loader registry.Load, graphLoader registry.Gr
 		}
 	}
 
-	populator := registry.NewDirectoryPopulator(loader, graphLoader, querier, unpackedImageMap, overwriteImageMap, overwrite)
+	populator := registry.NewDirectoryPopulator(loader, graphLoader, querier, unpackedImageMap, overwriteImageMap, overwrite, permissive)
 	return populator.Populate(mode)
 }
 

--- a/pkg/registry/populator_test.go
+++ b/pkg/registry/populator_test.go
@@ -73,7 +73,7 @@ func createAndPopulateDB(db *sql.DB) (*sqlite.SQLQuerier, error) {
 			graphLoader,
 			query,
 			refMap,
-			make(map[string]map[image.Reference]string, 0), false).Populate(registry.ReplacesMode)
+			make(map[string]map[image.Reference]string, 0), false, false).Populate(registry.ReplacesMode)
 	}
 	names := []string{"etcd.0.9.0", "etcd.0.9.2", "prometheus.0.22.2", "prometheus.0.14.0", "prometheus.0.15.0"}
 	if err := populate(names); err != nil {
@@ -489,7 +489,7 @@ func TestImageLoading(t *testing.T) {
 					graphLoader,
 					query,
 					map[image.Reference]string{i.ref: i.dir},
-					make(map[string]map[image.Reference]string, 0), false)
+					make(map[string]map[image.Reference]string, 0), false, false)
 				require.NoError(t, p.Populate(registry.ReplacesMode))
 			}
 			add := registry.NewDirectoryPopulator(
@@ -497,7 +497,7 @@ func TestImageLoading(t *testing.T) {
 				graphLoader,
 				query,
 				map[image.Reference]string{tt.addImage.ref: tt.addImage.dir},
-				make(map[string]map[image.Reference]string, 0), false)
+				make(map[string]map[image.Reference]string, 0), false, false)
 			err = add.Populate(registry.ReplacesMode)
 			if tt.wantErr {
 				require.True(t, checkAggErr(err, tt.err))
@@ -707,7 +707,7 @@ func TestDirectoryPopulator(t *testing.T) {
 			query,
 			bundles,
 			make(map[string]map[image.Reference]string),
-			false).Populate(registry.ReplacesMode)
+			false, false).Populate(registry.ReplacesMode)
 	}
 	add := map[image.Reference]string{
 		image.SimpleReference("quay.io/test/etcd.0.9.2"):        "../../bundles/etcd.0.9.2",
@@ -1269,7 +1269,7 @@ func TestOverwrite(t *testing.T) {
 					query,
 					bundles,
 					overwrites,
-					true).Populate(registry.ReplacesMode)
+					true, false).Populate(registry.ReplacesMode)
 			}
 			require.NoError(t, populate(tt.args.firstAdd, nil))
 			popErr := populate(tt.args.secondAdd, tt.args.overwrites)

--- a/pkg/sqlite/remove_test.go
+++ b/pkg/sqlite/remove_test.go
@@ -32,7 +32,7 @@ func TestRemover(t *testing.T) {
 			map[image.Reference]string{
 				image.SimpleReference("quay.io/test/" + name): "../../bundles/" + name,
 			},
-			make(map[string]map[image.Reference]string, 0), false).Populate(registry.ReplacesMode)
+			make(map[string]map[image.Reference]string, 0), false, false).Populate(registry.ReplacesMode)
 	}
 	for _, name := range []string{"etcd.0.9.0", "etcd.0.9.2", "prometheus.0.14.0", "prometheus.0.15.0", "prometheus.0.22.2"} {
 		require.NoError(t, populate(name))

--- a/pkg/sqlite/stranded_test.go
+++ b/pkg/sqlite/stranded_test.go
@@ -33,7 +33,7 @@ func TestStrandedBundleRemover(t *testing.T) {
 			map[image.Reference]string{
 				image.SimpleReference("quay.io/test/" + name): "./testdata/strandedbundles/" + name,
 			},
-			make(map[string]map[image.Reference]string, 0), false).Populate(registry.ReplacesMode)
+			make(map[string]map[image.Reference]string, 0), false, false).Populate(registry.ReplacesMode)
 	}
 	for _, name := range []string{"prometheus.0.14.0", "prometheus.0.15.0", "prometheus.0.22.2"} {
 		require.NoError(t, populate(name))


### PR DESCRIPTION
**Description of the change:**

When the `opm index add` was used with the `permissive` flag, the index
was being created, but the valid bundles from the list of bundles provided
with the command was not being added. Instead, an empty index was being
created. This PR fixes the issue by adding the valid bundles to the index,
while ignoring the invalid ones.

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
