### PR TITLE
feat(decl-cfg) cmds to generate(to build) and unpack indexes with configs

### DIFF
--- a/cmd/opm/generate/generate.go
+++ b/cmd/opm/generate/generate.go
@@ -1,0 +1,63 @@
+package generate
+
+import (
+	"context"
+	"os"
+
+	"github.com/operator-framework/operator-registry/pkg/action"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+const defaultDockerfileName = "index.Dockerfile"
+
+type generate struct {
+	configDir   string
+	sourceImage string
+	debug       bool
+	logger      *logrus.Entry
+}
+
+func NewCmd() *cobra.Command {
+	logger := logrus.New()
+	g := generate{
+		logger: logrus.NewEntry(logger),
+	}
+	cmd := &cobra.Command{
+		Use:   "generate <configs_dir>",
+		Short: "generate DockerFile",
+		Long:  `generate DockerFile to be used to build index image with configs`,
+		Args:  cobra.ExactArgs(1),
+		PreRunE: func(_ *cobra.Command, args []string) error {
+			g.configDir = args[0]
+			if g.debug {
+				logger.SetLevel(logrus.DebugLevel)
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return g.run(cmd.Context())
+		},
+	}
+
+	cmd.Flags().BoolVar(&g.debug, "debug", false, "enable debug logging")
+	cmd.Flags().StringVarP(&g.sourceImage, "source-image", "s", "quay.io/operator-framework/upstream-opm-builder", "the base/source image to build the index image on")
+	return cmd
+}
+
+func (s *generate) run(ctx context.Context) error {
+
+	f, err := os.Create(defaultDockerfileName)
+	if err != nil {
+		return err
+	}
+
+	request := action.GenerateDockerfileRequest{
+		SourceImage: s.sourceImage,
+		ConfigsDir:  s.configDir,
+		File:        f,
+	}
+	generator := action.NewGenerator(s.logger)
+
+	return generator.GenerateDockerfile(request)
+}

--- a/cmd/opm/root/cmd.go
+++ b/cmd/opm/root/cmd.go
@@ -5,10 +5,11 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/operator-framework/operator-registry/cmd/opm/alpha"
+	"github.com/operator-framework/operator-registry/cmd/opm/generate"
 	"github.com/operator-framework/operator-registry/cmd/opm/index"
 	"github.com/operator-framework/operator-registry/cmd/opm/registry"
 	"github.com/operator-framework/operator-registry/cmd/opm/serve"
-	"github.com/operator-framework/operator-registry/cmd/opm/validate"
+	"github.com/operator-framework/operator-registry/cmd/opm/unpack"
 	"github.com/operator-framework/operator-registry/cmd/opm/version"
 )
 
@@ -25,7 +26,7 @@ func NewCmd() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(registry.NewOpmRegistryCmd(), alpha.NewCmd(), serve.NewCmd(), newAddCmd(), validate.NewCmd())
+	cmd.AddCommand(registry.NewOpmRegistryCmd(), alpha.NewCmd(), serve.NewCmd(), newAddCmd(), generate.NewCmd(), unpack.NewCmd())
 	index.AddCommand(cmd)
 	version.AddCommand(cmd)
 

--- a/cmd/opm/unpack/unpack.go
+++ b/cmd/opm/unpack/unpack.go
@@ -1,0 +1,69 @@
+package unpack
+
+import (
+	"context"
+
+	"github.com/operator-framework/operator-registry/pkg/action"
+	"github.com/operator-framework/operator-registry/pkg/image/containerdregistry"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+type unpack struct {
+	image   string
+	dir     string
+	caFile  string
+	skipTLS bool
+	debug   bool
+	logger  *logrus.Entry
+}
+
+func NewCmd() *cobra.Command {
+	logger := logrus.New()
+	u := unpack{
+		logger: logrus.NewEntry(logger),
+	}
+	cmd := &cobra.Command{
+		Use:   "unpack <image>",
+		Short: "unpack an index image",
+		Long:  "unpack an index image's content(i.e operators shipped with the index)",
+		Args:  cobra.ExactArgs(1),
+		PreRunE: func(_ *cobra.Command, args []string) error {
+			u.image = args[0]
+			if u.debug {
+				logger.SetLevel(logrus.DebugLevel)
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return u.run(cmd.Context())
+		},
+	}
+
+	cmd.Flags().BoolVar(&u.debug, "debug", false, "enable debug logging")
+	cmd.Flags().StringVarP(&u.caFile, "ca-file", "", "", "the root Certificates to use with this command")
+	cmd.Flags().BoolVar(&u.skipTLS, "skip-tls", false, "disable TLS verification")
+	cmd.Flags().StringVarP(&u.dir, "unpack-dir", "", "", "the directory the configs will be copied to")
+	return cmd
+}
+
+func (u *unpack) run(ctx context.Context) error {
+
+	reg, err := containerdregistry.NewRegistry()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := reg.Destroy(); err != nil {
+			u.logger.WithError(err).Warn("error destroying local cache")
+		}
+	}()
+
+	unpacker := action.NewIndexUnpacker(u.logger, reg, ctx)
+	request := action.UnpackRequest{
+		Image:     u.image,
+		UnpackDir: u.dir,
+	}
+	return unpacker.Unpack(request)
+}

--- a/pkg/action/generate_dockerfile.go
+++ b/pkg/action/generate_dockerfile.go
@@ -1,0 +1,35 @@
+package action
+
+import (
+	"os"
+
+	"github.com/operator-framework/operator-registry/pkg/containertools"
+	"github.com/sirupsen/logrus"
+)
+
+type generator struct {
+	logger *logrus.Entry
+}
+
+type GenerateDockerfileRequest struct {
+	SourceImage string
+	ConfigsDir  string
+	File        *os.File
+}
+
+func NewGenerator(logger *logrus.Entry) generator {
+	return generator{
+		logger: logger,
+	}
+}
+
+func (g generator) GenerateDockerfile(request GenerateDockerfileRequest) error {
+	generator := containertools.NewConfigDockerFileGenerator(g.logger)
+	content := generator.GenerateIndexDockerfile(request.SourceImage, request.ConfigsDir)
+
+	_, err := request.File.WriteString(content)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/action/index_unpacker.go
+++ b/pkg/action/index_unpacker.go
@@ -1,0 +1,80 @@
+package action
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/operator-framework/operator-registry/pkg/containertools"
+	"github.com/operator-framework/operator-registry/pkg/image"
+	"github.com/operator-framework/operator-registry/pkg/image/containerdregistry"
+
+	dircopy "github.com/otiai10/copy"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	defaultDockerfileName = "index.Dockerfile"
+	imgUnpackTmpDirPrefix = "tmp_unpack_"
+	defaultUnpackDir      = "configs"
+)
+
+type indexUnpacker struct {
+	logger *logrus.Entry
+	reg    *containerdregistry.Registry
+	ctx    context.Context
+}
+
+type UnpackRequest struct {
+	Image     string
+	UnpackDir string
+}
+
+func NewIndexUnpacker(l *logrus.Entry, r *containerdregistry.Registry, ctx context.Context) indexUnpacker {
+	return indexUnpacker{
+		logger: l,
+		reg:    r,
+		ctx:    ctx,
+	}
+}
+
+func (i indexUnpacker) Unpack(request UnpackRequest) error {
+	i.logger.Infof("Pulling image %q to get metadata", request.Image)
+
+	imageRef := image.SimpleReference(request.Image)
+	if err := i.reg.Pull(i.ctx, imageRef); err != nil {
+		return fmt.Errorf("error pulling image from remote registry. Error: %v", err)
+	}
+	// Get the index image's ConfigsLocation Label to find this path
+	labels, err := i.reg.Labels(context.TODO(), imageRef)
+	if err != nil {
+		return err
+	}
+
+	configsLocation, ok := labels[containertools.ConfigsLocationLabel]
+	if !ok {
+		return fmt.Errorf("index image %q missing label %q", request.Image, containertools.ConfigsLocationLabel)
+	}
+
+	tmpDir, err := ioutil.TempDir("./", imgUnpackTmpDirPrefix)
+	defer os.RemoveAll(tmpDir)
+	if err != nil {
+		return err
+	}
+	i.reg.Unpack(context.TODO(), imageRef, tmpDir)
+
+	if request.UnpackDir == "" {
+		request.UnpackDir = defaultUnpackDir
+	}
+	configDir := filepath.Join("./", request.UnpackDir)
+	if err := os.MkdirAll(configDir, 0777); err != nil {
+		return err
+	}
+	if err := dircopy.Copy(filepath.Join(tmpDir, configsLocation), configDir, dircopy.Options{}); err != nil {
+		return err
+	}
+	i.logger.Infof("Unpacked image %q to directory %q", request.Image, request.UnpackDir)
+	return nil
+}

--- a/pkg/containertools/dockerfilegenerator.go
+++ b/pkg/containertools/dockerfilegenerator.go
@@ -11,6 +11,8 @@ const (
 	defaultBinarySourceImage = "quay.io/operator-framework/upstream-opm-builder"
 	DefaultDbLocation        = "/database/index.db"
 	DbLocationLabel          = "operators.operatorframework.io.index.database.v1"
+	DefaultConfigsLocation   = "/configs"
+	ConfigsLocationLabel     = "operators.operatorframework.io.index.configs.v1"
 )
 
 // DockerfileGenerator defines functions to generate index dockerfiles
@@ -23,8 +25,8 @@ type IndexDockerfileGenerator struct {
 	Logger *logrus.Entry
 }
 
-// NewDockerfileGenerator is a constructor that returns a DockerfileGenerator
-func NewDockerfileGenerator(logger *logrus.Entry) DockerfileGenerator {
+// NewIndexDockerfileGenerator is a constructor that returns a DockerfileGenerator
+func NewIndexDockerfileGenerator(logger *logrus.Entry) DockerfileGenerator {
 	return &IndexDockerfileGenerator{
 		Logger: logger,
 	}
@@ -52,6 +54,36 @@ func (g *IndexDockerfileGenerator) GenerateIndexDockerfile(binarySourceImage, da
 	dockerfile += fmt.Sprintf("EXPOSE 50051\n")
 	dockerfile += fmt.Sprintf("ENTRYPOINT [\"/bin/opm\"]\n")
 	dockerfile += fmt.Sprintf("CMD [\"registry\", \"serve\", \"--database\", \"%s\"]\n", DefaultDbLocation)
+
+	return dockerfile
+}
+
+type ConfigDockerFileGenerator struct {
+	Logger *logrus.Entry
+}
+
+func NewConfigDockerFileGenerator(logger *logrus.Entry) DockerfileGenerator {
+	return &ConfigDockerFileGenerator{
+		Logger: logger,
+	}
+}
+
+func (g *ConfigDockerFileGenerator) GenerateIndexDockerfile(binarySourceImage, configsPath string) string {
+	var dockerfile string
+
+	g.Logger.Info("Generating dockerfile")
+
+	// From
+	dockerfile += fmt.Sprintf("FROM %s\n", binarySourceImage)
+
+	// Labels
+	dockerfile += fmt.Sprintf("LABEL %s=%s\n", ConfigsLocationLabel, DefaultConfigsLocation)
+
+	// Content
+	dockerfile += fmt.Sprintf("ADD %s %s\n", configsPath, DefaultConfigsLocation)
+	dockerfile += fmt.Sprintf("EXPOSE 50051\n")
+	dockerfile += fmt.Sprintf("ENTRYPOINT [\"/bin/opm\"]\n")
+	dockerfile += fmt.Sprintf("CMD [\"serve\",\"%s\"]\n", DefaultConfigsLocation)
 
 	return dockerfile
 }

--- a/pkg/containertools/dockerfilegenerator_test.go
+++ b/pkg/containertools/dockerfilegenerator_test.go
@@ -56,3 +56,27 @@ CMD ["registry", "serve", "--database", "/database/index.db"]
 	dockerfile := dockerfileGenerator.GenerateIndexDockerfile("", databasePath)
 	require.Equal(t, dockerfile, expectedDockerfile)
 }
+
+func TestGenerateConfigsDockerfile(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	binarySourceImage := "quay.io/operator-framework/builder"
+	configsPath := "configs"
+	expectedDockerfile := `FROM quay.io/operator-framework/builder
+LABEL operators.operatorframework.io.index.configs.v1=/configs
+ADD configs /configs
+EXPOSE 50051
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve","/configs"]
+`
+
+	logger := logrus.NewEntry(logrus.New())
+
+	dockerfileGenerator := containertools.ConfigDockerFileGenerator{
+		Logger: logger,
+	}
+
+	dockerfile := dockerfileGenerator.GenerateIndexDockerfile(binarySourceImage, configsPath)
+	require.Equal(t, dockerfile, expectedDockerfile)
+}

--- a/pkg/lib/indexer/interfaces.go
+++ b/pkg/lib/indexer/interfaces.go
@@ -17,7 +17,7 @@ type IndexAdder interface {
 // NewIndexAdder is a constructor that returns an IndexAdder
 func NewIndexAdder(buildTool, pullTool containertools.ContainerTool, logger *logrus.Entry) IndexAdder {
 	return ImageIndexer{
-		DockerfileGenerator: containertools.NewDockerfileGenerator(logger),
+		DockerfileGenerator: containertools.NewIndexDockerfileGenerator(logger),
 		CommandRunner:       containertools.NewCommandRunner(buildTool, logger),
 		LabelReader:         containertools.NewLabelReader(pullTool, logger),
 		RegistryAdder:       registry.NewRegistryAdder(logger),
@@ -37,7 +37,7 @@ type IndexDeleter interface {
 // NewIndexDeleter is a constructor that returns an IndexDeleter
 func NewIndexDeleter(buildTool, pullTool containertools.ContainerTool, logger *logrus.Entry) IndexDeleter {
 	return ImageIndexer{
-		DockerfileGenerator: containertools.NewDockerfileGenerator(logger),
+		DockerfileGenerator: containertools.NewIndexDockerfileGenerator(logger),
 		CommandRunner:       containertools.NewCommandRunner(buildTool, logger),
 		LabelReader:         containertools.NewLabelReader(pullTool, logger),
 		RegistryDeleter:     registry.NewRegistryDeleter(logger),
@@ -55,7 +55,7 @@ type IndexExporter interface {
 // NewIndexExporter is a constructor that returns an IndexExporter
 func NewIndexExporter(containerTool containertools.ContainerTool, logger *logrus.Entry) IndexExporter {
 	return ImageIndexer{
-		DockerfileGenerator: containertools.NewDockerfileGenerator(logger),
+		DockerfileGenerator: containertools.NewIndexDockerfileGenerator(logger),
 		CommandRunner:       containertools.NewCommandRunner(containerTool, logger),
 		LabelReader:         containertools.NewLabelReader(containerTool, logger),
 		BuildTool:           containerTool,
@@ -71,7 +71,7 @@ type IndexStrandedPruner interface {
 
 func NewIndexStrandedPruner(containerTool containertools.ContainerTool, logger *logrus.Entry) IndexStrandedPruner {
 	return ImageIndexer{
-		DockerfileGenerator:    containertools.NewDockerfileGenerator(logger),
+		DockerfileGenerator:    containertools.NewIndexDockerfileGenerator(logger),
 		CommandRunner:          containertools.NewCommandRunner(containerTool, logger),
 		LabelReader:            containertools.NewLabelReader(containerTool, logger),
 		RegistryStrandedPruner: registry.NewRegistryStrandedPruner(logger),
@@ -88,7 +88,7 @@ type IndexPruner interface {
 
 func NewIndexPruner(containerTool containertools.ContainerTool, logger *logrus.Entry) IndexPruner {
 	return ImageIndexer{
-		DockerfileGenerator: containertools.NewDockerfileGenerator(logger),
+		DockerfileGenerator: containertools.NewIndexDockerfileGenerator(logger),
 		CommandRunner:       containertools.NewCommandRunner(containerTool, logger),
 		LabelReader:         containertools.NewLabelReader(containerTool, logger),
 		RegistryPruner:      registry.NewRegistryPruner(logger),
@@ -105,7 +105,7 @@ type IndexDeprecator interface {
 
 func NewIndexDeprecator(buildTool, pullTool containertools.ContainerTool, logger *logrus.Entry) IndexDeprecator {
 	return ImageIndexer{
-		DockerfileGenerator: containertools.NewDockerfileGenerator(logger),
+		DockerfileGenerator: containertools.NewIndexDockerfileGenerator(logger),
 		CommandRunner:       containertools.NewCommandRunner(buildTool, logger),
 		LabelReader:         containertools.NewLabelReader(pullTool, logger),
 		RegistryDeprecator:  registry.NewRegistryDeprecator(logger),


### PR DESCRIPTION
**Description of the change:**

This PR introduces
* The opm generate command that generates the Dockerfile for building
and index with a directory of configs
* The opm unpack command that allows for the inspection of an index
image for it's cotent package configs.

**Motivation for the change:**

https://github.com/operator-framework/enhancements/blob/master/enhancements/declarative-index-config.md

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
