### PR TITLE
Test for bundlepaths before deprecate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/Microsoft/hcsshim v0.8.9 // indirect
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/blang/semver/v4 v4.0.0
 	github.com/bugsnag/bugsnag-go v1.5.3 // indirect
 	github.com/bugsnag/panicwrap v1.2.0 // indirect
 	github.com/containerd/containerd v1.3.2
@@ -61,6 +62,7 @@ require (
 	k8s.io/kubectl v0.20.6
 	sigs.k8s.io/controller-runtime v0.8.0
 	sigs.k8s.io/kind v0.10.0
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (

--- a/pkg/lib/registry/registry.go
+++ b/pkg/lib/registry/registry.go
@@ -342,7 +342,9 @@ func (r RegistryUpdater) DeprecateFromRegistry(request DeprecateFromRegistryRequ
 		return fmt.Errorf("unable to migrate database: %s", err)
 	}
 
-	deprecator := sqlite.NewSQLDeprecatorForBundles(dbLoader, request.Bundles)
+	dbQuerier := sqlite.NewSQLLiteQuerierFromDb(db)
+
+	deprecator := sqlite.NewSQLDeprecatorForBundles(dbLoader, dbQuerier, request.Bundles)
 	if err := deprecator.Deprecate(); err != nil {
 		r.Logger.Debugf("unable to deprecate bundles from database: %s", err)
 		if !request.Permissive {

--- a/pkg/registry/empty.go
+++ b/pkg/registry/empty.go
@@ -112,6 +112,10 @@ func (EmptyQuery) ListRegistryBundles(ctx context.Context) ([]*Bundle, error) {
 	return nil, errors.New("empty querier: cannot list registry bundles")
 }
 
+func (EmptyQuery) GetBundleNameAndVersionForImage(ctx context.Context, path string) (bundleName string, bundleVersion string, err error) {
+	return "", "", errors.New("empty querier: cannot get bundle from path")
+}
+
 var _ Query = &EmptyQuery{}
 
 func NewEmptyQuerier() *EmptyQuery {

--- a/pkg/registry/interface.go
+++ b/pkg/registry/interface.go
@@ -13,7 +13,7 @@ type Load interface {
 	AddBundlePackageChannels(manifest PackageManifest, bundle *Bundle) error
 	RemovePackage(packageName string) error
 	RemoveStrandedBundles() error
-	DeprecateBundle(name, version, path string) error
+	DeprecateBundle(path string) error
 	ClearNonHeadBundles() error
 }
 

--- a/pkg/registry/interface.go
+++ b/pkg/registry/interface.go
@@ -13,7 +13,7 @@ type Load interface {
 	AddBundlePackageChannels(manifest PackageManifest, bundle *Bundle) error
 	RemovePackage(packageName string) error
 	RemoveStrandedBundles() error
-	DeprecateBundle(path string) error
+	DeprecateBundle(name, version, path string) error
 	ClearNonHeadBundles() error
 }
 
@@ -79,6 +79,8 @@ type Query interface {
 	GetBundlePathIfExists(ctx context.Context, csvName string) (string, error)
 	// ListRegistryBundles returns a set of registry bundles.
 	ListRegistryBundles(ctx context.Context) ([]*Bundle, error)
+
+	GetBundleNameAndVersionForImage(ctx context.Context, bundlepath string) (name string, version string, err error)
 }
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . GraphLoader

--- a/pkg/registry/populator_test.go
+++ b/pkg/registry/populator_test.go
@@ -859,7 +859,7 @@ func TestDeprecateBundle(t *testing.T) {
 			store, err := sqlite.NewSQLLiteLoader(db)
 			require.NoError(t, err)
 
-			deprecator := sqlite.NewSQLDeprecatorForBundles(store, tt.args.bundles)
+			deprecator := sqlite.NewSQLDeprecatorForBundles(store, querier, tt.args.bundles)
 			err = deprecator.Deprecate()
 			fmt.Printf("error: %s\n", err)
 			require.Equal(t, tt.expected.err, err)
@@ -994,7 +994,7 @@ func TestAddAfterDeprecate(t *testing.T) {
 			// Initialize index with some bundles
 			require.NoError(t, populate(tt.args.firstBundles))
 
-			deprecator := sqlite.NewSQLDeprecatorForBundles(load, tt.args.deprecatedBundles)
+			deprecator := sqlite.NewSQLDeprecatorForBundles(load, query, tt.args.deprecatedBundles)
 			err = deprecator.Deprecate()
 			require.Equal(t, tt.expected.err, err)
 

--- a/pkg/sqlite/deprecate_test.go
+++ b/pkg/sqlite/deprecate_test.go
@@ -1,0 +1,329 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/operator-framework/api/pkg/lib/version"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-registry/pkg/api"
+	"github.com/operator-framework/operator-registry/pkg/image"
+	"github.com/operator-framework/operator-registry/pkg/registry"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+type testBundle struct {
+	version        string
+	pkg            string
+	channels       []string
+	defaultChannel string
+	skips          []string
+	replaces       string
+}
+
+func newRegistryBundle(t *testing.T, b testBundle) *registry.Bundle {
+	name := b.version
+	csvYAML, err := yaml.Marshal(&v1alpha1.ClusterServiceVersion{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       v1alpha1.ClusterServiceVersionKind,
+			APIVersion: v1alpha1.ClusterServiceVersionAPIVersion,
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: map[string]string{}},
+		Spec: v1alpha1.ClusterServiceVersionSpec{
+			Version: version.OperatorVersion{
+				Version: semver.MustParse(b.version),
+			},
+			Replaces: b.replaces,
+			Skips:    b.skips,
+		},
+	})
+	require.NoError(t, err)
+
+	tmpdir, err := ioutil.TempDir(".", "depr-")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	annotationsYAML, err := yaml.Marshal(&registry.AnnotationsFile{
+		Annotations: registry.Annotations{
+			PackageName:        b.pkg,
+			Channels:           strings.Join(b.channels, ","),
+			DefaultChannelName: b.defaultChannel,
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, os.Mkdir(filepath.Join(tmpdir, "manifests"), 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(tmpdir, "metadata"), 0755))
+	require.NoError(t, ioutil.WriteFile(filepath.Join(tmpdir, "manifests", "csv.yaml"), csvYAML, 0644))
+	require.NoError(t, ioutil.WriteFile(filepath.Join(tmpdir, "metadata", "annotations.yaml"), annotationsYAML, 0644))
+
+	img, err := registry.NewImageInput(image.SimpleReference(fmt.Sprintf("bundle-%s", b.version)), tmpdir)
+	require.NoError(t, err)
+
+	return img.Bundle
+}
+
+func TestDeprecate(t *testing.T) {
+	tests := []struct {
+		description   string
+		initial       []testBundle
+		deprecate     []string
+		expected      []*api.Bundle
+		expectedError error
+	}{
+		{
+			description: "Missing Image",
+			initial: []testBundle{
+				{
+					version:        "0.0.1",
+					pkg:            "testpkg",
+					channels:       []string{"stable"},
+					defaultChannel: "stable",
+					skips:          nil,
+					replaces:       "",
+				},
+			},
+			deprecate: []string{
+				"bundle-nonexistent",
+			},
+			expectedError: fmt.Errorf("error deprecating bundle bundle-nonexistent: %s", registry.ErrBundleImageNotInDatabase),
+		},
+		{
+			description: "Unordered multi-bundle deprecation",
+			initial: []testBundle{
+				{
+					version:        "0.0.1",
+					pkg:            "testpkg",
+					channels:       []string{"stable", "0.x"},
+					defaultChannel: "stable",
+					skips:          []string{"0.0.1-rc0"},
+				},
+				{
+					version:        "0.0.2",
+					pkg:            "testpkg",
+					channels:       []string{"stable", "0.x"},
+					defaultChannel: "stable",
+					replaces:       "0.0.1",
+				},
+				{
+					version:        "0.0.3-rc0",
+					pkg:            "testpkg",
+					channels:       []string{"0.x"},
+					defaultChannel: "stable",
+					skips:          nil,
+					replaces:       "0.0.2",
+				},
+				{
+					version:        "1.0.1",
+					pkg:            "testpkg",
+					channels:       []string{"stable", "1.x"},
+					defaultChannel: "stable",
+					skips:          []string{"0.0.3-rc0", "0.0.1"},
+					replaces:       "0.0.2",
+				},
+				{
+					version:        "1.0.2-rc0",
+					pkg:            "testpkg",
+					channels:       []string{"1.x"},
+					defaultChannel: "stable",
+					skips:          nil,
+					replaces:       "1.0.1",
+				},
+				{
+					version:        "1.0.2",
+					pkg:            "testpkg",
+					channels:       []string{"stable", "1.x"},
+					defaultChannel: "stable",
+					skips:          []string{"1.0.2-rc0"},
+					replaces:       "1.0.1",
+				},
+				{
+					version:        "2.0.1",
+					pkg:            "testpkg",
+					channels:       []string{"stable", "2.x"},
+					defaultChannel: "stable",
+					skips:          nil,
+					replaces:       "1.0.2",
+				},
+				{
+					version:        "2.0.2",
+					pkg:            "testpkg",
+					channels:       []string{"stable", "2.x"},
+					defaultChannel: "stable",
+					skips:          nil,
+					replaces:       "2.0.1",
+				},
+			},
+			deprecate: []string{
+				"bundle-1.0.2",
+				"bundle-0.0.2",
+				"bundle-2.0.2",
+			},
+			expected: []*api.Bundle{
+				{
+					CsvName:     "2.0.2",
+					PackageName: "testpkg",
+					ChannelName: "2.x",
+					CsvJson:     "{\"apiVersion\":\"operators.coreos.com/v1alpha1\",\"kind\":\"ClusterServiceVersion\",\"metadata\":{\"creationTimestamp\":null,\"name\":\"2.0.2\"},\"spec\":{\"apiservicedefinitions\":{},\"cleanup\":{\"enabled\":false},\"customresourcedefinitions\":{},\"displayName\":\"\",\"install\":{\"spec\":{\"deployments\":null},\"strategy\":\"\"},\"provider\":{},\"replaces\":\"2.0.1\",\"version\":\"2.0.2\"},\"status\":{\"cleanup\":{}}}",
+					Object: []string{
+						"{\"apiVersion\":\"operators.coreos.com/v1alpha1\",\"kind\":\"ClusterServiceVersion\",\"metadata\":{\"creationTimestamp\":null,\"name\":\"2.0.2\"},\"spec\":{\"apiservicedefinitions\":{},\"cleanup\":{\"enabled\":false},\"customresourcedefinitions\":{},\"displayName\":\"\",\"install\":{\"spec\":{\"deployments\":null},\"strategy\":\"\"},\"provider\":{},\"replaces\":\"2.0.1\",\"version\":\"2.0.2\"},\"status\":{\"cleanup\":{}}}",
+					},
+					BundlePath: "bundle-2.0.2",
+					Version:    "2.0.2",
+					Replaces:   "",
+					Skips:      nil,
+					Properties: []*api.Property{{
+						Type:  registry.DeprecatedType,
+						Value: "{}",
+					}},
+				},
+				{
+					CsvName:     "2.0.2",
+					PackageName: "testpkg",
+					ChannelName: "stable",
+					CsvJson:     "{\"apiVersion\":\"operators.coreos.com/v1alpha1\",\"kind\":\"ClusterServiceVersion\",\"metadata\":{\"creationTimestamp\":null,\"name\":\"2.0.2\"},\"spec\":{\"apiservicedefinitions\":{},\"cleanup\":{\"enabled\":false},\"customresourcedefinitions\":{},\"displayName\":\"\",\"install\":{\"spec\":{\"deployments\":null},\"strategy\":\"\"},\"provider\":{},\"replaces\":\"2.0.1\",\"version\":\"2.0.2\"},\"status\":{\"cleanup\":{}}}",
+					Object: []string{
+						"{\"apiVersion\":\"operators.coreos.com/v1alpha1\",\"kind\":\"ClusterServiceVersion\",\"metadata\":{\"creationTimestamp\":null,\"name\":\"2.0.2\"},\"spec\":{\"apiservicedefinitions\":{},\"cleanup\":{\"enabled\":false},\"customresourcedefinitions\":{},\"displayName\":\"\",\"install\":{\"spec\":{\"deployments\":null},\"strategy\":\"\"},\"provider\":{},\"replaces\":\"2.0.1\",\"version\":\"2.0.2\"},\"status\":{\"cleanup\":{}}}",
+					},
+					BundlePath: "bundle-2.0.2",
+					Version:    "2.0.2",
+					Replaces:   "",
+					Skips:      nil,
+					Properties: []*api.Property{{
+						Type:  registry.DeprecatedType,
+						Value: "{}",
+					}},
+				},
+			},
+		},
+		{
+			description: "deprecate semver branch",
+			initial: []testBundle{
+				{
+					version:        "1.0.1",
+					pkg:            "testpkg",
+					channels:       []string{"stable", "1.x"},
+					defaultChannel: "stable",
+					skips:          nil,
+					replaces:       "",
+				},
+				{
+					version:        "1.0.2-rc0",
+					pkg:            "testpkg",
+					channels:       []string{"1.x"},
+					defaultChannel: "stable",
+					skips:          nil,
+					replaces:       "1.0.1",
+				},
+				{
+					version:        "1.0.2-rc1",
+					pkg:            "testpkg",
+					channels:       []string{"1.x"},
+					defaultChannel: "stable",
+					skips:          []string{"1.0.2-rc0"},
+					replaces:       "1.0.1",
+				},
+				{
+					version:        "1.0.2",
+					pkg:            "testpkg",
+					channels:       []string{"stable", "1.x"},
+					defaultChannel: "stable",
+					skips:          []string{"1.0.2-rc0"},
+					replaces:       "1.0.1",
+				},
+			},
+			deprecate: []string{
+				"bundle-1.0.2-rc1",
+				"bundle-1.0.2-rc0",
+			},
+			expected: []*api.Bundle{
+
+				{
+					CsvName:     "1.0.2",
+					PackageName: "testpkg",
+					ChannelName: "1.x",
+					CsvJson:     "{\"apiVersion\":\"operators.coreos.com/v1alpha1\",\"kind\":\"ClusterServiceVersion\",\"metadata\":{\"creationTimestamp\":null,\"name\":\"1.0.2\"},\"spec\":{\"apiservicedefinitions\":{},\"cleanup\":{\"enabled\":false},\"customresourcedefinitions\":{},\"displayName\":\"\",\"install\":{\"spec\":{\"deployments\":null},\"strategy\":\"\"},\"provider\":{},\"replaces\":\"1.0.1\",\"skips\":[\"1.0.2-rc0\"],\"version\":\"1.0.2\"},\"status\":{\"cleanup\":{}}}",
+					Object:      []string{"{\"apiVersion\":\"operators.coreos.com/v1alpha1\",\"kind\":\"ClusterServiceVersion\",\"metadata\":{\"creationTimestamp\":null,\"name\":\"1.0.2\"},\"spec\":{\"apiservicedefinitions\":{},\"cleanup\":{\"enabled\":false},\"customresourcedefinitions\":{},\"displayName\":\"\",\"install\":{\"spec\":{\"deployments\":null},\"strategy\":\"\"},\"provider\":{},\"replaces\":\"1.0.1\",\"skips\":[\"1.0.2-rc0\"],\"version\":\"1.0.2\"},\"status\":{\"cleanup\":{}}}"},
+					BundlePath:  "bundle-1.0.2",
+					Version:     "1.0.2",
+					Replaces:    "1.0.2-rc1",
+				},
+				{
+					CsvName:     "1.0.2",
+					PackageName: "testpkg",
+					ChannelName: "stable",
+					CsvJson:     "{\"apiVersion\":\"operators.coreos.com/v1alpha1\",\"kind\":\"ClusterServiceVersion\",\"metadata\":{\"creationTimestamp\":null,\"name\":\"1.0.2\"},\"spec\":{\"apiservicedefinitions\":{},\"cleanup\":{\"enabled\":false},\"customresourcedefinitions\":{},\"displayName\":\"\",\"install\":{\"spec\":{\"deployments\":null},\"strategy\":\"\"},\"provider\":{},\"replaces\":\"1.0.1\",\"skips\":[\"1.0.2-rc0\"],\"version\":\"1.0.2\"},\"status\":{\"cleanup\":{}}}",
+					Object:      []string{"{\"apiVersion\":\"operators.coreos.com/v1alpha1\",\"kind\":\"ClusterServiceVersion\",\"metadata\":{\"creationTimestamp\":null,\"name\":\"1.0.2\"},\"spec\":{\"apiservicedefinitions\":{},\"cleanup\":{\"enabled\":false},\"customresourcedefinitions\":{},\"displayName\":\"\",\"install\":{\"spec\":{\"deployments\":null},\"strategy\":\"\"},\"provider\":{},\"replaces\":\"1.0.1\",\"skips\":[\"1.0.2-rc0\"],\"version\":\"1.0.2\"},\"status\":{\"cleanup\":{}}}"},
+					BundlePath:  "bundle-1.0.2",
+					Version:     "1.0.2",
+				},
+				{
+					CsvName:     "1.0.2-rc1",
+					PackageName: "testpkg",
+					ChannelName: "1.x",
+					CsvJson:     "{\"apiVersion\":\"operators.coreos.com/v1alpha1\",\"kind\":\"ClusterServiceVersion\",\"metadata\":{\"creationTimestamp\":null,\"name\":\"1.0.2-rc1\"},\"spec\":{\"apiservicedefinitions\":{},\"cleanup\":{\"enabled\":false},\"customresourcedefinitions\":{},\"displayName\":\"\",\"install\":{\"spec\":{\"deployments\":null},\"strategy\":\"\"},\"provider\":{},\"replaces\":\"1.0.1\",\"skips\":[\"1.0.2-rc0\"],\"version\":\"1.0.2-rc1\"},\"status\":{\"cleanup\":{}}}",
+					Object:      []string{"{\"apiVersion\":\"operators.coreos.com/v1alpha1\",\"kind\":\"ClusterServiceVersion\",\"metadata\":{\"creationTimestamp\":null,\"name\":\"1.0.2-rc1\"},\"spec\":{\"apiservicedefinitions\":{},\"cleanup\":{\"enabled\":false},\"customresourcedefinitions\":{},\"displayName\":\"\",\"install\":{\"spec\":{\"deployments\":null},\"strategy\":\"\"},\"provider\":{},\"replaces\":\"1.0.1\",\"skips\":[\"1.0.2-rc0\"],\"version\":\"1.0.2-rc1\"},\"status\":{\"cleanup\":{}}}"},
+					BundlePath:  "bundle-1.0.2-rc1",
+					Version:     "1.0.2-rc1",
+					Properties: []*api.Property{{
+						Type:  registry.DeprecatedType,
+						Value: "{}",
+					}},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			logrus.SetLevel(logrus.DebugLevel)
+			db, cleanup := CreateTestDb(t)
+			defer cleanup()
+			store, err := NewSQLLiteLoader(db)
+			require.NoError(t, err)
+			err = store.Migrate(context.TODO())
+			require.NoError(t, err)
+
+			graphLoader, err := NewSQLGraphLoaderFromDB(db)
+			require.NoError(t, err)
+
+			querier := NewSQLLiteQuerierFromDb(db)
+
+			bundleLoader := registry.BundleGraphLoader{}
+			for _, b := range tt.initial {
+				graph, err := graphLoader.Generate(b.pkg)
+				if err != nil {
+					require.EqualError(t, err, registry.ErrPackageNotInDatabase.Error(), "Expected empty error or package not in database")
+				}
+				bndl := newRegistryBundle(t, b)
+				graph, err = bundleLoader.AddBundleToGraph(bndl, graph, &registry.AnnotationsFile{Annotations: *bndl.Annotations}, false)
+				require.NoError(t, err)
+
+				require.NoError(t, store.AddBundleSemver(graph, bndl))
+			}
+
+			err = NewSQLDeprecatorForBundles(store, querier, tt.deprecate).Deprecate()
+			if tt.expectedError != nil && err != nil {
+				require.EqualError(t, err, tt.expectedError.Error())
+			}
+			var result []*api.Bundle
+			if err == nil {
+				result, err = querier.ListBundles(context.TODO())
+			}
+			if tt.expectedError != nil {
+				require.EqualError(t, err, tt.expectedError.Error())
+				return
+			}
+			require.NoError(t, err)
+			require.ElementsMatch(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/sqlite/load.go
+++ b/pkg/sqlite/load.go
@@ -1367,7 +1367,28 @@ func getTailFromBundle(tx *sql.Tx, name string) (bundles []string, err error) {
 
 }
 
-func (s *sqlLoader) DeprecateBundle(name, version, path string) error {
+func getBundleNameAndVersionForImage(tx *sql.Tx, path string) (string, string, error) {
+	query := `SELECT name, version FROM operatorbundle WHERE bundlepath=? LIMIT 1`
+	rows, err := tx.QueryContext(context.TODO(), query, path)
+	if err != nil {
+		return "", "", err
+	}
+	defer rows.Close()
+
+	var name sql.NullString
+	var version sql.NullString
+	if rows.Next() {
+		if err := rows.Scan(&name, &version); err != nil {
+			return "", "", err
+		}
+	}
+	if name.Valid && version.Valid {
+		return name.String, version.String, nil
+	}
+	return "", "", registry.ErrBundleImageNotInDatabase
+}
+
+func (s *sqlLoader) DeprecateBundle(path string) error {
 	tx, err := s.db.Begin()
 	if err != nil {
 		return err
@@ -1382,6 +1403,10 @@ func (s *sqlLoader) DeprecateBundle(name, version, path string) error {
 	}
 	defer nullifyBundleReplaces.Close()
 
+	name, version, err := getBundleNameAndVersionForImage(tx, path)
+	if err != nil {
+		return fmt.Errorf("error deprecating bundle %s: %s", path, err)
+	}
 	tailBundles, err := getTailFromBundle(tx, name)
 	if err != nil {
 		return err

--- a/pkg/sqlite/query.go
+++ b/pkg/sqlite/query.go
@@ -1233,6 +1233,27 @@ func (s *SQLQuerier) GetBundlePathIfExists(ctx context.Context, bundleName strin
 	return
 }
 
+func (s *SQLQuerier) GetBundleNameAndVersionForImage(ctx context.Context, path string) (string, string, error) {
+	query := `SELECT name, version FROM operatorbundle WHERE bundlepath=? LIMIT 1`
+	rows, err := s.db.QueryContext(ctx, query, path)
+	if err != nil {
+		return "", "", err
+	}
+	defer rows.Close()
+
+	var name sql.NullString
+	var version sql.NullString
+	if rows.Next() {
+		if err := rows.Scan(&name, &version); err != nil {
+			return "", "", err
+		}
+	}
+	if name.Valid && version.Valid {
+		return name.String, version.String, nil
+	}
+	return "", "", registry.ErrBundleImageNotInDatabase
+}
+
 // ListRegistryBundles returns a set of registry bundles.
 // The set can be filtered by package by setting the given context's 'package' key to a desired package name.
 // e.g.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -45,6 +45,7 @@ github.com/beorn7/perks/quantile
 ## explicit
 github.com/blang/semver
 # github.com/blang/semver/v4 v4.0.0
+## explicit
 github.com/blang/semver/v4
 # github.com/bshuster-repo/logrus-logstash-hook v0.4.1
 github.com/bshuster-repo/logrus-logstash-hook
@@ -901,6 +902,7 @@ sigs.k8s.io/kind/pkg/log
 # sigs.k8s.io/structured-merge-diff/v4 v4.0.3
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
+## explicit
 sigs.k8s.io/yaml
 # github.com/containerd/containerd => github.com/ecordell/containerd v1.3.1-0.20200629153125-0ff1a1be2fa5
 # github.com/docker/distribution => github.com/docker/distribution v0.0.0-20191216044856-a8371794149d


### PR DESCRIPTION
Allow deprecatetruncate to handle multiple bundles on the same upgrade chain. Only the most latest bundle in the chain will be marked as deprecated, the remaining will be truncated with the rest of the upgrade chain older than the deprecated bundle.