### PR TITLE
.github: Add a sanity check for Go packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,18 @@ on:
       - '**'
       - '!doc/**'
 jobs:
+  sanity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '~1.16'
+      - name: Install goimports
+        run: go install golang.org/x/tools/cmd/goimports@latest
+      - name: Run sanity checks
+        run: make vendor && make lint && git diff --exit-code
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,10 @@ vendor:
 	$(GO) mod vendor
 	$(GO) mod verify
 
+.PHONY: lint
+lint:
+	find . -name '*.go' -not -path "./vendor/*" | xargs goimports -w
+
 .PHONY: codegen
 codegen:
 	protoc -I pkg/api/ --go_out=pkg/api pkg/api/*.proto

--- a/pkg/api/grpc_health_v1/health.pb.go
+++ b/pkg/api/grpc_health_v1/health.pb.go
@@ -7,11 +7,12 @@
 package grpc_health_v1
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	proto "github.com/golang/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/pkg/api/grpc_health_v1/health_grpc.pb.go
+++ b/pkg/api/grpc_health_v1/health_grpc.pb.go
@@ -4,6 +4,7 @@ package grpc_health_v1
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/pkg/api/registry.pb.go
+++ b/pkg/api/registry.pb.go
@@ -7,11 +7,12 @@
 package api
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	proto "github.com/golang/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/pkg/api/registry_grpc.pb.go
+++ b/pkg/api/registry_grpc.pb.go
@@ -4,6 +4,7 @@ package api
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/pkg/image/containerdregistry/resolver.go
+++ b/pkg/image/containerdregistry/resolver.go
@@ -28,7 +28,7 @@ func NewResolver(configDir string, insecure bool, roots *x509.CertPool) (remotes
 		ExpectContinueTimeout: 5 * time.Second,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: false,
-			RootCAs: roots,
+			RootCAs:            roots,
 		},
 	}
 
@@ -60,7 +60,7 @@ func NewResolver(configDir string, insecure bool, roots *x509.CertPool) (remotes
 	}
 
 	opts := docker.ResolverOptions{
-		Hosts: docker.ConfigureDefaultRegistries(regopts...),
+		Hosts:   docker.ConfigureDefaultRegistries(regopts...),
 		Headers: headers,
 	}
 

--- a/pkg/image/registry.go
+++ b/pkg/image/registry.go
@@ -29,4 +29,3 @@ type Registry interface {
 	// If it exists, it's used as the base image.
 	// Pack(ctx context.Context, ref Reference, from io.Reader) (next string, err error)
 }
-

--- a/pkg/lib/bundle/interfaces.go
+++ b/pkg/lib/bundle/interfaces.go
@@ -25,6 +25,6 @@ func NewImageValidator(registry image.Registry, logger *logrus.Entry, options ..
 	return imageValidator{
 		registry: registry,
 		logger:   logger,
-		optional:  options,
+		optional: options,
 	}
 }

--- a/pkg/lib/dns/nsswitch_test.go
+++ b/pkg/lib/dns/nsswitch_test.go
@@ -1,10 +1,11 @@
 package dns
 
 import (
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestEnsureNsswitch(t *testing.T) {

--- a/pkg/lib/indexer/indexer_test.go
+++ b/pkg/lib/indexer/indexer_test.go
@@ -29,7 +29,7 @@ func TestGetBundlesToExport(t *testing.T) {
 		t.Fatalf("creating querier: %s", err)
 	}
 
-	bundleMap, err := getBundlesToExport(dbQuerier, []string {"etcd"})
+	bundleMap, err := getBundlesToExport(dbQuerier, []string{"etcd"})
 	if err != nil {
 		t.Fatalf("exporting bundles from db: %s", err)
 	}

--- a/pkg/registry/bundlegraphloader_test.go
+++ b/pkg/registry/bundlegraphloader_test.go
@@ -2,8 +2,9 @@ package registry
 
 import (
 	"encoding/json"
-	"github.com/blang/semver"
 	"testing"
+
+	"github.com/blang/semver"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -315,55 +316,55 @@ func TestBundleGraphLoader(t *testing.T) {
 }
 
 func TestIsSkipPatchCandidate(t *testing.T) {
-	tests := []struct{
-		name     string
-		added     string
-		compare  string
-		expected bool
+	tests := []struct {
+		name        string
+		added       string
+		compare     string
+		expected    bool
 		commutative bool
 	}{
 		{
-			name: "equal versions",
-			added: "0.0.0",
-			compare: "0.0.0",
-			expected: false,
+			name:        "equal versions",
+			added:       "0.0.0",
+			compare:     "0.0.0",
+			expected:    false,
 			commutative: true,
 		},
 		{
-			name: "do not accept different major/minor version",
-			added: "0.1.0",
-			compare: "0.2.0",
-			expected: false,
+			name:        "do not accept different major/minor version",
+			added:       "0.1.0",
+			compare:     "0.2.0",
+			expected:    false,
 			commutative: true,
 		},
 		{
-			name: "accept larger patch version",
-			added: "0.0.1",
-			compare: "0.0.0",
+			name:     "accept larger patch version",
+			added:    "0.0.1",
+			compare:  "0.0.0",
 			expected: true,
 		},
 		{
-			name: "accept patch version without pre-release",
-			added: "0.0.0",
-			compare: "0.0.0-1",
+			name:     "accept patch version without pre-release",
+			added:    "0.0.0",
+			compare:  "0.0.0-1",
 			expected: true,
 		},
 		{
-			name: "accept longer pre-release with same prefix",
-			added: "0.0.1-1.2",
-			compare: "0.0.1-1",
+			name:     "accept longer pre-release with same prefix",
+			added:    "0.0.1-1.2",
+			compare:  "0.0.1-1",
 			expected: true,
 		},
 		{
-			name: "accept numerically larger pre-release",
-			added: "0.0.1-11",
-			compare: "0.0.1-2",
+			name:     "accept numerically larger pre-release",
+			added:    "0.0.1-11",
+			compare:  "0.0.1-2",
 			expected: true,
 		},
 		{
-			name: "accept lexicographically larger pre-release",
-			added: "0.0.1-beta.1",
-			compare: "0.0.1-alpha.1",
+			name:     "accept lexicographically larger pre-release",
+			added:    "0.0.1-beta.1",
+			compare:  "0.0.1-alpha.1",
 			expected: true,
 		},
 	}

--- a/pkg/registry/csv_test.go
+++ b/pkg/registry/csv_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestClusterServiceVersion_GetApiServiceDefinitions(t *testing.T) {

--- a/pkg/registry/decode_test.go
+++ b/pkg/registry/decode_test.go
@@ -1,12 +1,13 @@
 package registry
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestDecodeUnstructured(t *testing.T) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -15,7 +15,7 @@ type RegistryServer struct {
 var _ api.RegistryServer = &RegistryServer{}
 
 func NewRegistryServer(store registry.Query) *RegistryServer {
-	return &RegistryServer{UnimplementedRegistryServer: api.UnimplementedRegistryServer{},  store: store}
+	return &RegistryServer{UnimplementedRegistryServer: api.UnimplementedRegistryServer{}, store: store}
 }
 
 func (s *RegistryServer) ListPackages(req *api.ListPackageRequest, stream api.Registry_ListPackagesServer) error {

--- a/pkg/sqlite/db.go
+++ b/pkg/sqlite/db.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"database/sql"
+
 	_ "github.com/mattn/go-sqlite3"
 )
 
@@ -19,11 +20,10 @@ func OpenReadOnly(fileName string) (*sql.DB, error) {
 // EnableForeignKeys appends the option to enable foreign keys on connections
 // note that without this option, PRAGMAs about foreign keys will lie.
 func EnableForeignKeys(fileName string) string {
-	return "file:"+fileName+"?_foreign_keys=on"
+	return "file:" + fileName + "?_foreign_keys=on"
 }
 
 // Immutable appends the option to mark the db immutable on connections
 func EnableImmutable(fileName string) string {
-	return "file:"+fileName+"?immutable=true"
+	return "file:" + fileName + "?immutable=true"
 }
-

--- a/pkg/sqlite/migrations/006_associate_apis_with_bundle.go
+++ b/pkg/sqlite/migrations/006_associate_apis_with_bundle.go
@@ -3,6 +3,7 @@ package migrations
 import (
 	"context"
 	"database/sql"
+
 	"github.com/operator-framework/operator-registry/pkg/registry"
 )
 

--- a/pkg/sqlite/migrations/006_associate_apis_with_bundle_test.go
+++ b/pkg/sqlite/migrations/006_associate_apis_with_bundle_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/operator-framework/operator-registry/pkg/registry"
 	"testing"
+
+	"github.com/operator-framework/operator-registry/pkg/registry"
 
 	"github.com/stretchr/testify/require"
 

--- a/pkg/sqlite/remove_test.go
+++ b/pkg/sqlite/remove_test.go
@@ -2,8 +2,9 @@ package sqlite
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/operator-framework/operator-registry/pkg/image"
 	"github.com/operator-framework/operator-registry/pkg/registry"

--- a/tools.go
+++ b/tools.go
@@ -3,9 +3,9 @@
 package tools
 
 import (
-	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
-	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
 	_ "github.com/grpc-ecosystem/grpc-health-probe"
 	_ "github.com/maxbrunsfeld/counterfeiter/v6"
 	_ "github.com/onsi/ginkgo/ginkgo"
+	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
+	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
 )


### PR DESCRIPTION
Add a vendor check to the testing actions that runs `$(make) vendor` and
verifies that the vendor directory is up-to-date and no `git diff` has
been produced.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
