### PR TITLE
fix(sqlite): upsert deprecation table entries

### DIFF
--- a/pkg/sqlite/load.go
+++ b/pkg/sqlite/load.go
@@ -1457,7 +1457,7 @@ func (s *sqlLoader) DeprecateBundle(path string) error {
 
 	// Create a persistent record of the bundle's deprecation
 	// This lets us recover from losing the properties and augmented bundle rows
-	_, err = tx.Exec("INSERT INTO deprecated(operatorbundle_name) VALUES(?)", name)
+	_, err = tx.Exec("INSERT OR REPLACE INTO deprecated(operatorbundle_name) VALUES(?)", name)
 	if err != nil {
 		return err
 	}

--- a/pkg/sqlite/migrations/012_deprecated.go
+++ b/pkg/sqlite/migrations/012_deprecated.go
@@ -29,7 +29,7 @@ var deprecatedMigration = &Migration{
 			return err
 		}
 
-		initDeprecated := fmt.Sprintf(`INSERT INTO deprecated(operatorbundle_name) SELECT operatorbundle_name FROM properties WHERE properties.type='%s'`, registry.DeprecatedType)
+		initDeprecated := fmt.Sprintf(`INSERT OR REPLACE INTO deprecated(operatorbundle_name) SELECT operatorbundle_name FROM properties WHERE properties.type='%s'`, registry.DeprecatedType)
 		_, err := tx.ExecContext(ctx, initDeprecated)
 
 		return err

--- a/pkg/sqlite/migrations/012_deprecated_test.go
+++ b/pkg/sqlite/migrations/012_deprecated_test.go
@@ -26,6 +26,9 @@ func TestDeprecated(t *testing.T) {
 	require.NoError(t, err)
 	_, err = db.Exec(insertProperty, registry.DeprecatedType, "operator.v1.0.0", "1.0.0", "quay.io/operator:v1.0.0")
 	require.NoError(t, err)
+	// Add a duplicate deprecated property to ensure idempotency of the migration
+	_, err = db.Exec(insertProperty, registry.DeprecatedType, "operator.v1.0.0", "1.0.0", "quay.io/operator:v1.0.0")
+	require.NoError(t, err)
 	_, err = db.Exec(insertProperty, "extraneous", "operator.v1.0.0", "1.0.0", "quay.io/operator:v1.0.0")
 	require.NoError(t, err)
 


### PR DESCRIPTION
Ensure insertions into the deprecated table always succeed by ignoring
primary key constraints; i.e. "upsert" rows. This makes insertions
idempotent and prevents duplicate deprecated properties from causing
migration failures.

