### PR TITLE
Stream bundles to the ListBundles response.

### DIFF
--- a/pkg/registry/empty.go
+++ b/pkg/registry/empty.go
@@ -100,6 +100,10 @@ func (EmptyQuery) ListBundles(ctx context.Context) ([]*api.Bundle, error) {
 	return nil, errors.New("empty querier: cannot list bundles")
 }
 
+func (EmptyQuery) ListBundlesAsStream(ctx context.Context) (BundleCursor, error) {
+	return nil, errors.New("empty querier: cannot list bundles")
+}
+
 func (EmptyQuery) GetDependenciesForBundle(ctx context.Context, name, version, path string) (dependencies []*api.Dependency, err error) {
 	return nil, errors.New("empty querier: cannot get dependencies for bundle")
 }

--- a/pkg/registry/interface.go
+++ b/pkg/registry/interface.go
@@ -17,6 +17,12 @@ type Load interface {
 	ClearNonHeadBundles() error
 }
 
+type BundleCursor interface {
+	Next(context.Context) *api.Bundle
+	Close()
+	Err() error
+}
+
 type Query interface {
 	ListTables(ctx context.Context) ([]string, error)
 	ListPackages(ctx context.Context) ([]string, error)
@@ -55,6 +61,8 @@ type Query interface {
 	GetCurrentCSVNameForChannel(ctx context.Context, pkgName, channel string) (string, error)
 	// List all available bundles in the database
 	ListBundles(ctx context.Context) (bundles []*api.Bundle, err error)
+	// List all available bundles in the database, streaming version
+	ListBundlesAsStream(ctx context.Context) (BundleCursor, error)
 	// Get the list of dependencies for a bundle
 	GetDependenciesForBundle(ctx context.Context, name, version, path string) (dependencies []*api.Dependency, err error)
 	// Get the bundle path if it exists


### PR DESCRIPTION
The existing implementation of the ListBundles endpoint collects all
bundles first, then writes them to the response. It now writes bundles
to the response as they are read out of the database in order to
reduce the memory usage high watermark.
