### PR TITLE
Elide channels starting with deprecated bundles

### DIFF
--- a/pkg/sqlite/deprecate.go
+++ b/pkg/sqlite/deprecate.go
@@ -31,17 +31,15 @@ func NewSQLDeprecatorForBundles(store registry.Load, bundles []string) *BundleDe
 
 func (d *BundleDeprecator) Deprecate() error {
 	log := logrus.WithField("bundles", d.bundles)
-
 	log.Info("deprecating bundles")
 
 	var errs []error
-
 	for _, bundlePath := range d.bundles {
 		if err := d.store.DeprecateBundle(bundlePath); err != nil {
-			if !errors.Is(err, registry.ErrBundleImageNotInDatabase) && !errors.Is(err, registry.ErrRemovingDefaultChannelDuringDeprecation) {
-				return utilerrors.NewAggregate(append(errs, fmt.Errorf("error deprecating bundle %s: %s", bundlePath, err)))
-			}
 			errs = append(errs, fmt.Errorf("error deprecating bundle %s: %s", bundlePath, err))
+			if !errors.Is(err, registry.ErrBundleImageNotInDatabase) && !errors.Is(err, registry.ErrRemovingDefaultChannelDuringDeprecation) {
+				break
+			}
 		}
 	}
 

--- a/pkg/sqlite/load_test.go
+++ b/pkg/sqlite/load_test.go
@@ -252,6 +252,18 @@ func newBundle(t *testing.T, name, pkgName string, channels []string, objs ...*u
 	return bundle
 }
 
+func TestRMBundle(t *testing.T) {
+	db, cleanup := CreateTestDb(t)
+	defer cleanup()
+	store, err := NewSQLLiteLoader(db)
+	require.NoError(t, err)
+	require.NoError(t, store.Migrate(context.Background()))
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	loader := store.(*sqlLoader)
+	require.NoError(t, loader.rmBundle(tx, "non-existent"))
+}
+
 func TestGetTailFromBundle(t *testing.T) {
 	type fields struct {
 		bundles []*registry.Bundle


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Elide channels that start with deprecated bundles.

**Motivation for the change:**

When a bundle is deprecated, authors don't expect channels starting with that bundle to be visible to cluster admins (since they can't install anything from such channels anyway).

**Downstream bug report:** [BZ 1959957](https://bugzilla.redhat.com/show_bug.cgi?id=1959957)

**Notes:**

~~This change brings into question the usefulness of retaining deprecated bundles at all. It's probably more straightforward to treat a deprecated bundle in a similar way to bundles referenced by `skips`; i.e. use for outbound edges only and don't return it in `ListBundles`.~~

~~I'm going to implement the above for comparison -- holding while I do that.~~

~~/hold~~

I was unable to get consensus on this, so I'm opting to get this patch in now and pick up the conversation afterwards.
