### PR TITLE
.github: Separate the jobs in the test workflow into their own workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,16 @@
+name: build
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    paths:
+      - '**'
+      - '!doc/**'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make build

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -1,0 +1,23 @@
+name: sanity
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    paths:
+      - '**'
+      - '!doc/**'
+
+jobs:
+  sanity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '~1.16'
+      - name: Install goimports
+        run: go install golang.org/x/tools/cmd/goimports@latest
+      - name: Run sanity checks
+        run: make vendor && make lint && git diff --exit-code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,33 +8,6 @@ on:
       - '**'
       - '!doc/**'
 jobs:
-  sanity:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '~1.16'
-      - name: Install goimports
-        run: go install golang.org/x/tools/cmd/goimports@latest
-      - name: Run sanity checks
-        run: make vendor && make lint && git diff --exit-code
-
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: make build
-  unit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: make unit
-      - run: sed -i'' "s:^github.com/$GITHUB_REPOSITORY/::" coverage.out
-      - uses: codecov/codecov-action@v1
-        with:
-          file: coverage.out
-          fail_ci_if_error: false
   e2e-minikube:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,0 +1,22 @@
+name: unit
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    paths:
+      - '**'
+      - '!doc/**'
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make unit
+      - run: sed -i'' "s:^github.com/$GITHUB_REPOSITORY/::" coverage.out
+      - uses: codecov/codecov-action@v1
+        with:
+          file: coverage.out
+          fail_ci_if_error: false


### PR DESCRIPTION
Update the test.yaml workflow and migrate some of the jobs to their own
workflow configurations. This is a workaround to GH actions not
supporting re-running individual job actions when they fail.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
