### PR TITLE
declcfg: allow properties to have unset or null values

### DIFF
--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -454,7 +454,7 @@ func TestValidators(t *testing.T) {
 				Channel:    ch,
 				Name:       "anakin.v0.1.0",
 				Replaces:   "anakin.v0.0.1",
-				Properties: []property.Property{{Value: json.RawMessage("")}},
+				Properties: []property.Property{{Value: json.RawMessage("{")}},
 			},
 			assertion: require.Error,
 		},

--- a/internal/property/property.go
+++ b/internal/property/property.go
@@ -21,12 +21,11 @@ func (p Property) Validate() error {
 	if len(p.Type) == 0 {
 		return errors.New("type must be set")
 	}
-	if len(p.Value) == 0 {
-		return errors.New("value must be set")
-	}
-	var raw json.RawMessage
-	if err := json.Unmarshal(p.Value, &raw); err != nil {
-		return fmt.Errorf("value is not valid json: %v", err)
+	if len(p.Value) > 0 {
+		var raw json.RawMessage
+		if err := json.Unmarshal(p.Value, &raw); err != nil {
+			return fmt.Errorf("value is not valid json: %v", err)
+		}
 	}
 	return nil
 }
@@ -202,8 +201,10 @@ func Parse(in []Property) (*Properties, error) {
 			out.BundleObjects = append(out.BundleObjects, p)
 		default:
 			var p json.RawMessage
-			if err := json.Unmarshal(prop.Value, &p); err != nil {
-				return nil, ParseError{Idx: i, Typ: prop.Type, Err: err}
+			if len(prop.Value) > 0 {
+				if err := json.Unmarshal(prop.Value, &p); err != nil {
+					return nil, ParseError{Idx: i, Typ: prop.Type, Err: err}
+				}
 			}
 			out.Others = append(out.Others, prop)
 		}

--- a/internal/property/property_test.go
+++ b/internal/property/property_test.go
@@ -30,25 +30,25 @@ func TestValidate(t *testing.T) {
 			assertion: require.NoError,
 		},
 		{
-			name: "Error/NoType",
-			v: Property{
-				Value: json.RawMessage(""),
-			},
-			assertion: require.Error,
-		},
-		{
-			name: "Error/NoValue",
+			name: "Success/NoValue",
 			v: Property{
 				Type:  "custom.type",
 				Value: nil,
 			},
-			assertion: require.Error,
+			assertion: require.NoError,
 		},
 		{
-			name: "Error/EmptyValue",
+			name: "Success/EmptyValue",
 			v: Property{
 				Type:  "custom.type",
 				Value: json.RawMessage{},
+			},
+			assertion: require.NoError,
+		},
+		{
+			name: "Error/NoType",
+			v: Property{
+				Value: json.RawMessage(""),
 			},
 			assertion: require.Error,
 		},


### PR DESCRIPTION
The olm.deprecated property is an example of a property
that has no value. Its presence conveys its meaning.

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [x] Commit messages sensible and descriptive
