### PR TITLE
cmd,pkg: Deflate unnecessary conditionals

### DIFF
--- a/cmd/opm/index/add.go
+++ b/cmd/opm/index/add.go
@@ -195,9 +195,8 @@ func getContainerTools(cmd *cobra.Command) (string, string, error) {
 	if containerTool != "" {
 		if pullTool == "" && buildTool == "" {
 			return containerTool, containerTool, nil
-		} else {
-			return "", "", fmt.Errorf("container-tool cannot be set alongside pull-tool or build-tool")
 		}
+		return "", "", fmt.Errorf("container-tool cannot be set alongside pull-tool or build-tool")
 	}
 
 	// Check for defaults, then return

--- a/pkg/lib/bundle/utils_test.go
+++ b/pkg/lib/bundle/utils_test.go
@@ -70,8 +70,7 @@ func clearDir(dir string) {
 	for _, item := range items {
 		if item.IsDir() {
 			continue
-		} else {
-			os.Remove(filepath.Join(dir, item.Name()))
 		}
+		os.Remove(filepath.Join(dir, item.Name()))
 	}
 }

--- a/pkg/lib/validation/bundle.go
+++ b/pkg/lib/validation/bundle.go
@@ -56,9 +56,9 @@ func validateOwnedCRDs(bundle *registry.Bundle, csv *registry.ClusterServiceVers
 	for _, ownedKey := range ownedKeys {
 		if _, ok := keySet[*ownedKey]; !ok {
 			result.Add(errors.ErrInvalidBundle(fmt.Sprintf("owned CRD %s not found in bundle %q", keyToString(*ownedKey), bundle.Name), *ownedKey))
-		} else {
-			delete(keySet, *ownedKey)
+			continue
 		}
+		delete(keySet, *ownedKey)
 	}
 	// CRDs not defined in the CSV present in the bundle
 	for key := range keySet {

--- a/pkg/registry/bundlegraphloader.go
+++ b/pkg/registry/bundlegraphloader.go
@@ -42,11 +42,10 @@ func (g *BundleGraphLoader) AddBundleToGraph(bundle *Bundle, graph *Package, ann
 
 	if graph.DefaultChannel == "" {
 		// Infer default channel from channel list
-		if annotations.SelectDefaultChannel() != "" {
-			graph.DefaultChannel = annotations.SelectDefaultChannel()
-		} else {
+		if annotations.SelectDefaultChannel() == "" {
 			return nil, fmt.Errorf("Default channel is missing and can't be inferred")
 		}
+		graph.DefaultChannel = annotations.SelectDefaultChannel()
 	}
 
 	// generate the DAG for each channel the new bundle is being insert into

--- a/pkg/sqlite/query.go
+++ b/pkg/sqlite/query.go
@@ -645,7 +645,7 @@ func (s *SQLQuerier) GetApisForEntry(ctx context.Context, entryID int64) (provid
 	kinds := map[string]struct{}{}
 	versions := map[string]struct{}{}
 
-	providedQuery := `SELECT properties.value FROM properties 
+	providedQuery := `SELECT properties.value FROM properties
 		 	  		  INNER JOIN channel_entry ON channel_entry.operatorbundle_name = properties.operatorbundle_name
 			  		  WHERE properties.type=? AND channel_entry.entry_id=?`
 
@@ -821,11 +821,10 @@ func (s *SQLQuerier) GetBundlePathsForPackage(ctx context.Context, pkgName strin
 		if err := rows.Scan(&imgName); err != nil {
 			return nil, err
 		}
-		if imgName.Valid && imgName.String != "" {
-			images = append(images, imgName.String)
-		} else {
+		if imgName.Valid && imgName.String == "" {
 			return nil, fmt.Errorf("Index malformed: cannot find paths to bundle images")
 		}
+		images = append(images, imgName.String)
 	}
 	return images, nil
 }
@@ -1173,7 +1172,7 @@ func (s *SQLQuerier) GetDependenciesForBundle(ctx context.Context, name, version
 }
 
 func (s *SQLQuerier) GetPropertiesForBundle(ctx context.Context, name, version, path string) (properties []*api.Property, err error) {
-	propQuery := `SELECT DISTINCT type, value FROM properties 
+	propQuery := `SELECT DISTINCT type, value FROM properties
 				 WHERE operatorbundle_name=?
 				 AND (operatorbundle_version=? OR operatorbundle_version is NULL)
 				 AND (operatorbundle_path=? OR operatorbundle_path is NULL)`


### PR DESCRIPTION
Remove unneeded if/else conditionals where the if/else both specify
return statements.

Deflate if/else conditionals where in loops using the `continue`
keyword.

Switch the if/else logic to avoid nested conditionals.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
