### PR TITLE
fix: use none driver without sudo in upstream minikube e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,7 @@ jobs:
           curl -sLo minikube "$(curl -sL https://api.github.com/repos/kubernetes/minikube/releases/latest | jq -r '[.assets[] | select(.name == "minikube-linux-amd64")] | first | .browser_download_url')"
           chmod +x minikube
           sudo mv minikube /bin/
-          minikube config set vm-driver none
-          sudo minikube start # needs root for none driver
+          minikube start --driver=none
           sudo chown -R "$USER" "$HOME/.kube" "$HOME/.minikube"
           sudo usermod -aG docker "$USER"
           eval $(minikube docker-env)


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Similar to  https://github.com/operator-framework/operator-lifecycle-manager/pull/1983, we started seeing failures in the minikube e2e tests after the underlying `ubuntu-latest` VM image used in github actions changed from ubuntu 18 to 20. 

It seems like using `minikube config set vm-driver none` is no longer being respected, minikube used the docker driver instead and complained about sudo mode. This change is to use the `none` vm driver for and not require sudo for running minikube. Based on https://github.com/kubernetes/minikube/issues/3760 this seems to work now and will be supported. 

**Motivation for the change:**
Regression 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
