### PR TITLE
[release-4.7] Bug 1937097: Add retries to opm index add

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,6 @@ jobs:
           minikube start --driver=none
           sudo chown -R "$USER" "$HOME/.kube" "$HOME/.minikube"
           sudo usermod -aG docker "$USER"
-          eval $(minikube docker-env)
       - run: |
           mkdir -p certs
           openssl req -x509 -newkey rsa:4096 -keyout certs/key.pem -out certs/cert.pem -days 365 -subj '/CN=localhost' -nodes -addext 'subjectAltName = DNS:localhost'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          sudo apt-get -y update
+          . /etc/os-release
+          echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+          curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
+          sudo apt-get update
           sudo apt-get -y install conntrack podman
           podman version
       - run: |
@@ -58,7 +61,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          sudo apt-get -y update
+          . /etc/os-release
+          echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+          curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
+          sudo apt-get update
+          sudo apt-get -y install conntrack podman
           podman version
       - run: |
           curl -sLo kind "$(curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r '[.assets[] | select(.name == "kind-linux-amd64")] | first | .browser_download_url')"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,8 @@ jobs:
       - run: |
           sudo apt-get -y update
           sudo apt-get -y install conntrack podman
+          podman version
+      - run: |
           curl -sLo minikube "$(curl -sL https://api.github.com/repos/kubernetes/minikube/releases/latest | jq -r '[.assets[] | select(.name == "minikube-linux-amd64")] | first | .browser_download_url')"
           chmod +x minikube
           sudo mv minikube /bin/
@@ -57,7 +59,8 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           sudo apt-get -y update
-          sudo apt-get -y install podman
+          podman version
+      - run: |
           curl -sLo kind "$(curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r '[.assets[] | select(.name == "kind-linux-amd64")] | first | .browser_download_url')"
           chmod +x kind
           sudo mv kind /bin/

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/operator-framework/api v0.5.0

--- a/pkg/image/buildahregistry/_registry.go
+++ b/pkg/image/buildahregistry/_registry.go
@@ -4,6 +4,7 @@ package buildahregistry
 import (
 	"context"
 	"path"
+	"time"
 
 	"github.com/containers/buildah"
 	"github.com/containers/image/v5/types"
@@ -42,8 +43,8 @@ func (r *Registry) Pull(ctx context.Context, ref image.Reference) error {
 		BlobDirectory:    r.CacheDir,
 		AllTags:          false,
 		RemoveSignatures: false,
-		MaxRetries:       0,
-		RetryDelay:       0,
+		MaxRetries:       5,
+		RetryDelay:       1 * time.Second,
 	})
 
 	r.log.Info(img)

--- a/pkg/image/registry_test.go
+++ b/pkg/image/registry_test.go
@@ -3,12 +3,21 @@ package image_test
 import (
 	"context"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"math/rand"
+	"net/http"
 	"os"
+	"sync"
 	"testing"
 
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/configuration"
+	"github.com/docker/distribution/reference"
+	repositorymiddleware "github.com/docker/distribution/registry/middleware/repository"
+	"github.com/opencontainers/go-digest"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/mod/sumdb/dirhash"
@@ -74,20 +83,20 @@ func TestRegistries(t *testing.T) {
 	}
 
 	for name, registry := range registries {
-		t.Run(name, func(t *testing.T) {
-			testPullAndUnpack(t, registry)
-		})
-
+		testPullAndUnpack(t, name, registry)
 	}
 }
 
