### PR TITLE
Check if package exists before removing from registry

### DIFF
--- a/pkg/sqlite/remove_test.go
+++ b/pkg/sqlite/remove_test.go
@@ -2,8 +2,9 @@ package sqlite
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/operator-framework/operator-registry/pkg/image"
 	"github.com/operator-framework/operator-registry/pkg/registry"
@@ -62,6 +63,10 @@ func TestRemover(t *testing.T) {
 
 	_, err = query.GetPackage(context.TODO(), "etcd")
 	require.EqualError(t, err, "package etcd not found")
+
+	require.EqualError(t, store.RemovePackage("missing-package"), "package does not exist")
+	_, err = query.GetPackage(context.TODO(), "missing-package")
+	require.Error(t, err, "querying for a non-existent package should produce an error")
 
 	// prometheus apis still around
 	rows, err := db.QueryContext(context.TODO(), "select * from api")


### PR DESCRIPTION

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Motivation for the change:**

Before, when attempting to delete a package from an existing registry,
no error was logged when that package did not exist.

**Description of the change:**

Update pkg/sqlite/load.go and check if the package we're currently
processing exists in the registry before removing it.
```bash
make bin/opm
./bin/opm index add -c podman --bundles quay.io/operator-framework/operator-bundle-prometheus:0.14.0,quay.io/operator-framework/operator-bundle-prometheus:0.15.0,quay.io/operator-framework/operator-bundle-prometheus:0.22.2,quay.io/tflannag/bundle:v4.6,quay.io/tflannag/bundle:v4.7 --tag quay.io/tflannag/index:latest
...
$ podman create quay.io/tflannag/index:latest
5bbe07c6785da4885c59d739c8ab234994112df4dd46abd7e81fb3abb5828735
$ podman cp 5bbe07c6785da4885c59d739c8ab234994112df4dd46abd7e81fb3abb5828735:/database/index.db test.db
```

The test.db contains several channels for the `prometheus` and
`metering-ocp` packages:

```bash
sqlite> select * from channel;
name    package_name  head_operatorbundle_name
------  ------------  -------------------------
beta    prometheus    prometheusoperator.0.22.2
stable  prometheus    prometheusoperator.0.22.2
4.6     metering-ocp  metering-operator.v4.6.0
4.7     metering-ocp  metering-operator.v4.7.0
sqlite> select * from package;
name          default_channel
------------  ---------------
prometheus    stable
metering-ocp  4.7
sqlite>
```

This produces the following error when attempting to remove the
`prometheus2` package from the empty sqlite registry:

```bash
$ ./bin/opm registry rm -d test.db -o prometheus2
INFO[0000] removing from the registry                    packages="[prometheus2]"
INFO[0000] deleting packages                             pkg=prometheus2
INFO[0000] input has been sanitized                      pkg=prometheus2
INFO[0000] packages: [prometheus2]                       pkg=prometheus2
FATA[0000] permissive mode disabled                      error="error deleting packages from database: error removing operator package prometheus2: package does not exist"
```

Open Questions:
- Should this be a warning message instead?
- Does this need to be backported?

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
