### PR TITLE
fix(opm-index-add) Throw error when a bundle is invalid

### DIFF
--- a/pkg/registry/input_stream.go
+++ b/pkg/registry/input_stream.go
@@ -142,7 +142,7 @@ func (r *ReplacesInputStream) Next() (*ImageInput, error) {
 				delete(r.packages, pkg)
 			}
 
-			return image, nil
+			return image, utilerrors.NewAggregate(errs)
 		}
 
 		// No viable bundle found in the package, can't parse it any further


### PR DESCRIPTION
**Description of the change:**

With the introduction of #503, when a bundle from the list of bundles
being added with the `opm index add` command was invalid, opm was not
throwing an error, and was building the index with the valid bundles
instead, even when the `permissive` mode was not enabled. This PR
fixes the issue.

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
