### PR TITLE
Disable broken ppc64le and s390x release builds.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,16 +28,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        arch:
-          - amd64
-        include:
-          - os: ubuntu-latest
-            arch: ppc64le
-          - os: ubuntu-latest
-            arch: s390x
     runs-on: ${{ matrix.os }}
-    env:
-      GOARCH: ${{ matrix.arch }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2


### PR DESCRIPTION
We don't have machines with either architecture to support native
builds since TravisCI ended its free plan for open source
projects. Since a large part of opm's functionality depends on linking
to SQLite, it needs to be built with CGO enabled, either on the target
platform or with a suitable cross-compilation toolchain.
