### PR TITLE
Bug 1904297: Unexpected images left in `related_images` after pruning

### DIFF
--- a/cmd/configmap-server/main.go
+++ b/cmd/configmap-server/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"net"
 
@@ -105,7 +104,7 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 		logger.Fatalf("error getting configmap: %s", err)
 	}
 
-	db, err := sql.Open("sqlite3", dbName)
+	db, err := sqlite.Open(dbName)
 	if err != nil {
 		return err
 	}

--- a/cmd/initializer/main.go
+++ b/cmd/initializer/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
@@ -55,7 +54,7 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	db, err := sql.Open("sqlite3", outFilename)
+	db, err := sqlite.Open(outFilename)
 	if err != nil {
 		return err
 	}

--- a/cmd/opm/registry/serve.go
+++ b/cmd/opm/registry/serve.go
@@ -85,7 +85,7 @@ func serveFunc(cmd *cobra.Command, args []string) error {
 	}
 	defer os.Remove(tmpdb)
 
-	db, err := sql.Open("sqlite3", tmpdb)
+	db, err := sqlite.Open(tmpdb)
 	if err != nil {
 		return err
 	}

--- a/cmd/registry-server/main.go
+++ b/cmd/registry-server/main.go
@@ -86,7 +86,7 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 	}
 	defer os.Remove(tmpdb)
 
-	db, err := sql.Open("sqlite3", tmpdb)
+	db, err := sqlite.Open(tmpdb)
 	if err != nil {
 		return err
 	}

