### PR TITLE
test/e2e: Fix output log message when Podman is not found

### DIFF
--- a/test/e2e/opm_test.go
+++ b/test/e2e/opm_test.go
@@ -485,7 +485,9 @@ var _ = Describe("opm", func() {
 	}
 
 	Context("using docker", func() {
-		if err := exec.Command("docker").Run(); err != nil {
+		cmd := exec.Command("docker")
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
 			GinkgoT().Logf("container tool docker not found - skipping docker-based opm e2e tests: %v", err)
 			return
 		}
@@ -493,7 +495,9 @@ var _ = Describe("opm", func() {
 	})
 
 	Context("using podman", func() {
-		if err := exec.Command("podman", "info").Run(); err != nil {
+		cmd := exec.Command("podman", "info")
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
 			GinkgoT().Logf("container tool podman not found - skipping podman-based opm e2e tests: %v", err)
 			return
 		}

--- a/test/e2e/opm_test.go
+++ b/test/e2e/opm_test.go
@@ -486,7 +486,7 @@ var _ = Describe("opm", func() {
 
 	Context("using docker", func() {
 		if err := exec.Command("docker").Run(); err != nil {
-			GinkgoT().Logf("container tool docker not found - skipping docker-based opm e2e tests: %s", err)
+			GinkgoT().Logf("container tool docker not found - skipping docker-based opm e2e tests: %v", err)
 			return
 		}
 		IncludeSharedSpecs("docker")
@@ -494,7 +494,7 @@ var _ = Describe("opm", func() {
 
 	Context("using podman", func() {
 		if err := exec.Command("podman", "info").Run(); err != nil {
-			GinkgoT().Log("container tool podman not found - skipping podman-based opm e2e tests: %s", err)
+			GinkgoT().Logf("container tool podman not found - skipping podman-based opm e2e tests: %v", err)
 			return
 		}
 		IncludeSharedSpecs("podman")


### PR DESCRIPTION
These are minor cosmetic changes that I noted when attempting to run the e2e suite locally.

Switch from `.Log(...)` to `.Logf(...)` when passing an error argument.

Use the `%v` format specifier instead of `%s` when interacting with
`error` typed arguments.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
