### PR TITLE
Add optional go-apidiff test to CI

### DIFF
--- a/.github/workflows/go-apidiff.yaml
+++ b/.github/workflows/go-apidiff.yaml
@@ -1,0 +1,27 @@
+name: go-apidiff
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    paths:
+      - '**'
+      - '!doc/**'
+
+jobs:
+  go-apidiff:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+      id: go
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Run go-apidiff
+      uses: joelanford/go-apidiff@master


### PR DESCRIPTION
I wrote [`go-apidiff`](https://github.com/joelanford/go-apidiff) to help maintainers of `kubernetes-sigs/controller-runtime` easily identify PRs that break Go APIs. It's also being used in `kubernetes-sigs/cluster-api*` repos.

Today I finally got around to making a GitHub action out of it. I figured it might help in some of the operator-framework repos that are used as libraries.

It will compare the PR head with the target branch, report any API changes, and fail if any of them are breaking changes. Other projects using this make this test optional so that it is a simple signal to maintainers about whether changes are API-compatible.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
