### PR TITLE
Remove (config) add cmd from root to alpha subcommand

### DIFF
--- a/cmd/opm/add/add.go
+++ b/cmd/opm/add/add.go
@@ -1,4 +1,4 @@
-package root
+package add
 
 import (
 	"fmt"
@@ -26,7 +26,7 @@ type add struct {
 	skipTLS    bool
 }
 
-func newAddCmd() *cobra.Command {
+func NewCmd() *cobra.Command {
 	logger := logrus.New()
 	a := add{
 		logger:   logrus.NewEntry(logger),

--- a/cmd/opm/alpha/cmd.go
+++ b/cmd/opm/alpha/cmd.go
@@ -1,6 +1,7 @@
 package alpha
 
 import (
+	"github.com/operator-framework/operator-registry/cmd/opm/add"
 	"github.com/operator-framework/operator-registry/cmd/opm/alpha/bundle"
 	"github.com/spf13/cobra"
 )
@@ -12,6 +13,6 @@ func NewCmd() *cobra.Command {
 		Short:  "Run an alpha subcommand",
 	}
 
-	runCmd.AddCommand(bundle.NewCmd())
+	runCmd.AddCommand(bundle.NewCmd(), add.NewCmd())
 	return runCmd
 }

--- a/cmd/opm/root/cmd.go
+++ b/cmd/opm/root/cmd.go
@@ -25,7 +25,7 @@ func NewCmd() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(registry.NewOpmRegistryCmd(), alpha.NewCmd(), serve.NewCmd(), newAddCmd(), validate.NewCmd())
+	cmd.AddCommand(registry.NewOpmRegistryCmd(), alpha.NewCmd(), serve.NewCmd(), validate.NewCmd())
 	index.AddCommand(cmd)
 	version.AddCommand(cmd)
 


### PR DESCRIPTION
The config add command is still experimental so listing it under
alpha subcommand will allow us to make some significant changes
to it in the future releases if needed.

Signed-off-by: Vu Dinh <vudinh@outlook.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
