### PR TITLE
Bug 1902824: fix(index): account for default channel in index add order

### DIFF
--- a/pkg/registry/input_stream.go
+++ b/pkg/registry/input_stream.go
@@ -93,6 +93,23 @@ func (r *ReplacesInputStream) canAdd(bundle *Bundle, packageGraph *Package) erro
 		return fmt.Errorf("Invalid bundle %s, replaces nonexistent bundle %s", bundle.Name, replaces)
 	}
 
+	defaultChannel := bundle.Annotations.DefaultChannelName
+	if defaultChannel != "" && !packageGraph.HasChannel(defaultChannel) {
+		// We also can't add if the bundle isn't in the default channel it specifies or it doesn't already exist in the package
+		var defaultFound bool
+		for _, channel := range bundle.Channels {
+			if channel != defaultChannel {
+				continue
+			}
+			defaultFound = true
+			break
+		}
+
+		if !defaultFound {
+			return fmt.Errorf("Invalid bundle %s, references nonexistent default channel %s", bundle.Name, defaultChannel)
+		}
+	}
+
 	images, ok := r.packages[packageGraph.Name]
 	if !ok || images == nil {
 		// This shouldn't happen unless canAdd is being called without the correct setup

--- a/pkg/registry/populator.go
+++ b/pkg/registry/populator.go
@@ -487,7 +487,7 @@ func SemverPackageManifest(bundles []*Bundle) (*PackageManifest, error) {
 	}
 
 	if !defaultFound {
-		return nil, fmt.Errorf("unable to determine default channel")
+		return nil, fmt.Errorf("unable to determine default channel among channel heads: %+v", heads)
 	}
 
 	return pkg, nil


### PR DESCRIPTION
Ensure the default channel referenced by a bundle exists, either by that
bundle or in the package, before returning it as the next element of an
input stream. Adding this check prevents smaller versions from breaking
index add when the `--overwrite-latest` flag is set; e.g. if a z-stream
bundle was originally added _after_ a larger y-stream and references a
default channel only defined in that y-stream.