--- a/pkg/appregistry/builder.go
+++ b/pkg/appregistry/builder.go
@@ -5,7 +5,6 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"context"
-	"database/sql"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -118,7 +117,7 @@ func (b *AppregistryImageBuilder) Build() error {
 }
 
 func BuildDatabase(manifestPath, databasePath string) error {
-	db, err := sql.Open("sqlite3", databasePath)
+	db, err := sqlite.Open(databasePath)
 	if err != nil {
 		return err
 	}

--- a/pkg/appregistry/dbloader.go
+++ b/pkg/appregistry/dbloader.go
@@ -12,7 +12,7 @@ import (
 )
 
 func NewDbLoader(dbName string, logger *logrus.Entry) (*dbLoader, error) {
-	db, err := sql.Open("sqlite3", dbName)
+	db, err := sqlite.Open(dbName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lib/indexer/indexer.go
+++ b/pkg/lib/indexer/indexer.go
@@ -2,7 +2,6 @@ package indexer
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -496,7 +495,7 @@ func (i ImageIndexer) ExportFromIndex(request ExportFromIndexRequest) error {
 		return err
 	}
 
-	db, err := sql.Open("sqlite3", databaseFile)
+	db, err := sqlite.Open(databaseFile)
 	if err != nil {
 		return err
 	}

--- a/pkg/lib/indexer/indexer_test.go
+++ b/pkg/lib/indexer/indexer_test.go
@@ -1,7 +1,6 @@
 package indexer
 
 import (
-	"database/sql"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -9,9 +8,9 @@ import (
 	"testing"
 
 	"github.com/ghodss/yaml"
-	"github.com/operator-framework/operator-registry/pkg/sqlite"
 
 	pregistry "github.com/operator-framework/operator-registry/pkg/registry"
+	"github.com/operator-framework/operator-registry/pkg/sqlite"
 )
 
 func TestGetBundlesToExport(t *testing.T) {
@@ -19,7 +18,7 @@ func TestGetBundlesToExport(t *testing.T) {
 		"quay.io/olmtest/example-bundle:etcdoperator.v0.6.1"}
 	sort.Strings(expected)
 
-	db, err := sql.Open("sqlite3", "./testdata/bundles.db")
+	db, err := sqlite.Open("./testdata/bundles.db")
 	if err != nil {
 		t.Fatalf("opening db: %s", err)
 	}
@@ -48,7 +47,7 @@ func TestGetBundlesToExport(t *testing.T) {
 }
 
 func TestGeneratePackageYaml(t *testing.T) {
-	db, err := sql.Open("sqlite3", "./testdata/bundles.db")
+	db, err := sqlite.Open("./testdata/bundles.db")
 	if err != nil {
 		t.Fatalf("opening db: %s", err)
 	}

--- a/pkg/lib/registry/registry.go
+++ b/pkg/lib/registry/registry.go
@@ -2,7 +2,6 @@ package registry
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -35,7 +34,7 @@ type AddToRegistryRequest struct {
 }
 
 func (r RegistryUpdater) AddToRegistry(request AddToRegistryRequest) error {
-	db, err := sql.Open("sqlite3", "file:"+request.InputDatabase+"?_foreign_keys=on")
+	db, err := sqlite.Open(request.InputDatabase)
 	if err != nil {
 		return err
 	}
@@ -206,7 +205,7 @@ type DeleteFromRegistryRequest struct {
 }
 
 func (r RegistryUpdater) DeleteFromRegistry(request DeleteFromRegistryRequest) error {
-	db, err := sql.Open("sqlite3", request.InputDatabase)
+	db, err := sqlite.Open(request.InputDatabase)
 	if err != nil {
 		return err
 	}
@@ -247,7 +246,7 @@ type PruneStrandedFromRegistryRequest struct {
 }
 
 func (r RegistryUpdater) PruneStrandedFromRegistry(request PruneStrandedFromRegistryRequest) error {
-	db, err := sql.Open("sqlite3", request.InputDatabase)
+	db, err := sqlite.Open(request.InputDatabase)
 	if err != nil {
 		return err
 	}
@@ -276,7 +275,7 @@ type PruneFromRegistryRequest struct {
 }
 
 func (r RegistryUpdater) PruneFromRegistry(request PruneFromRegistryRequest) error {
-	db, err := sql.Open("sqlite3", request.InputDatabase)
+	db, err := sqlite.Open(request.InputDatabase)
 	if err != nil {
 		return err
 	}
@@ -328,7 +327,7 @@ type DeprecateFromRegistryRequest struct {
 }
 
 func (r RegistryUpdater) DeprecateFromRegistry(request DeprecateFromRegistryRequest) error {
-	db, err := sql.Open("sqlite3", request.InputDatabase)
+	db, err := sqlite.Open(request.InputDatabase)
 	if err != nil {
 		return err
 	}

--- a/pkg/mirror/mirror.go
+++ b/pkg/mirror/mirror.go
@@ -2,7 +2,6 @@ package mirror
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"strings"
 
@@ -71,7 +70,7 @@ func (b *IndexImageMirrorer) Mirror() (map[string]string, error) {
 		return nil, err
 	}
 
-	db, err := sql.Open("sqlite3", dbPath)
+	db, err := sqlite.Open(dbPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mirror/mirror_test.go
+++ b/pkg/mirror/mirror_test.go
@@ -16,7 +16,7 @@ import (
 func CreateTestDb(t *testing.T) (*sql.DB, string, func()) {
 	dbName := fmt.Sprintf("test-%d.db", rand.Int())
 
-	db, err := sql.Open("sqlite3", dbName)
+	db, err := sqlite.Open(dbName)
 	require.NoError(t, err)
 
 	load, err := sqlite.NewSQLLiteLoader(db)

--- a/pkg/registry/interface.go
+++ b/pkg/registry/interface.go
@@ -12,7 +12,7 @@ type Load interface {
 	AddPackageChannels(manifest PackageManifest) error
 	AddBundlePackageChannels(manifest PackageManifest, bundle *Bundle) error
 	RemovePackage(packageName string) error
-	RemoveStrandedBundles() ([]string, error)
+	RemoveStrandedBundles() error
 	DeprecateBundle(path string) error
 	ClearNonHeadBundles() error
 }

--- a/pkg/registry/populator_test.go
+++ b/pkg/registry/populator_test.go
@@ -30,7 +30,7 @@ func init() {
 func CreateTestDb(t *testing.T) (*sql.DB, func()) {
 	dbName := fmt.Sprintf("test-%d.db", rand.Int())
 
-	db, err := sql.Open("sqlite3", "file:"+dbName+"?_foreign_keys=on")
+	db, err := sqlite.Open(dbName)
 	require.NoError(t, err)
 
 	return db, func() {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"database/sql"
 	"io"
 	"net"
 	"os"
@@ -30,7 +29,7 @@ func server() *grpc.Server {
 	_ = os.Remove(dbName)
 	s := grpc.NewServer()
 
-	db, err := sql.Open("sqlite3", dbName)
+	db, err := sqlite.Open(dbName)
 	if err != nil {
 		logrus.Fatal(err)
 	}

--- a/pkg/sqlite/configmap_test.go
+++ b/pkg/sqlite/configmap_test.go
@@ -23,7 +23,7 @@ import (
 func CreateTestDb(t *testing.T) (*sql.DB, func()) {
 	dbName := fmt.Sprintf("test-%d.db", rand.Int())
 
-	db, err := sql.Open("sqlite3", dbName)
+	db, err := Open(dbName)
 	require.NoError(t, err)
 
 	return db, func() {

--- a/pkg/sqlite/db.go
+++ b/pkg/sqlite/db.go
@@ -1,0 +1,29 @@
+package sqlite
+
+import (
+	"database/sql"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// Open opens a connection to a sqlite db. It should be used everywhere instead of sql.Open so that foreign keys are
+// ensured.
+func Open(fileName string) (*sql.DB, error) {
+	return sql.Open("sqlite3", EnableForeignKeys(fileName))
+}
+
+// Open opens a connection to a sqlite db. It is
+func OpenReadOnly(fileName string) (*sql.DB, error) {
+	return sql.Open("sqlite3", EnableImmutable(fileName))
+}
+
+// EnableForeignKeys appends the option to enable foreign keys on connections
+// note that without this option, PRAGMAs about foreign keys will lie.
+func EnableForeignKeys(fileName string) string {
+	return "file:"+fileName+"?_foreign_keys=on"
+}
+
+// Immutable appends the option to mark the db immutable on connections
+func EnableImmutable(fileName string) string {
+	return "file:"+fileName+"?immutable=true"
+}
+

--- a/pkg/sqlite/migrations/001_related_images_test.go
+++ b/pkg/sqlite/migrations/001_related_images_test.go
@@ -24,7 +24,7 @@ func CreateTestDbAt(t *testing.T, key int) (*sql.DB, sqlite.Migrator, func()) {
 	dbName := fmt.Sprintf("%d.db", rand.Int())
 	logrus.SetLevel(logrus.DebugLevel)
 
-	db, err := sql.Open("sqlite3", dbName)
+	db, err := sqlite.Open(dbName)
 	require.NoError(t, err)
 
 	_, err = db.Exec("PRAGMA foreign_keys = ON", nil)

--- a/pkg/sqlite/query.go
+++ b/pkg/sqlite/query.go
@@ -40,7 +40,7 @@ type SQLQuerier struct {
 var _ registry.Query = &SQLQuerier{}
 
 func NewSQLLiteQuerier(dbFilename string) (*SQLQuerier, error) {
-	db, err := sql.Open("sqlite3", "file:"+dbFilename+"?immutable=true")
+	db, err := OpenReadOnly(dbFilename)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sqlite/remove.go
+++ b/pkg/sqlite/remove.go
@@ -36,7 +36,6 @@ func (d *PackageRemover) Remove() error {
 
 	var errs []error
 	packages := sanitizePackageList(strings.Split(d.packages, ","))
-	log.Info("input has been sanitized")
 	log.Infof("packages: %s", packages)
 
 	for _, pkg := range packages {

--- a/pkg/sqlite/remove_test.go
+++ b/pkg/sqlite/remove_test.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"testing"
 
 	"github.com/operator-framework/operator-registry/pkg/image"
@@ -38,11 +39,28 @@ func TestRemover(t *testing.T) {
 		require.NoError(t, populate(name))
 	}
 
+	// check that bundles not properly associated with a package are not left
+	b := registry.NewBundle("stranded", &registry.Annotations{
+		PackageName:        "p",
+		Channels:           "c",
+		DefaultChannelName: "c",
+	}, &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind": "ClusterServiceVersion",
+			"metadata": map[string]interface{}{
+				"name": "stranded",
+			},
+			"spec": map[string]interface{}{
+				"version": "0.0.1",
+			},
+		}})
+	b.BundleImage = "bundle-image"
+	require.NoError(t, store.AddOperatorBundle(b))
+
 	// delete etcd
 	require.NoError(t, store.RemovePackage("etcd"))
 
-	querier := NewSQLLiteQuerierFromDb(db)
-	_, err = querier.GetPackage(context.TODO(), "etcd")
+	_, err = query.GetPackage(context.TODO(), "etcd")
 	require.EqualError(t, err, "package etcd not found")
 
 	// prometheus apis still around
@@ -54,7 +72,7 @@ func TestRemover(t *testing.T) {
 	// delete prometheus
 	require.NoError(t, store.RemovePackage("prometheus"))
 
-	_, err = querier.GetPackage(context.TODO(), "prometheus")
+	_, err = query.GetPackage(context.TODO(), "prometheus")
 	require.EqualError(t, err, "package prometheus not found")
 
 	// no apis after all packages are removed
@@ -62,6 +80,11 @@ func TestRemover(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, rows.Next())
 	require.NoError(t, rows.Close())
+
+	// check there are no related images, included stranded csv
+	imgs, err := query.ListImages(context.TODO())
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{}, imgs)
 
 	// and insert again
 	for _, name := range []string{"etcd.0.9.0", "etcd.0.9.2", "prometheus.0.14.0", "prometheus.0.15.0", "prometheus.0.22.2"} {

--- a/pkg/sqlite/stranded.go
+++ b/pkg/sqlite/stranded.go
@@ -26,16 +26,11 @@ func NewSQLStrandedBundleRemover(store registry.Load) *StrandedBundleRemover {
 func (d *StrandedBundleRemover) Remove() error {
 	log := logrus.New()
 
-	bundles, err := d.store.RemoveStrandedBundles()
+	err := d.store.RemoveStrandedBundles()
 	if err != nil {
 		return err
 	}
-
-	if len(bundles) > 0 {
-		log.Info("removing stranded bundles ", bundles)
-	} else {
-		log.Info("no stranded bundles found")
-	}
+	log.Info("removing stranded bundles ")
 
 	return nil
 }

--- a/pkg/sqlite/stranded_test.go
+++ b/pkg/sqlite/stranded_test.go
@@ -57,10 +57,8 @@ func TestStrandedBundleRemover(t *testing.T) {
 	require.NoError(t, rows.Close())
 
 	// prune the orphaned bundle
-	removedBundles, err := store.RemoveStrandedBundles()
+	err = store.RemoveStrandedBundles()
 	require.NoError(t, err)
-	require.Equal(t, 2, len(removedBundles))
-	require.EqualValues(t, []string{`"prometheusoperator.0.14.0"`, `"prometheusoperator.0.15.0"`}, removedBundles)
 
 	// other bundles in the package still exist, but the bundle is removed
 	packageBundles, err = querier.GetBundlesForPackage(context.TODO(), "prometheus")

--- a/test/e2e/opm_test.go
+++ b/test/e2e/opm_test.go
@@ -2,7 +2,6 @@ package e2e_test
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -187,7 +186,7 @@ func initialize() error {
 	}
 	defer os.Remove(tmpDB.Name())
 
-	db, err := sql.Open("sqlite3", tmpDB.Name())
+	db, err := sqlite.Open(tmpDB.Name())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Removes stranded bundles (bundles that are not referenced by any channel entry) after a prune operation.

This also abstracts database opening via a package that ensures foreign keys are always enabled - this bug was harder to fix because of this (even querying the db to check if foreign keys are enabled will lie to you if the db is not opened with that flag).

**Motivation for the change:**
Pruning is often done right before mirroring. If dangling bundles are not removed on prune, it can lead to unexpected images being mirrored.

It looks like this fixes https://github.com/operator-framework/operator-registry/issues/542

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
