### PR TITLE
Bug 1921763: add missing closes

### DIFF
--- a/pkg/registry/csv.go
+++ b/pkg/registry/csv.go
@@ -87,6 +87,7 @@ func ReadCSVFromBundleDirectory(bundleDir string) (*ClusterServiceVersion, error
 		if err != nil {
 			continue
 		}
+		defer yamlReader.Close()
 
 		unstructuredCSV := unstructured.Unstructured{}
 

--- a/pkg/sqlite/directory.go
+++ b/pkg/sqlite/directory.go
@@ -92,6 +92,7 @@ func (d *DirectoryLoader) LoadBundleWalkFunc(path string, f os.FileInfo, err err
 	if err != nil {
 		return fmt.Errorf("unable to load file %s: %s", path, err)
 	}
+	defer fileReader.Close()
 
 	decoder := yaml.NewYAMLOrJSONDecoder(fileReader, 30)
 	csv := unstructured.Unstructured{}
@@ -155,6 +156,7 @@ func (d *DirectoryLoader) LoadPackagesWalkFunc(path string, f os.FileInfo, err e
 	if err != nil {
 		return fmt.Errorf("unable to load package from file %s: %s", path, err)
 	}
+	defer fileReader.Close()
 
 	decoder := yaml.NewYAMLOrJSONDecoder(fileReader, 30)
 	manifest := registry.PackageManifest{}
@@ -207,6 +209,7 @@ func loadBundle(csvName string, dir string) (*registry.Bundle, error) {
 			errs = append(errs, fmt.Errorf("unable to load file %s: %s", path, err))
 			continue
 		}
+		defer fileReader.Close()
 
 		decoder := yaml.NewYAMLOrJSONDecoder(fileReader, 30)
 		obj := &unstructured.Unstructured{}


### PR DESCRIPTION
**Description of the change:**
There are a few places where Close() is forgotten to be called. Over time these could cause memory issues.

**Motivation for the change:**
4.7 has 4 opm processes running that I have seen grow to 500 MB over time.They are the top 4 memory consumers on the machine.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


