### PR TITLE
Dockerfile: Add a symbolically linked release Dockerfile

### DIFF
--- a/operator-registry.Dockerfile
+++ b/operator-registry.Dockerfile
@@ -1,0 +1,1 @@
+Dockerfile


### PR DESCRIPTION
Introduce the operator-registry.Dockerfile that's symbolically
linked from the root Dockerfile.

This is likely only needed in the short term while we iron out the
upstream/downstream split, and needed as the openshift/release
ci-operator is expecting to build the registry container image using the
operator-registry.Dockerfile (what's currently present in
openshfit/ocp-build-data for the registry 4.8 images) and that file doesn't
exist anywhere in the repository.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
