### PR TITLE
Bump to Go 1.16

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '~1.15'
+          go-version: '~1.16'
       - run: |
           echo "asset_path=bin/opm" >> $GITHUB_ENV
           echo "asset_name=$(go env GOOS)-$(go env GOARCH)-opm$(go env GOEXE)" >> $GITHUB_ENV

--- a/appr-registry.Dockerfile
+++ b/appr-registry.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine as builder
+FROM golang:1.16-alpine as builder
 
 RUN apk update && apk add sqlite build-base git mercurial bash
 WORKDIR /go/src/github.com/operator-framework/operator-registry
@@ -6,7 +6,7 @@ WORKDIR /go/src/github.com/operator-framework/operator-registry
 COPY . .
 RUN make static
 
-FROM golang:1.15-alpine as probe-builder
+FROM golang:1.16-alpine as probe-builder
 
 RUN apk update && apk add build-base git
 ENV ORG github.com/grpc-ecosystem

--- a/codegen.Dockerfile
+++ b/codegen.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine
+FROM golang:1.16-alpine
 
 RUN apk update && \
     apk add make git protobuf

--- a/registry.Dockerfile
+++ b/registry.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine as builder
+FROM golang:1.16-alpine as builder
 
 RUN apk update && apk add sqlite build-base git mercurial bash
 WORKDIR /build

--- a/upstream-builder.Dockerfile
+++ b/upstream-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine as builder
+FROM golang:1.16-alpine as builder
 
 RUN apk update && apk add sqlite build-base git mercurial bash
 WORKDIR /build

--- a/upstream-opm-builder.Dockerfile
+++ b/upstream-opm-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine AS builder
+FROM golang:1.16-alpine AS builder
 
 RUN apk update && apk add sqlite build-base git mercurial bash
 WORKDIR /build


### PR DESCRIPTION
**Description of the change:**
Bump all operator-registry builds to Go 1.16

**Motivation for the change:**
Update to latest version of Go.
