### PR TITLE
Fix nil function in buildContext return values

### DIFF
--- a/pkg/lib/indexer/indexer.go
+++ b/pkg/lib/indexer/indexer.go
@@ -394,6 +394,9 @@ func copyDatabaseTo(databaseFile, targetDir string) (string, error) {
 }
 
 func buildContext(generate bool, requestedDockerfile string) (buildDir, outDockerfile string, cleanup func(), err error) {
+	// set cleanup to a no-op until explicitly set
+	cleanup = func() {}
+
 	if generate {
 		buildDir = "./"
 		if len(requestedDockerfile) == 0 {

--- a/pkg/lib/indexer/indexer_test.go
+++ b/pkg/lib/indexer/indexer_test.go
@@ -29,7 +29,7 @@ func TestGetBundlesToExport(t *testing.T) {
 		t.Fatalf("creating querier: %s", err)
 	}
 
-	bundleMap, err := getBundlesToExport(dbQuerier, []string {"etcd"})
+	bundleMap, err := getBundlesToExport(dbQuerier, []string{"etcd"})
 	if err != nil {
 		t.Fatalf("exporting bundles from db: %s", err)
 	}
@@ -82,4 +82,62 @@ func TestGeneratePackageYaml(t *testing.T) {
 	}
 
 	_ = os.RemoveAll("./package.yaml")
+}
+
+func TestBuildContext(t *testing.T) {
+	// TODO(): Test does not currently have a clean way
+	// of testing the generated returned values such as
+	// outDockerfile and buildDir.
+
+	defaultBuildDirOnGenerate := "./"
+	fooDockerfile := "foo.Dockerfile"
+	defaultDockerfile := defaultDockerfileName
+
+	cases := []struct {
+		generate              bool
+		requestedDockerfile   string
+		expectedBuildDir      *string // return values not checked if nil
+		expectedOutDockerfile *string // return values not checked if nil
+	}{
+		{
+			generate:              true,
+			requestedDockerfile:   "",
+			expectedOutDockerfile: &defaultDockerfile,
+			expectedBuildDir:      &defaultBuildDirOnGenerate,
+		},
+		{
+			generate:              false,
+			requestedDockerfile:   "foo.Dockerfile",
+			expectedOutDockerfile: &fooDockerfile,
+			expectedBuildDir:      nil,
+		},
+		{
+			generate:              false,
+			requestedDockerfile:   "",
+			expectedOutDockerfile: nil,
+			expectedBuildDir:      nil,
+		},
+	}
+
+	for _, testCase := range cases {
+		actualBuildDir, actualOutDockerfile, actualCleanup, _ := buildContext(
+			testCase.generate, testCase.requestedDockerfile)
+
+		if actualCleanup == nil {
+			// prevent regression - cleanup should never be nil
+			t.Fatal("buildContext returned nil cleanup function")
+		}
+
+		if testCase.expectedOutDockerfile != nil && actualOutDockerfile != *testCase.expectedOutDockerfile {
+			t.Fatalf("comparing outDockerfile: expected %v actual %v",
+				*testCase.expectedOutDockerfile,
+				actualOutDockerfile)
+		}
+
+		if testCase.expectedBuildDir != nil && actualBuildDir != *testCase.expectedBuildDir {
+			t.Fatalf("comparing buildDir: expected %v actual %v",
+				*testCase.expectedBuildDir,
+				actualBuildDir)
+		}
+	}
 }


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

The change sets a return value for `cleanup` (type `func()`) to a no-op at the top of the function logic. This helps prevent a situation where returning before setting that function in `buildContext()` can cause a `<nil>` to be returned for that value which throws an error at runtime when called.

**Concrete Context**

During an `opm index prune` -

In pkg/lib/indexer/indexer.go:

```go
func (i ImageIndexer) PruneFromIndex(request PruneFromIndexRequest) error {
    buildDir, outDockerfile, cleanup, err := buildContext(request.Generate, request.OutDockerfile)
    defer cleanup()
    if err != nil {
        return err
    }

    // ...
```

If the user has not passed `--generate` to `opm index prune` AND they cannot write to the underlying directory, `buildContext(...)` runs into an error trying to `TempDir(...)`:

```go
func buildContext(generate bool, requestedDockerfile string) (buildDir, outDockerfile string, cleanup func(), err error) {
    if generate {
        ...
    }

    // set a temp directory for building the new image
    buildDir, err = ioutil.TempDir(".", tmpBuildDirPrefix)     // error is here
    if err != nil {
        return
    }
    cleanup = func() {
        os.RemoveAll(buildDir)
    }
```

Up until that point `cleanup` hasn't been defined, so it's `<nil>`.  Then, `buildContext` completes and the next line of `PruneFromIndex` calls `defer cleanup()` (i.e. `defer <nil>()`) which causes the panic.


**Motivation for the change:**

https://bugzilla.redhat.com/show_bug.cgi?id=1943284 - While needing write permissions is fair, other commands return a permission denied (bubbling up from `ioutil.TempDir`). I think that was probably the intention for this command as well.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [X] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
