### PR TITLE
Bug 1883560: Avoid duplicate registry binaries across downstream image layers.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ RUN CGO_ENABLED=0 go build -mod=vendor -tags netgo -ldflags "-w" ./vendor/github
 
 FROM registry.svc.ci.openshift.org/ocp/4.7:base
 
-COPY --from=builder /src/bin/* /tmp/bin/
+COPY --from=builder /src/bin/* /bin/registry/
 COPY --from=builder /src/grpc-health-probe /bin/grpc_health_probe
 
-RUN cp -avr /tmp/bin/. /bin/ && rm -rf /tmp/bin
+RUN ln -s /bin/registry/* /bin
 
 RUN mkdir /registry
 RUN chgrp -R 0 /registry && \


### PR DESCRIPTION
The registry binaries are copied from the build stage to an
intermediate directory because the downstream image builder overwrites
the destination directory when the source is a glob pattern. The
existing COPY and RUN (mv) commands both add a layer to the image, so
a copy of each binary lives in each layer.

To avoid this, symlinks are created from /bin to the intermediate
directory instead of moving the binaries from the intermediate
directory to /bin.

I'm not super familiar with the downstream build, but on my machine with Docker, the resulting image goes from 1.03GB to 651MB.
