### PR TITLE
Read only CSV content in ListBundles query.

### DIFF
--- a/pkg/sqlite/query.go
+++ b/pkg/sqlite/query.go
@@ -973,7 +973,7 @@ tip (depth) AS (
 )
 SELECT
     replaces_bundle.entry_id,
-    operatorbundle.bundle,
+    operatorbundle.csv,
     operatorbundle.bundlepath,
     operatorbundle.name,
     replaces_bundle.package_name,


### PR DESCRIPTION
The original implementation extracts the CSV manifest from the
concatenation of all manifests in a bundle.
