### PR TITLE
fix example bundle dockerfile so that it copies the manifests folder

### DIFF
--- a/docs/design/operator-bundle.md
+++ b/docs/design/operator-bundle.md
@@ -106,7 +106,7 @@ LABEL operators.operatorframework.io.bundle.package.v1=test-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=beta,stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
 
-ADD test/*.yaml /manifests
+ADD test/*.yaml /manifests/
 ADD test/metadata/annotations.yaml /metadata/annotations.yaml
 ```
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
fix example bundle dockerfile

pre-fix this would copy all yaml files in `./manifests` into the _file_
`/manifests` and it would only keep the last file's contents.

Adding that trailing slash properly creates the `/manifests` directory and copies
all files as expected.

**Motivation for the change:**

I tried to generate an index image from such a broken bundle image and even first suspected #603.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