-func testPullAndUnpack(t *testing.T, newRegistry newRegistryFunc) {
+func testPullAndUnpack(t *testing.T, name string, newRegistry newRegistryFunc) {
 	type args struct {
 		dockerRootDir string
 		img           string
+		pullErrCount  int
+		pullErr       error
 	}
 	type expected struct {
-		checksum string
+		checksum      string
+		pullAssertion require.ErrorAssertionFunc
 	}
 	tests := []struct {
 		description string
@@ -95,23 +104,61 @@ func testPullAndUnpack(t *testing.T, newRegistry newRegistryFunc) {
 		expected    expected
 	}{
 		{
-			description: "ByTag",
+			description: fmt.Sprintf("%s/ByTag", name),
 			args: args{
 				dockerRootDir: "testdata/golden",
 				img:           "/olmtest/kiali:1.4.2",
 			},
 			expected: expected{
-				checksum: dirChecksum(t, "testdata/golden/bundles/kiali"),
+				checksum:      dirChecksum(t, "testdata/golden/bundles/kiali"),
+				pullAssertion: require.NoError,
 			},
 		},
 		{
-			description: "ByDigest",
+			description: fmt.Sprintf("%s/ByDigest", name),
 			args: args{
 				dockerRootDir: "testdata/golden",
 				img:           "/olmtest/kiali@sha256:a1bec450c104ceddbb25b252275eb59f1f1e6ca68e0ced76462042f72f7057d8",
 			},
 			expected: expected{
-				checksum: dirChecksum(t, "testdata/golden/bundles/kiali"),
+				checksum:      dirChecksum(t, "testdata/golden/bundles/kiali"),
+				pullAssertion: require.NoError,
+			},
+		},
+		{
+			description: fmt.Sprintf("%s/WithOneRetriableError", name),
+			args: args{
+				dockerRootDir: "testdata/golden",
+				img:           "/olmtest/kiali:1.4.2",
+				pullErrCount:  1,
+				pullErr:       errors.New("dummy"),
+			},
+			expected: expected{
+				checksum:      dirChecksum(t, "testdata/golden/bundles/kiali"),
+				pullAssertion: require.NoError,
+			},
+		},
+		// TODO: figure out how to have the server send a detectable non-retriable error.
+		//{
+		//  description: fmt.Sprintf("%s/WithNonRetriableError", name),
+		//	args: args{
+		//		dockerRootDir: "testdata/golden",
+		//		img:           "/olmtest/kiali:1.4.2",
+		//	},
+		//	expected: expected{
+		//		pullAssertion: require.Error,
+		//	},
+		//},
+		{
+			description: fmt.Sprintf("%s/WithAlwaysRetriableError", name),
+			args: args{
+				dockerRootDir: "testdata/golden",
+				img:           "/olmtest/kiali:1.4.2",
+				pullErrCount:  math.MaxInt64,
+				pullErr:       errors.New("dummy"),
+			},
+			expected: expected{
+				pullAssertion: require.Error,
 			},
 		},
 	}
@@ -121,23 +168,45 @@ func testPullAndUnpack(t *testing.T, newRegistry newRegistryFunc) {
 			ctx, close := context.WithCancel(context.Background())
 			defer close()
 
-			host, cafile, err := libimage.RunDockerRegistry(ctx, tt.args.dockerRootDir)
+			configOpts := []libimage.ConfigOpt{}
+
+			if tt.args.pullErrCount > 0 {
+				configOpts = append(configOpts, func(config *configuration.Configuration) {
+					if config.Middleware == nil {
+						config.Middleware = make(map[string][]configuration.Middleware)
+					}
+
+					mockRepo := &mockRepo{blobStore: &mockBlobStore{
+						maxCount: tt.args.pullErrCount,
+						err:      tt.args.pullErr,
+					}}
+					middlewareName := fmt.Sprintf("test-%x", rand.Int())
+					require.NoError(t, repositorymiddleware.Register(middlewareName, mockRepo.init))
+					config.Middleware["repository"] = append(config.Middleware["repository"], configuration.Middleware{
+						Name: middlewareName,
+					})
+				})
+			}
+
+			host, cafile, err := libimage.RunDockerRegistry(ctx, tt.args.dockerRootDir, configOpts...)
 			require.NoError(t, err)
 
 			r, cleanup := newRegistry(t, cafile)
 			defer cleanup()
 
 			ref := image.SimpleReference(host + tt.args.img)
-			require.NoError(t, r.Pull(ctx, ref))
+			tt.expected.pullAssertion(t, r.Pull(ctx, ref))
 
-			// Copy golden manifests to a temp dir
-			dir := "kiali-unpacked"
-			require.NoError(t, r.Unpack(ctx, ref, dir))
+			if tt.expected.checksum != "" {
+				// Copy golden manifests to a temp dir
+				dir := "kiali-unpacked"
+				require.NoError(t, r.Unpack(ctx, ref, dir))
 
-			checksum := dirChecksum(t, dir)
-			require.Equal(t, tt.expected.checksum, checksum)
+				checksum := dirChecksum(t, dir)
+				require.Equal(t, tt.expected.checksum, checksum)
 
-			require.NoError(t, os.RemoveAll(dir))
+				require.NoError(t, os.RemoveAll(dir))
+			}
 		})
 	}
 }
