### PR TITLE
Inherit replaced versions when skipping patches

### DIFF
--- a/pkg/registry/bundlegraphloader.go
+++ b/pkg/registry/bundlegraphloader.go
@@ -130,6 +130,12 @@ func (g *BundleGraphLoader) AddBundleToGraph(bundle *Bundle, graph *Package, ann
 		// the new node. If we didn't find a node semantically ahead, the new node is
 		// the new channel head
 		if !lowestAhead.IsEmpty() {
+
+			// Inherit replacements form the version replacing the new node.
+			for replaced, val := range channelGraph.Nodes[lowestAhead] {
+				replaces[replaced] = val
+			}
+
 			channelGraph.Nodes[lowestAhead] = map[BundleKey]struct{}{
 				newBundleKey: struct{}{},
 			}

--- a/pkg/registry/bundlegraphloader.go
+++ b/pkg/registry/bundlegraphloader.go
@@ -140,6 +140,9 @@ func (g *BundleGraphLoader) AddBundleToGraph(bundle *Bundle, graph *Package, ann
 		if skippatch {
 			// Remove the nodes that are now being skipped by a new patch version update
 			for _, candidate := range skipPatchCandidates {
+				for replaced, val := range channelGraph.Nodes[candidate] {
+					replaces[replaced] = val
+				}
 				delete(channelGraph.Nodes, candidate)
 			}
 		}

--- a/pkg/registry/bundlegraphloader.go
+++ b/pkg/registry/bundlegraphloader.go
@@ -152,34 +152,36 @@ func (g *BundleGraphLoader) AddBundleToGraph(bundle *Bundle, graph *Package, ann
 		graph.Channels[channel] = channelGraph
 	}
 
+	if !skippatch {
+		return graph, nil
+	}
+
 	// Remove the nodes that where patch-skipped previously, also in channels unaffected by the new bundle
-	if skippatch {
-		for channel := range graph.Channels {
-			channelGraph := graph.Channels[channel]
-			allSkips := make([]BundleKey, len(channelGraph.Nodes))
-			for node, replacedNodes := range channelGraph.Nodes {
-				for replaced := range replacedNodes {
-					nodeVersion, err := semver.Make(node.Version)
-					if err != nil {
-						// not semver, skip this replacement
-						continue
-					}
+	for channel := range graph.Channels {
+		channelGraph := graph.Channels[channel]
+		allSkips := make([]BundleKey, len(channelGraph.Nodes))
+		for node, replacedNodes := range channelGraph.Nodes {
+			for replaced := range replacedNodes {
+				nodeVersion, err := semver.Make(node.Version)
+				if err != nil {
+					// not semver, skip this replacement
+					continue
+				}
 
-					replacedVersion, err := semver.Make(replaced.Version)
-					if err != nil {
-						// not semver, skip this replacement
-						continue
-					}
+				replacedVersion, err := semver.Make(replaced.Version)
+				if err != nil {
+					// not semver, skip this replacement
+					continue
+				}
 
-					if isSkipPatchCandidate(nodeVersion, replacedVersion) && len(channelGraph.Nodes[replaced]) == 0 {
-						allSkips = append(allSkips, replaced)
-					}
+				if isSkipPatchCandidate(nodeVersion, replacedVersion) && len(channelGraph.Nodes[replaced]) == 0 {
+					allSkips = append(allSkips, replaced)
 				}
 			}
+		}
 
-			for _, node := range allSkips {
-				delete(channelGraph.Nodes, node)
-			}
+		for _, node := range allSkips {
+			delete(channelGraph.Nodes, node)
 		}
 	}
 

--- a/pkg/registry/bundlegraphloader_test.go
+++ b/pkg/registry/bundlegraphloader_test.go
@@ -278,7 +278,7 @@ func TestBundleGraphLoader(t *testing.T) {
 							BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"}: {
 								BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
 								BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {},
-								BundleKey{CsvName: "etcdoperator.v0.9.1"}: {},
+								BundleKey{CsvName: "etcdoperator.v0.9.1"}:                   {},
 								BundleKey{CsvName: "etcdoperator.v0.9.2", Version: "0.9.2"}: {},
 							},
 						}},
@@ -296,7 +296,7 @@ func TestBundleGraphLoader(t *testing.T) {
 							BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"}: {
 								BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
 								BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {},
-								BundleKey{CsvName: "etcdoperator.v0.9.1"}: {},
+								BundleKey{CsvName: "etcdoperator.v0.9.1"}:                   {},
 								BundleKey{CsvName: "etcdoperator.v0.9.2", Version: "0.9.2"}: {},
 							},
 						}},

--- a/pkg/registry/bundlegraphloader_test.go
+++ b/pkg/registry/bundlegraphloader_test.go
@@ -275,22 +275,29 @@ func TestBundleGraphLoader(t *testing.T) {
 					"alpha": {Head: BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"},
 						Nodes: map[BundleKey]map[BundleKey]struct{}{
 							BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
-							BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"}: {BundleKey{CsvName: "etcdoperator.v0.9.2", Version: "0.9.2"}: {},
+							BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"}: {
+								BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
 								BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {},
+								BundleKey{CsvName: "etcdoperator.v0.9.1"}: {},
+								BundleKey{CsvName: "etcdoperator.v0.9.2", Version: "0.9.2"}: {},
 							},
 						}},
 
 					"beta": {Head: BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"},
 						Nodes: map[BundleKey]map[BundleKey]struct{}{
 							BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
-							BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {}},
+							BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {
+								BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {}},
 						}},
 
 					"stable": {Head: BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"},
 						Nodes: map[BundleKey]map[BundleKey]struct{}{
 							BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
-							BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"}: {BundleKey{CsvName: "etcdoperator.v0.9.2", Version: "0.9.2"}: {},
+							BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"}: {
+								BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"}: {},
 								BundleKey{CsvName: "etcdoperator.v0.9.0", Version: "0.9.0"}: {},
+								BundleKey{CsvName: "etcdoperator.v0.9.1"}: {},
+								BundleKey{CsvName: "etcdoperator.v0.9.2", Version: "0.9.2"}: {},
 							},
 						}},
 				},


### PR DESCRIPTION
**Description of the change:**

Inherit the replaced versions from deleted versions when skipping patches with `semver-skippatch`. This ensures that it is possible to build a complete "replaces" path to previous versions, that are not skipped/removed from the channel.

In addition to this, skipped version from previous skips, but on other minor versions are trimmed if they where skipped. These are "synthectic" versions and not part of the "single upgrade path". They will be recreated later as synthetic versions in `sqlLoader.AddPackageChannelsFromGraph`.

**Motivation for the change:**

When adding a series of bundles with versions `0.0.1`, `0.1.0`, `0.1.1` with

```shell
opm index add --mode semver-skippatch ...
```

The following error will be thrown:

> Invalid graph: some (non-bottom) nodes defined in the graph were not mentioned as replacements of any node

This fixes the error by enabling `sqlLoader.AddPackageChannelsFromGraph` to build a complete graph from the channel head to the oldest version in the channel.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive