### PR TITLE
.github,test: Re-enable Podman e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,14 +24,17 @@ jobs:
           file: coverage.out
           fail_ci_if_error: false
   e2e-minikube:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - run: |
-          sudo apt-get -y update
-          sudo apt-get -y upgrade
-          sudo apt-get -y install conntrack
-          podman version
+          sudo apt-get update \
+            && sudo apt-get remove buildah podman -y \
+            && sudo apt-get autoremove -y \
+            && sudo apt-get upgrade \
+            && sudo apt-get install podman dbus-x11 conntrack -y \
+            && podman version
+      - run: |
           curl -sLo minikube "$(curl -sL https://api.github.com/repos/kubernetes/minikube/releases/latest | jq -r '[.assets[] | select(.name == "minikube-linux-amd64")] | first | .browser_download_url')"
           chmod +x minikube
           sudo mv minikube /bin/
@@ -54,14 +57,19 @@ jobs:
           export DOCKER_REGISTRY_HOST=localhost:443
       - run: |
           KUBECONFIG="$HOME/.kube/config" DOCKER_REGISTRY_HOST=localhost:443 make build e2e
+
   e2e-kind:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - run: |
-          sudo apt-get -y update
-          sudo apt-get -y upgrade
-          podman version
+          sudo apt-get update \
+            && sudo apt-get remove buildah podman -y \
+            && sudo apt-get autoremove -y \
+            && sudo apt-get upgrade \
+            && sudo apt-get -y install podman dbus-x11 \
+            && podman version
+      - run: |
           curl -sLo kind "$(curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r '[.assets[] | select(.name == "kind-linux-amd64")] | first | .browser_download_url')"
           chmod +x kind
           sudo mv kind /bin/

--- a/test/e2e/opm_test.go
+++ b/test/e2e/opm_test.go
@@ -493,8 +493,6 @@ var _ = Describe("opm", func() {
 	})
 
 	Context("using podman", func() {
-		//FIXME skip podman tests due to failed to add podman to systemd sandbox cgroup
-		return
 		if err := exec.Command("podman", "info").Run(); err != nil {
 			GinkgoT().Log("container tool podman not found - skipping podman-based opm e2e tests: %s", err)
 			return


### PR DESCRIPTION
Update the test/e2e/opm_test.go and avoid returning early so the Podman-related e2e tests do not get run.

Update the test Github action workflow and ensure we get a new Podman dependency for both of the minikube and kind e2e tests.

Previously, we were seeing problems when attempting to update/upgrade our existing dependencies from the latest ubuntu image, which contains a default Podman installation. This resulted in failed action runs due to older dependencies being packaged in that image.