@@ -146,4 +215,85 @@ func dirChecksum(t *testing.T, dir string) string {
 	sum, err := dirhash.HashDir(dir, "", dirhash.DefaultHash)
 	require.NoError(t, err)
 	return sum
+}
+
+var _ distribution.Repository = &mockRepo{}
+
+type mockRepo struct {
+	base      distribution.Repository
+	blobStore *mockBlobStore
+	once      sync.Once
+}
+
+func (f *mockRepo) init(ctx context.Context, base distribution.Repository, options map[string]interface{}) (distribution.Repository, error) {
+	f.once.Do(func() {
+		f.base = base
+		f.blobStore.base = base.Blobs(ctx)
+	})
+	return f, nil
+}
+
+func (f mockRepo) Named() reference.Named {
+	return f.base.Named()
+}
+
+func (f mockRepo) Manifests(ctx context.Context, options ...distribution.ManifestServiceOption) (distribution.ManifestService, error) {
+	return f.base.Manifests(ctx, options...)
+}
+
+func (f mockRepo) Blobs(ctx context.Context) distribution.BlobStore {
+	return f.blobStore
+}
+
+func (f mockRepo) Tags(ctx context.Context) distribution.TagService {
+	return f.base.Tags(ctx)
+}
+
+var _ distribution.BlobStore = &mockBlobStore{}
+
+type mockBlobStore struct {
+	base     distribution.BlobStore
+	err      error
+	maxCount int
+
+	count int
+	m     sync.Mutex
+}
+
+func (f *mockBlobStore) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	f.m.Lock()
+	defer f.m.Unlock()
+	f.count++
+	if f.count <= f.maxCount {
+		return distribution.Descriptor{}, f.err
+	}
+	return f.base.Stat(ctx, dgst)
+}
+
+func (f mockBlobStore) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
+	return f.base.Get(ctx, dgst)
+}
+
+func (f mockBlobStore) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
+	return f.base.Open(ctx, dgst)
+}
+
+func (f mockBlobStore) Put(ctx context.Context, mediaType string, p []byte) (distribution.Descriptor, error) {
+	return f.base.Put(ctx, mediaType, p)
+}
+
+func (f mockBlobStore) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
+	return f.base.Create(ctx, options...)
+}
+
+func (f mockBlobStore) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
+	return f.base.Resume(ctx, id)
+}
+
+func (f mockBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter, r *http.Request, dgst digest.Digest) error {
+	return f.base.ServeBlob(ctx, w, r, dgst)
+}
+
+func (f mockBlobStore) Delete(ctx context.Context, dgst digest.Digest) error {
+	return f.base.Delete(ctx, dgst)
 }

--- a/pkg/lib/image/registry.go
+++ b/pkg/lib/image/registry.go
@@ -27,10 +27,12 @@ import (
 	"github.com/phayes/freeport"
 )
 
+type ConfigOpt func(*configuration.Configuration)
+
 // RunDockerRegistry runs a docker registry on an available port and returns its host string if successful, otherwise it returns an error.
 // If the rootDir argument isn't empty, the registry is configured to use this as the root directory for persisting image data to the filesystem.
 // If the rootDir argument is empty, the registry is configured to keep image data in memory.
-func RunDockerRegistry(ctx context.Context, rootDir string) (string, string, error) {
+func RunDockerRegistry(ctx context.Context, rootDir string, configOpts ...ConfigOpt) (string, string, error) {
 	dockerPort, err := freeport.GetFreePort()
 	if err != nil {
 		return "", "", err
@@ -77,6 +79,10 @@ func RunDockerRegistry(ctx context.Context, rootDir string) (string, string, err
 		config.Storage = map[string]configuration.Parameters{"inmemory": map[string]interface{}{}}
 	}
 	config.HTTP.DrainTimeout = 2 * time.Second
+
+	for _, opt := range configOpts {
+		opt(config)
+	}
 
 	dockerRegistry, err := registry.NewRegistry(ctx, config)
 	if err != nil {

--- a/vendor/k8s.io/client-go/util/retry/OWNERS
+++ b/vendor/k8s.io/client-go/util/retry/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- caesarxuchao

--- a/vendor/k8s.io/client-go/util/retry/util.go
+++ b/vendor/k8s.io/client-go/util/retry/util.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retry
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// DefaultRetry is the recommended retry for a conflict where multiple clients
+// are making changes to the same resource.
+var DefaultRetry = wait.Backoff{
+	Steps:    5,
+	Duration: 10 * time.Millisecond,
+	Factor:   1.0,
+	Jitter:   0.1,
+}
+
+// DefaultBackoff is the recommended backoff for a conflict where a client
+// may be attempting to make an unrelated modification to a resource under
+// active management by one or more controllers.
+var DefaultBackoff = wait.Backoff{
+	Steps:    4,
+	Duration: 10 * time.Millisecond,
+	Factor:   5.0,
+	Jitter:   0.1,
+}
+
+// OnError allows the caller to retry fn in case the error returned by fn is retriable
+// according to the provided function. backoff defines the maximum retries and the wait
+// interval between two retries.
+func OnError(backoff wait.Backoff, retriable func(error) bool, fn func() error) error {
+	var lastErr error
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		err := fn()
+		switch {
+		case err == nil:
+			return true, nil
+		case retriable(err):
+			lastErr = err
+			return false, nil
+		default:
+			return false, err
+		}
+	})
+	if err == wait.ErrWaitTimeout {
+		err = lastErr
+	}
+	return err
+}
+
+// RetryOnConflict is used to make an update to a resource when you have to worry about
+// conflicts caused by other code making unrelated updates to the resource at the same
+// time. fn should fetch the resource to be modified, make appropriate changes to it, try
+// to update it, and return (unmodified) the error from the update function. On a
+// successful update, RetryOnConflict will return nil. If the update function returns a
+// "Conflict" error, RetryOnConflict will wait some amount of time as described by
+// backoff, and then try again. On a non-"Conflict" error, or if it retries too many times
+// and gives up, RetryOnConflict will return an error to the caller.
+//
+//     err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+//         // Fetch the resource here; you need to refetch it on every try, since
+//         // if you got a conflict on the last update attempt then you need to get
+//         // the current version before making your own changes.
+//         pod, err := c.Pods("mynamespace").Get(name, metav1.GetOptions{})
+//         if err ! nil {
+//             return err
+//         }
+//
+//         // Make whatever updates to the resource are needed
+//         pod.Status.Phase = v1.PodFailed
+//
+//         // Try to update
+//         _, err = c.Pods("mynamespace").UpdateStatus(pod)
+//         // You have to return err itself here (not wrapped inside another error)
+//         // so that RetryOnConflict can identify it correctly.
+//         return err
+//     })
+//     if err != nil {
+//         // May be conflict if max retries were hit, or may be something unrelated
+//         // like permissions or a network error
+//         return err
+//     }
+//     ...
+//
+// TODO: Make Backoff an interface?
+func RetryOnConflict(backoff wait.Backoff, fn func() error) error {
+	return OnError(backoff, errors.IsConflict, fn)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -792,6 +792,7 @@ k8s.io/client-go/util/exec
 k8s.io/client-go/util/flowcontrol
 k8s.io/client-go/util/homedir
 k8s.io/client-go/util/keyutil
+k8s.io/client-go/util/retry
 k8s.io/client-go/util/workqueue
 # k8s.io/component-base v0.20.0
 k8s.io/component-base/metrics


### PR DESCRIPTION
Manual cherry pick of #633

This commit adds retries to the containerd and podman pull tools.
The docker pull tool shells out to the docker CLI, which already
supports retries.

The retry backoff is setup to retry every 1 second, 5 times.

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>