### PR TITLE
fix(indexing): respect strict mode

### DIFF
--- a/pkg/registry/input_stream.go
+++ b/pkg/registry/input_stream.go
@@ -90,7 +90,7 @@ func (r *ReplacesInputStream) canAdd(bundle *Bundle, packageGraph *Package) erro
 
 	if replaces != "" && !packageGraph.HasCsv(replaces) {
 		// We can't add this until a replacement exists
-		return fmt.Errorf("Invalid bundle %s, bundle specifies a non-existent replacement %s", bundle.Name, replaces)
+		return fmt.Errorf("Invalid bundle %s, replaces nonexistent bundle %s", bundle.Name, replaces)
 	}
 
 	images, ok := r.packages[packageGraph.Name]
@@ -145,11 +145,8 @@ func (r *ReplacesInputStream) Next() (*ImageInput, error) {
 			return image, nil
 		}
 
-		// No viable bundle found in the package, can't parse it any further
-		if len(packageErrs) > 0 {
-			delete(r.packages, pkg)
-			errs = append(errs, packageErrs...)
-		}
+		// No viable bundle found in the package, can't parse it any further, so return any errors
+		errs = append(errs, packageErrs...)
 	}
 
 	// We've exhausted all valid input bundles, any errors here indicate invalid input of some kind

--- a/pkg/registry/populator.go
+++ b/pkg/registry/populator.go
@@ -196,7 +196,6 @@ func (i *DirectoryPopulator) loadManifests(imagesToAdd []*ImageInput, imagesToRe
 				errs = append(errs, err)
 				break
 			}
-
 		}
 
 		if len(errs) > 0 {

--- a/pkg/registry/populator_test.go
+++ b/pkg/registry/populator_test.go
@@ -714,8 +714,8 @@ func TestDirectoryPopulator(t *testing.T) {
 
 	err = populate(add)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("Invalid bundle %s, bundle specifies a non-existent replacement %s", "etcdoperator.v0.9.2", "etcdoperator.v0.9.0"))
-	require.Contains(t, err.Error(), fmt.Sprintf("Invalid bundle %s, bundle specifies a non-existent replacement %s", "prometheusoperator.0.22.2", "prometheusoperator.0.15.0"))
+	require.Contains(t, err.Error(), fmt.Sprintf("Invalid bundle %s, replaces nonexistent bundle %s", "etcdoperator.v0.9.2", "etcdoperator.v0.9.0"))
+	require.Contains(t, err.Error(), fmt.Sprintf("Invalid bundle %s, replaces nonexistent bundle %s", "prometheusoperator.0.22.2", "prometheusoperator.0.15.0"))
 }
 
 func TestDeprecateBundle(t *testing.T) {
@@ -943,8 +943,8 @@ func TestOverwrite(t *testing.T) {
 			},
 			expected: expected{
 				errs: []error{
-					fmt.Errorf("Invalid bundle %s, bundle specifies a non-existent replacement %s", "etcdoperator.v0.9.2", "etcdoperator.v0.9.0"),
-					fmt.Errorf("Invalid bundle %s, bundle specifies a non-existent replacement %s", "prometheusoperator.0.22.2", "prometheusoperator.0.15.0"),
+					fmt.Errorf("Invalid bundle %s, replaces nonexistent bundle %s", "etcdoperator.v0.9.2", "etcdoperator.v0.9.0"),
+					fmt.Errorf("Invalid bundle %s, replaces nonexistent bundle %s", "prometheusoperator.0.22.2", "prometheusoperator.0.15.0"),
 				},
 				remainingBundles: []string{
 					"quay.io/test/prometheus.0.14.0/preview",


### PR DESCRIPTION
Keep packages in the input stream regardless of errors attempting to add
bundles of that package to an index. This prevents invalid bundles from
being elided before all valid bundles have been exhausted, and fixes a
regression that effectively broke strict (non-permissive) mode.

Supersedes #522