### PR TITLE
fix: copy out only the selected file(s) from index images via a tar reader

### DIFF
--- a/cmd/opm/alpha/bundle/unpack.go
+++ b/cmd/opm/alpha/bundle/unpack.go
@@ -133,7 +133,7 @@ func unpackBundle(cmd *cobra.Command, args []string) error {
 			logger.Error(err.Error())
 		}
 	}()
-	if err := registry.Unpack(ctx, ref, dir); err != nil {
+	if err := registry.Unpack(ctx, ref, image.Root, dir); err != nil {
 		return err
 	}
 

--- a/internal/action/render.go
+++ b/internal/action/render.go
@@ -99,7 +99,7 @@ func (r Render) imageToDeclcfg(ctx context.Context, imageRef string) (*declcfg.D
 		return nil, err
 	}
 	defer os.RemoveAll(tmpDir)
-	if err := r.Registry.Unpack(ctx, ref, tmpDir); err != nil {
+	if err := r.Registry.Unpack(ctx, ref, image.Root, tmpDir); err != nil {
 		return nil, err
 	}
 

--- a/pkg/containertools/exporter.go
+++ b/pkg/containertools/exporter.go
@@ -10,40 +10,38 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Exporter can read a tar archive being passed along from a writer and write it to a local destination.
-type Exporter struct {
+// exporter can read a tar archive being passed along from a writer and write it to a local destination.
+type exporter struct {
 	dest   string
 	writer io.WriteCloser
 	reader *tar.Reader
 	log    *logrus.Entry
 }
 
-func NewExporter(dest string, logger *logrus.Entry) (*Exporter, error) {
-	// use stdout as pipew
-	piper, pipew := io.Pipe()
+func newExporter(dest string, logger *logrus.Entry, reader *tar.Reader, writer io.WriteCloser) (*exporter, error) {
 	d, err := filepath.Abs(dest)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Exporter{
+	return &exporter{
 		dest:   d,
-		writer: pipew,
-		reader: tar.NewReader(piper),
+		writer: writer,
+		reader: reader,
 		log:    logger,
 	}, nil
 }
 
-func (e *Exporter) Writer() io.WriteCloser {
+func (e *exporter) Writer() io.WriteCloser {
 	return e.writer
 }
 
-func (e *Exporter) Close() error {
+func (e *exporter) Close() error {
 	return e.writer.Close()
 }
 
 // Run reads the tar stream from reader as it comes from stdout and writes the file/dir to the destination specified.
-func (e *Exporter) Run() error {
+func (e *exporter) Run() error {
 	for {
 		header, err := e.reader.Next()
 		if err == io.EOF {

--- a/pkg/containertools/exporter.go
+++ b/pkg/containertools/exporter.go
@@ -1,0 +1,96 @@
+package containertools
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Exporter can read a tar archive being passed along from a writer and write it to a local destination.
+type Exporter struct {
+	dest   string
+	writer io.WriteCloser
+	reader *tar.Reader
+	log    *logrus.Entry
+}
+
+func NewExporter(dest string, logger *logrus.Entry) (*Exporter, error) {
+	// use stdout as pipew
+	piper, pipew := io.Pipe()
+	d, err := filepath.Abs(dest)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Exporter{
+		dest:   d,
+		writer: pipew,
+		reader: tar.NewReader(piper),
+		log:    logger,
+	}, nil
+}
+
+func (e *Exporter) Writer() io.WriteCloser {
+	return e.writer
+}
+
+func (e *Exporter) Close() error {
+	return e.writer.Close()
+}
+
+// Run reads the tar stream from reader as it comes from stdout and writes the file/dir to the destination specified.
+func (e *Exporter) Run() error {
+	for {
+		header, err := e.reader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		// determine proper file path info
+		finfo := header.FileInfo()
+		fileName := header.Name
+		absFileName := filepath.Join(e.dest, fileName)
+
+		// if a dir, create it, then go to next segment
+		if finfo.Mode().IsDir() {
+			if err := os.MkdirAll(absFileName, os.ModePerm); err != nil {
+				e.log.Debugf("creating %s dir", absFileName)
+				return err
+			}
+			continue
+		}
+
+		// create new file with custom file permissions
+		// TODO sync with existing containerd permissions
+		file, err := os.OpenFile(
+			absFileName,
+			os.O_RDWR|os.O_CREATE|os.O_TRUNC,
+			os.ModePerm,
+		)
+		if err != nil {
+			return err
+		}
+
+		e.log.Debugf("writing %s to disk", absFileName)
+		n, err := io.Copy(file, e.reader)
+		if err != nil {
+			return err
+		}
+		if closeErr := file.Close(); closeErr != nil {
+			return closeErr
+		}
+		if n != finfo.Size() {
+			return fmt.Errorf("unpacking to disk: wrote %d, want %d", n, finfo.Size())
+		}
+	}
+
+	e.log.Debugf("extracted contents from container filesystem")
+	return nil
+}

--- a/pkg/containertools/exporter_test.go
+++ b/pkg/containertools/exporter_test.go
@@ -1,0 +1,96 @@
+package containertools
+
+import (
+	"archive/tar"
+	"io/ioutil"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+var files = map[string]string{
+	"index.html": `<body>Hello!</body>`,
+	"lang.json":  `[{"code":"eng","name":"English"}]`,
+	"songs.txt":  `Claire de la lune, The Valkyrie, Swan Lake`,
+}
+
+// 1. create a tar archive in memory
+// 2. setup Exporter with Writer pipe
+// 4. read tar archive contents to a temporary directory on disk
+// 5. Ensure file contents are there
+// 6. Ensure permissions are set as expected
+func TestExporter_Run(t *testing.T) {
+	log := logrus.NewEntry(&logrus.Logger{})
+	temp, err := ioutil.TempDir("./", "temp-")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(temp)
+
+	exporter, err := NewExporter(temp, log)
+	if err != nil || exporter == nil {
+		t.Error(err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func(wg *sync.WaitGroup) {
+		defer wg.Done()
+		err := exporter.Run()
+		if err != nil {
+			t.Error(err)
+		}
+	}(&wg)
+
+	tw := tar.NewWriter(exporter.Writer())
+	for name, content := range files {
+		hdr := &tar.Header{
+			Name: name,
+			Mode: int64(0600),
+			Size: int64(len(content)),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Error(err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Error(err)
+		}
+	}
+
+	tw.Close()
+	wg.Wait()
+
+	dir, err := os.ReadDir(temp)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// check all files are on disk
+	var found bool
+	for f := range files {
+		found = false
+		for _, entry := range dir {
+			if f == entry.Name() {
+				found = true
+				continue
+			}
+		}
+	}
+
+	if !found {
+		t.Error("did not find expected file in tar archive on disk")
+	}
+
+	for _, entry := range dir {
+		info, err := entry.Info()
+		if err != nil {
+			t.Error(err)
+		}
+		// the file mode is changed from 0777 to 0755 due to the default umask 022
+		if info.Mode() != os.FileMode(0755) {
+			t.Errorf("unexpected file mode %s, expected %s", info.Mode(), os.FileMode(0755))
+		}
+	}
+}

--- a/pkg/containertools/runner.go
+++ b/pkg/containertools/runner.go
@@ -2,7 +2,9 @@
 package containertools
 
 import (
+	"archive/tar"
 	"fmt"
+	"io"
 	"os/exec"
 	"strings"
 	"sync"
@@ -141,7 +143,9 @@ func (r *ContainerCommandRunner) Unpack(image, src, dst string) error {
 
 	// Create a new exporter to copy and read output from stdout to a tar reader.
 	// This is done to rewrite file permissions on the fly to avoid permissions-related errors in standard docker cp.
-	exporter, err := NewExporter(dst, r.logger)
+	piper, pipew := io.Pipe()
+	reader := tar.NewReader(piper)
+	exporter, err := newExporter(dst, r.logger, reader, pipew)
 	if err != nil {
 		return fmt.Errorf("setting unpacking destination: #%v", err)
 	}

--- a/pkg/image/containerdregistry/registry.go
+++ b/pkg/image/containerdregistry/registry.go
@@ -91,7 +91,7 @@ func (r *Registry) Pull(ctx context.Context, ref image.Reference) error {
 
 // Unpack writes the unpackaged content of an image to a directory.
 // If the referenced image does not exist in the registry, an error is returned.
-func (r *Registry) Unpack(ctx context.Context, ref image.Reference, dir string) error {
+func (r *Registry) Unpack(ctx context.Context, ref image.Reference, from, to string) error {
 	// Set the default namespace if unset
 	ctx = ensureNamespace(ctx)
 
@@ -100,13 +100,13 @@ func (r *Registry) Unpack(ctx context.Context, ref image.Reference, dir string) 
 		return err
 	}
 
-	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+	if err := os.MkdirAll(to, os.ModePerm); err != nil {
 		return err
 	}
 
 	for _, layer := range manifest.Layers {
 		r.log.Debugf("unpacking layer: %v", layer)
-		if err := r.unpackLayer(ctx, layer, dir); err != nil {
+		if err := r.unpackLayer(ctx, layer, to); err != nil {
 			return err
 		}
 	}

--- a/pkg/image/containerdregistry/registry_test.go
+++ b/pkg/image/containerdregistry/registry_test.go
@@ -1,0 +1,41 @@
+package containerdregistry
+
+import (
+	"archive/tar"
+	"testing"
+)
+
+func Test_fromFilter(t *testing.T) {
+	type destination struct {
+		dest   string
+		match  bool
+		header *tar.Header
+	}
+	var destinations = []destination{
+		{
+			dest:   "/",
+			header: &tar.Header{Name: "root"},
+			match:  true,
+		},
+		{
+			dest:   "my-db.db",
+			header: &tar.Header{Name: "my-db.db"},
+			match:  true,
+		},
+		{
+			dest:   "my-db.db",
+			header: &tar.Header{Name: "rocks-db.db"},
+			match:  false,
+		},
+		// TODO directory test cases
+	}
+
+	for _, d := range destinations {
+		filter := fromFilter(d.dest)
+		result, err := filter(d.header)
+		if result == d.match && err == nil {
+			continue
+		}
+		t.Fatalf("error for %s, expected match to be %t, got %t", d.dest, d.match, result)
+	}
+}

--- a/pkg/image/execregistry/registry.go
+++ b/pkg/image/execregistry/registry.go
@@ -40,8 +40,8 @@ func (r *Registry) Pull(ctx context.Context, ref image.Reference) error {
 
 // Unpack writes the unpackaged content of an image to a directory.
 // If the referenced image does not exist in the registry, an error is returned.
-func (r *Registry) Unpack(ctx context.Context, ref image.Reference, dir string) error {
-	return r.cmd.Unpack(ref.String(), "/.", dir)
+func (r *Registry) Unpack(ctx context.Context, ref image.Reference, from, to string) error {
+	return r.cmd.Unpack(ref.String(), from, to)
 }
 
 // Labels gets the labels for an image reference.

--- a/pkg/image/mock.go
+++ b/pkg/image/mock.go
@@ -58,14 +58,14 @@ func (m *MockRegistry) Pull(_ context.Context, ref Reference) error {
 	return nil
 }
 
-func (m *MockRegistry) Unpack(_ context.Context, ref Reference, dir string) error {
+func (m *MockRegistry) Unpack(_ context.Context, ref Reference, from, to string) error {
 	m.m.RLock()
 	defer m.m.RUnlock()
 	image, ok := m.localImages[ref]
 	if !ok {
 		return errors.New("not found")
 	}
-	return image.unpack(dir)
+	return image.unpack(to)
 }
 
 func (m *MockRegistry) Labels(_ context.Context, ref Reference) (map[string]string, error) {

--- a/pkg/image/mock_test.go
+++ b/pkg/image/mock_test.go
@@ -43,7 +43,7 @@ func TestMockRegistry(t *testing.T) {
 	require.Error(t, r.Pull(ctx, dne))
 
 	// Test unpack and labels of unpulled ref
-	require.Error(t, r.Unpack(ctx, exists, tmpDir))
+	require.Error(t, r.Unpack(ctx, exists, Root, tmpDir))
 	_, err = r.Labels(ctx, exists)
 	require.Error(t, err)
 
@@ -51,7 +51,7 @@ func TestMockRegistry(t *testing.T) {
 	require.NoError(t, r.Pull(ctx, exists))
 
 	// Test unpack and labels of existing ref
-	require.NoError(t, r.Unpack(ctx, exists, tmpDir))
+	require.NoError(t, r.Unpack(ctx, exists, Root, tmpDir))
 	checkFile(t, filepath.Join(tmpDir, "file1"))
 	checkFile(t, filepath.Join(tmpDir, "subdir", "file2"))
 
@@ -63,7 +63,7 @@ func TestMockRegistry(t *testing.T) {
 	require.NoError(t, r.Destroy())
 
 	// Test unpack and labels of unpulled ref
-	require.Error(t, r.Unpack(ctx, exists, tmpDir))
+	require.Error(t, r.Unpack(ctx, exists, Root, tmpDir))
 	_, err = r.Labels(ctx, exists)
 	require.Error(t, err)
 }

--- a/pkg/image/registry.go
+++ b/pkg/image/registry.go
@@ -32,4 +32,4 @@ type Registry interface {
 
 // Root represents the root of the filesystem.
 // Used as the source when copying the entire contents of a container filesystem.
-const Root string = "/."
+const Root string = "/"

--- a/pkg/image/registry.go
+++ b/pkg/image/registry.go
@@ -14,9 +14,9 @@ type Registry interface {
 	// If the referenced image does not exist in the registry, an error is returned.
 	// Push(ctx context.Context, ref string) error
 
-	// Unpack writes the unpackaged content of an image to a directory.
+	// Unpack recursively copies the filesystem contents of an image from the specified location to a local directory.
 	// If the referenced image does not exist in the registry, an error is returned.
-	Unpack(ctx context.Context, ref Reference, dir string) error
+	Unpack(ctx context.Context, ref Reference, from, to string) error
 
 	// Labels gets the labels for an image that is already stored.
 	Labels(ctx context.Context, ref Reference) (map[string]string, error)
@@ -29,3 +29,7 @@ type Registry interface {
 	// If it exists, it's used as the base image.
 	// Pack(ctx context.Context, ref Reference, from io.Reader) (next string, err error)
 }
+
+// Root represents the root of the filesystem.
+// Used as the source when copying the entire contents of a container filesystem.
+const Root string = "/."

--- a/pkg/image/registry_test.go
+++ b/pkg/image/registry_test.go
@@ -200,7 +200,7 @@ func testPullAndUnpack(t *testing.T, name string, newRegistry newRegistryFunc) {
 			if tt.expected.checksum != "" {
 				// Copy golden manifests to a temp dir
 				dir := "kiali-unpacked"
-				require.NoError(t, r.Unpack(ctx, ref, dir))
+				require.NoError(t, r.Unpack(ctx, ref, image.Root, dir))
 
 				checksum := dirChecksum(t, dir)
 				require.Equal(t, tt.expected.checksum, checksum)

--- a/pkg/lib/bundle/exporter.go
+++ b/pkg/lib/bundle/exporter.go
@@ -63,7 +63,7 @@ func (i *BundleExporter) Export(skipTLS bool) error {
 		return err
 	}
 
-	if err := reg.Unpack(context.TODO(), image.SimpleReference(i.image), tmpDir); err != nil {
+	if err := reg.Unpack(context.TODO(), image.SimpleReference(i.image), image.Root, tmpDir); err != nil {
 		return err
 	}
 

--- a/pkg/lib/bundle/validate.go
+++ b/pkg/lib/bundle/validate.go
@@ -60,7 +60,7 @@ func (i imageValidator) PullBundleImage(imageTag, directory string) error {
 		return err
 	}
 
-	return i.registry.Unpack(ctx, ref, directory)
+	return i.registry.Unpack(ctx, ref, image.Root, directory)
 }
 
 // ValidateBundle takes a directory containing the contents of a bundle and validates

--- a/pkg/lib/indexer/indexer.go
+++ b/pkg/lib/indexer/indexer.go
@@ -354,18 +354,16 @@ func (i ImageIndexer) getDatabaseFile(workingDir, fromIndex, caFile string, skip
 
 	dbLocation, ok := labels[containertools.DbLocationLabel]
 	if !ok {
-		// fallback to extracting the entire filesystem?
-		dbLocation = image.Root
+		return "", fmt.Errorf("index image %s missing label %s", fromIndex, containertools.DbLocationLabel)
 	}
-	dbName := filepath.Base(dbLocation)
 
-	i.Logger.Debugf("Copying index db from %s inside the container to %s on the filesystem", dbLocation, path.Join(workingDir, dbName))
+	i.Logger.Debugf("Copying index db from %s inside the container to %s on the filesystem", dbLocation, workingDir)
 	// unpack just the index db file from the container filesystem to avoid potential file permissions errors
 	if err := reg.Unpack(context.TODO(), imageRef, dbLocation, workingDir); err != nil {
 		return "", err
 	}
 
-	return path.Join(workingDir, dbName), nil
+	return path.Join(workingDir, dbLocation), nil
 }
 
 func copyDatabaseTo(databaseFile, targetDir string) (string, error) {

--- a/pkg/lib/registry/registry.go
+++ b/pkg/lib/registry/registry.go
@@ -110,7 +110,7 @@ func unpackImage(ctx context.Context, reg image.Registry, ref image.Reference) (
 		errs = append(errs, err)
 	}
 
-	if err = reg.Unpack(ctx, ref, workingDir); err != nil {
+	if err = reg.Unpack(ctx, ref, image.Root, workingDir); err != nil {
 		errs = append(errs, err)
 	}
 


### PR DESCRIPTION
Signed-off-by: Daniel Sover <dsover@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Pruning an index via `opm index prune` can fail when permissions on the filesystem in the container are read-only. Since the command copies all files out from the container it is prone to failure. Fora example, the red hat operators catalog is based on the UBI image, which contains some directories with elevated permissions (`/root/*` for example). Extract the entire contents of this container filesystem via `docker cp` will fail. 

The extract database function relies on shelling out to external tools (docker or podman) and does not use the existing containerd unpacking implementation (since that does not support building images). These tools cannot dynamically change the filesystem permissions of files as they are copied out of the container filesystem, based on observed behavior. The solution is to instead copy the selected file(s) to stdout as a tar file and then read -> write them to the local filesystem with the permissions necessary to ensure the copying behavior succeeds always. 

**Motivation for the change:**
Fixes pruning the red hat operators catalog when running opm as a non-root user. Copying only the database file out from the catalog is simpler as well, since we knows its location ahead of time (via the label). 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
