### PR TITLE
Explicit bundle properties

### DIFF
--- a/internal/property/property.go
+++ b/internal/property/property.go
@@ -30,6 +30,10 @@ func (p Property) Validate() error {
 	return nil
 }
 
+func (p Property) String() string {
+	return fmt.Sprintf("type: %q, value: %q", p.Type, p.Value)
+}
+
 type Package struct {
 	PackageName string `json:"packageName"`
 	Version     string `json:"version"`

--- a/pkg/registry/bundle.go
+++ b/pkg/registry/bundle.go
@@ -47,7 +47,7 @@ type Bundle struct {
 	v1beta1crds  []*apiextensionsv1beta1.CustomResourceDefinition
 	v1crds       []*apiextensionsv1.CustomResourceDefinition
 	Dependencies []*Dependency
-	Properties   []*Property
+	Properties   []Property
 	Annotations  *Annotations
 	cacheStale   bool
 }
@@ -182,7 +182,7 @@ func (b *Bundle) ProvidedAPIs() (map[APIKey]struct{}, error) {
 	provided := map[APIKey]struct{}{}
 	crds, err := b.CustomResourceDefinitions()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting crds: %s", err)
 	}
 
 	for _, c := range crds {
@@ -210,7 +210,7 @@ func (b *Bundle) ProvidedAPIs() (map[APIKey]struct{}, error) {
 
 	ownedAPIs, _, err := csv.GetApiServiceDefinitions()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting apiservice definitions: %s", err)
 	}
 	for _, api := range ownedAPIs {
 		provided[APIKey{Group: api.Group, Version: api.Version, Kind: api.Kind, Plural: api.Name}] = struct{}{}
@@ -256,6 +256,7 @@ func (b *Bundle) AllProvidedAPIsInBundle() error {
 	if err != nil {
 		return err
 	}
+
 	ownedCRDs, _, err := csv.GetCustomResourceDefintions()
 	if err != nil {
 		return err

--- a/pkg/registry/csv.go
+++ b/pkg/registry/csv.go
@@ -263,7 +263,7 @@ func (csv *ClusterServiceVersion) GetApiServiceDefinitions() (owned []*Definitio
 	var objmap map[string]*json.RawMessage
 
 	if err = json.Unmarshal(csv.Spec, &objmap); err != nil {
-		return
+		return nil, nil, fmt.Errorf("error unmarshaling into object map: %s", err)
 	}
 
 	rawValue, ok := objmap[apiServiceDefinitions]

--- a/pkg/registry/decode.go
+++ b/pkg/registry/decode.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -41,4 +42,16 @@ func DecodePackageManifest(reader io.Reader) (manifest *PackageManifest, err err
 
 	manifest = obj
 	return
+}
+
+func decodeFileFS(root fs.FS, path string, into interface{}) error {
+	fileReader, err := root.Open(path)
+	if err != nil {
+		return fmt.Errorf("unable to read file %s: %s", path, err)
+	}
+	defer fileReader.Close()
+
+	decoder := yaml.NewYAMLOrJSONDecoder(fileReader, 30)
+
+	return decoder.Decode(into)
 }

--- a/pkg/registry/decode_test.go
+++ b/pkg/registry/decode_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"testing"
+	"testing/fstest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -88,6 +89,25 @@ func TestDecodePackageManifest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDecodeFileFS(t *testing.T) {
+	type foo struct {
+		Bar string
+	}
+
+	root := fstest.MapFS{
+		"foo.yaml": &fstest.MapFile{Data: []byte("bar: baz")},
+	}
+
+	var nilPtr *foo
+	require.NoError(t, decodeFileFS(root, "foo.yaml", nilPtr))
+	require.Nil(t, nilPtr)
+
+	ptr := &foo{}
+	require.NoError(t, decodeFileFS(root, "foo.yaml", ptr))
+	require.NotNil(t, ptr)
+	require.Equal(t, "baz", ptr.Bar)
 }
 
 func loadFile(t *testing.T, path string) io.Reader {

--- a/pkg/registry/imageinput.go
+++ b/pkg/registry/imageinput.go
@@ -1,129 +1,30 @@
 package registry
 
 import (
-	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
-	"strings"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/operator-framework/operator-registry/pkg/image"
+	"github.com/sirupsen/logrus"
 )
 
 type ImageInput struct {
-	manifestsDir     string
-	metadataDir      string
-	to               image.Reference
-	from             string
-	AnnotationsFile  *AnnotationsFile
-	dependenciesFile *DependenciesFile
-	Bundle           *Bundle
+	to     image.Reference
+	from   string
+	Bundle *Bundle
 }
 
 func NewImageInput(to image.Reference, from string) (*ImageInput, error) {
-	var annotationsFound, dependenciesFound bool
-	path := from
-	manifests := filepath.Join(path, "manifests")
-	metadata := filepath.Join(path, "metadata")
-	// Get annotations file
-	log := logrus.WithFields(logrus.Fields{"dir": from, "file": metadata, "load": "annotations"})
-	files, err := ioutil.ReadDir(metadata)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read directory %s: %s", metadata, err)
-	}
-
-	// Look for the metadata and manifests sub-directories to find the annotations.yaml
-	// file that will inform how the manifests of the bundle should be loaded into the database.
-	// If dependencies.yaml which contains operator dependencies in metadata directory
-	// exists, parse and load it into the DB
-	annotationsFile := &AnnotationsFile{}
-	dependenciesFile := &DependenciesFile{}
-	for _, f := range files {
-		if !annotationsFound {
-			err = DecodeFile(filepath.Join(metadata, f.Name()), annotationsFile)
-			if err == nil && *annotationsFile != (AnnotationsFile{}) {
-				annotationsFound = true
-				continue
-			}
-		}
-
-		if !dependenciesFound {
-			err = DecodeFile(filepath.Join(metadata, f.Name()), &dependenciesFile)
-			if err != nil {
-				return nil, err
-			}
-			if len(dependenciesFile.Dependencies) > 0 {
-				dependenciesFound = true
-			}
-		}
-	}
-
-	if !annotationsFound {
-		return nil, fmt.Errorf("Could not find annotations file")
-	}
-
-	if !dependenciesFound {
-		log.Info("Could not find optional dependencies file")
-	}
-
-	imageInput := &ImageInput{
-		manifestsDir:     manifests,
-		metadataDir:      metadata,
-		to:               to,
-		from:             from,
-		AnnotationsFile:  annotationsFile,
-		dependenciesFile: dependenciesFile,
-	}
-
-	err = imageInput.getBundleFromManifests()
+	parser := newBundleParser(logrus.WithFields(logrus.Fields{"with": from, "file": filepath.Join(from, "metadata"), "load": "annotations"}))
+	bundle, err := parser.Parse(os.DirFS(from))
 	if err != nil {
 		return nil, err
 	}
+	bundle.BundleImage = to.String()
 
-	return imageInput, nil
-}
-
-func (i *ImageInput) getBundleFromManifests() error {
-	log := logrus.WithFields(logrus.Fields{"dir": i.from, "file": i.manifestsDir, "load": "bundle"})
-
-	csv, err := i.findCSV(i.manifestsDir)
-	if err != nil {
-		return err
-	}
-
-	if csv.Object == nil {
-		return fmt.Errorf("csv is empty: %s", err)
-	}
-
-	log.Info("found csv, loading bundle")
-
-	csvName := csv.GetName()
-
-	bundle, err := loadBundle(csvName, i.manifestsDir)
-	if err != nil {
-		return fmt.Errorf("error loading objs in directory: %s", err)
-	}
-
-	if bundle == nil || bundle.Size() == 0 {
-		return fmt.Errorf("no bundle objects found")
-	}
-
-	// set the bundleimage on the bundle
-	bundle.BundleImage = i.to.String()
-	// set the dependencies on the bundle
-	bundle.Dependencies = i.dependenciesFile.GetDependencies()
-
-	bundle.Name = csvName
-	bundle.Annotations = &i.AnnotationsFile.Annotations
-	bundle.Package = i.AnnotationsFile.Annotations.PackageName
-	bundle.Channels = strings.Split(i.AnnotationsFile.Annotations.Channels, ",")
-
-	if err := bundle.AllProvidedAPIsInBundle(); err != nil {
-		return fmt.Errorf("error checking provided apis in bundle %s: %s", bundle.Name, err)
-	}
-
-	i.Bundle = bundle
-
-	return nil
+	return &ImageInput{
+		to:     to,
+		from:   from,
+		Bundle: bundle,
+	}, nil
 }

--- a/pkg/registry/parse.go
+++ b/pkg/registry/parse.go
@@ -1,0 +1,252 @@
+package registry
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+)
+
+type bundleParser struct {
+	log *logrus.Entry
+}
+
+func newBundleParser(log *logrus.Entry) *bundleParser {
+	return &bundleParser{
+		log: log,
+	}
+}
+
+// Parse parses the given FS into a Bundle.
+func (b *bundleParser) Parse(root fs.FS) (*Bundle, error) {
+	if root == nil {
+		return nil, fmt.Errorf("filesystem is nil")
+	}
+
+	bundle := &Bundle{}
+	manifests, err := fs.Sub(root, "manifests")
+	if err != nil {
+		return nil, fmt.Errorf("error opening manifests directory: %s", err)
+	}
+	if err := b.addManifests(manifests, bundle); err != nil {
+		return nil, err
+	}
+
+	metadata, err := fs.Sub(root, "metadata")
+	if err != nil {
+		return nil, fmt.Errorf("error opening metadata directory: %s", err)
+	}
+	if err := b.addMetadata(metadata, bundle); err != nil {
+		return nil, err
+	}
+
+	derived, err := b.derivedProperties(bundle)
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive properties: %s", err)
+	}
+
+	bundle.Properties = propertySet(append(bundle.Properties, derived...))
+
+	return bundle, nil
+}
+
+// addManifests adds the result of parsing the manifests directory to a bundle.
+func (b *bundleParser) addManifests(manifests fs.FS, bundle *Bundle) error {
+	files, err := fs.ReadDir(manifests, ".")
+	if err != nil {
+		return err
+	}
+
+	var csvFound bool
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+
+		name := f.Name()
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+
+		obj := &unstructured.Unstructured{}
+		if err = decodeFileFS(manifests, name, obj); err != nil {
+			b.log.Warnf("failed to decode: %s", err)
+			continue
+		}
+
+		// Only include the first CSV we find in the
+		if obj.GetKind() == operatorsv1alpha1.ClusterServiceVersionKind {
+			if csvFound {
+				continue
+			}
+			csvFound = true
+		}
+
+		if obj.Object != nil {
+			bundle.Add(obj)
+		}
+	}
+
+	if bundle.Size() == 0 {
+		return fmt.Errorf("no bundle objects found")
+	}
+
+	csv, err := bundle.ClusterServiceVersion()
+	if err != nil {
+		return err
+	}
+	if csv == nil {
+		return fmt.Errorf("no csv in bundle")
+	}
+
+	bundle.Name = csv.GetName()
+	if err := bundle.AllProvidedAPIsInBundle(); err != nil {
+		return fmt.Errorf("error checking provided apis in bundle %s: %s", bundle.Name, err)
+	}
+
+	return nil
+}
+
+// addManifests adds the result of parsing the metadata directory to a bundle.
+func (b *bundleParser) addMetadata(metadata fs.FS, bundle *Bundle) error {
+	files, err := fs.ReadDir(metadata, ".")
+	if err != nil {
+		return err
+	}
+
+	var (
+		af *AnnotationsFile
+		df *DependenciesFile
+		pf *PropertiesFile
+	)
+	for _, f := range files {
+		name := f.Name()
+		if af == nil {
+			decoded := AnnotationsFile{}
+			if err = decodeFileFS(metadata, name, &decoded); err == nil {
+				if decoded != (AnnotationsFile{}) {
+					af = &decoded
+				}
+			}
+		}
+		if df == nil {
+			decoded := DependenciesFile{}
+			if err = decodeFileFS(metadata, name, &decoded); err == nil {
+				if len(decoded.Dependencies) > 0 {
+					df = &decoded
+				}
+			}
+		}
+		if pf == nil {
+			decoded := PropertiesFile{}
+			if err = decodeFileFS(metadata, name, &decoded); err == nil {
+				if len(decoded.Properties) > 0 {
+					pf = &decoded
+				}
+			}
+		}
+	}
+
+	if af != nil {
+		bundle.Annotations = &af.Annotations
+		bundle.Package = af.Annotations.PackageName
+		bundle.Channels = af.GetChannels()
+	} else {
+		return fmt.Errorf("Could not find annotations file")
+	}
+
+	if df != nil {
+		bundle.Dependencies = append(bundle.Dependencies, df.GetDependencies()...)
+	} else {
+		b.log.Info("Could not find optional dependencies file")
+	}
+
+	if pf != nil {
+		bundle.Properties = append(bundle.Properties, pf.Properties...)
+	} else {
+		b.log.Info("Could not find optional properties file")
+	}
+
+	return nil
+}
+
+func (b *bundleParser) derivedProperties(bundle *Bundle) ([]Property, error) {
+	// Add properties from CSV annotations
+	csv, err := bundle.ClusterServiceVersion()
+	if err != nil {
+		return nil, fmt.Errorf("error getting csv: %s", err)
+	}
+	if csv == nil {
+		return nil, fmt.Errorf("bundle missing csv")
+	}
+
+	var derived []Property
+	if len(csv.GetAnnotations()) > 0 {
+		properties, ok := csv.GetAnnotations()[PropertyKey]
+		if ok {
+			if err := json.Unmarshal([]byte(properties), &derived); err != nil {
+				b.log.Warnf("failed to unmarshal csv annotation properties: %s", err)
+			}
+		}
+	}
+
+	if bundle.Annotations != nil && bundle.Annotations.PackageName != "" {
+		pkg := bundle.Annotations.PackageName
+		version, err := bundle.Version()
+		if err != nil {
+			return nil, err
+		}
+
+		value, err := json.Marshal(PackageProperty{
+			PackageName: pkg,
+			Version:     version,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal package property: %s", err)
+		}
+
+		// Annotations file takes precedent over CSV annotations
+		derived = append([]Property{{Type: PackageType, Value: value}}, derived...)
+	}
+
+	providedAPIs, err := bundle.ProvidedAPIs()
+	if err != nil {
+		return nil, fmt.Errorf("error getting provided apis: %s", err)
+	}
+
+	for api := range providedAPIs {
+		value, err := json.Marshal(GVKProperty{
+			Group:   api.Group,
+			Kind:    api.Kind,
+			Version: api.Version,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal gvk property: %s", err)
+		}
+		derived = append(derived, Property{Type: GVKType, Value: value})
+	}
+
+	return propertySet(derived), nil
+}
+
+// propertySet returns the deduplicated set of a property list.
+func propertySet(properties []Property) []Property {
+	var (
+		set     []Property
+		visited = map[string]struct{}{}
+	)
+	for _, p := range properties {
+		if _, ok := visited[p.String()]; ok {
+			continue
+		}
+		visited[p.String()] = struct{}{}
+		set = append(set, p)
+	}
+
+	return set
+}

--- a/pkg/registry/parse_test.go
+++ b/pkg/registry/parse_test.go
@@ -1,0 +1,617 @@
+package registry
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"regexp"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func mustMarshal(t *testing.T, value interface{}) json.RawMessage {
+	v, err := json.Marshal(value)
+	require.NoError(t, err, "bad test data")
+	return v
+}
+
+func TestBundleParser(t *testing.T) {
+	blankLines := regexp.MustCompile(`[\t\r\n]+`)
+	format := func(s string) []byte {
+		trimmed := strings.TrimSpace(s)
+		return []byte(blankLines.ReplaceAllString(trimmed, "\n"))
+	}
+
+	bundleFS := func() fstest.MapFS {
+		// Creating a new MapFS for each test case allows concurrent testing
+		return fstest.MapFS{
+			"manifests/csv.yaml": &fstest.MapFile{
+				Data: format(`
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: foo.v1.1.0
+spec:
+  version: 1.1.0
+  replaces: v1.1.0
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+      - serviceAccountName: foo-operator
+        rules:
+        - apiGroups:
+          - test.io
+          resources:
+          - foos
+          - bars
+          verbs:
+          - "*"
+      deployments:
+      - name: etcd-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: foo-operator
+          template:
+            metadata:
+              name: foo-operator
+              labels:
+                name: foo-operator
+            spec:
+              serviceAccountName: foo-operator
+              containers:
+              - name: foo-controller
+                command:
+                - foo
+                image: quay.io/test/foo-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2
+  customresourcedefinitions:
+    required:
+    - name: bars.test.io
+      version: v2
+      kind: Bar
+    owned:
+    - name: foos.test.io
+      version: v1
+      kind: Foo
+				`),
+			},
+			"manifests/crd.yaml": &fstest.MapFile{
+				Data: format(`
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: foos.test.io
+spec:
+  group: test.io
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              thing:
+                type: string
+  scope: Namespaced
+  names:
+    plural: foos
+    singular: foo
+    kind: Foo
+				`),
+			},
+			"metadata/annotations.yaml": &fstest.MapFile{
+				Data: format(`
+annotations:
+  operators.operatorframework.io.bundle.package.v1: "foo"
+  operators.operatorframework.io.bundle.channels.v1: "alpha,stable"
+  operators.operatorframework.io.bundle.channel.default.v1: "stable"
+				`),
+			},
+		}
+	}
+
+	for _, tt := range []struct {
+		name   string
+		root   fs.FS
+		err    bool
+		bundle *Bundle
+	}{
+		{
+			name: "NilFS",
+			err:  true,
+		},
+		{
+			name: "MissingManifests",
+			root: func() fstest.MapFS {
+				r := bundleFS()
+				for p := range r {
+					if strings.HasPrefix(p, "manifests") {
+						delete(r, p)
+					}
+				}
+
+				return r
+			}(),
+			err: true,
+		},
+		{
+			name: "MissingMetadata",
+			root: func() fstest.MapFS {
+				r := bundleFS()
+				for p := range r {
+					if strings.HasPrefix(p, "metadata") {
+						delete(r, p)
+					}
+				}
+
+				return r
+			}(),
+			err: true,
+		},
+		{
+			name: "MissingAnnotationsFile",
+			root: func() fstest.MapFS {
+				r := bundleFS()
+				delete(r, "metadata/annotations.yaml")
+
+				return r
+			}(),
+			err: true,
+		},
+		{
+			name: "ManifestsOnly",
+			root: bundleFS(),
+			bundle: &Bundle{
+				Name:     "foo.v1.1.0",
+				Package:  "foo",
+				Channels: []string{"alpha", "stable"},
+				Properties: []Property{
+					{
+						Type: PackageType,
+						Value: mustMarshal(t, PackageProperty{
+							PackageName: "foo",
+							Version:     "1.1.0",
+						}),
+					},
+					{
+						Type: GVKType,
+						Value: mustMarshal(t, GVKProperty{
+							Group:   "test.io",
+							Version: "v1",
+							Kind:    "Foo",
+						}),
+					},
+				},
+				Annotations: &Annotations{
+					PackageName:        "foo",
+					Channels:           "alpha,stable",
+					DefaultChannelName: "stable",
+				},
+			},
+		},
+		{
+			name: "WithDependenciesFile",
+			root: func() fstest.MapFS {
+				r := bundleFS()
+				r["metadata/dependencies.yaml"] = &fstest.MapFile{
+					Data: format(`
+dependencies:
+- type: olm.package
+  value:
+    packageName: bar
+    version: 2.0.0
+					`),
+				}
+
+				return r
+			}(),
+			bundle: &Bundle{
+				Name:     "foo.v1.1.0",
+				Package:  "foo",
+				Channels: []string{"alpha", "stable"},
+				Dependencies: []*Dependency{
+					{
+						Type: PackageType,
+						Value: mustMarshal(t, PackageDependency{
+							PackageName: "bar",
+							Version:     "2.0.0",
+						}),
+					},
+				},
+				Properties: []Property{
+					{
+						Type: PackageType,
+						Value: mustMarshal(t, PackageProperty{
+							PackageName: "foo",
+							Version:     "1.1.0",
+						}),
+					},
+					{
+						Type: GVKType,
+						Value: mustMarshal(t, GVKProperty{
+							Group:   "test.io",
+							Version: "v1",
+							Kind:    "Foo",
+						}),
+					},
+				},
+				Annotations: &Annotations{
+					PackageName:        "foo",
+					Channels:           "alpha,stable",
+					DefaultChannelName: "stable",
+				},
+			},
+		},
+		{
+			name: "PropertiesAnnotation",
+			root: func() fstest.MapFS {
+				r := bundleFS()
+				r["manifests/csv.yaml"] = &fstest.MapFile{
+					Data: format(fmt.Sprintf(`
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: foo.v1.1.0
+  annotations:
+    '%s': '%s'
+spec:
+  version: 1.1.0
+  replaces: v1.1.0
+				`,
+						PropertyKey,
+						mustMarshal(t, []Property{
+							{
+								Type: LabelType,
+								Value: mustMarshal(t,
+									LabelProperty{
+										Label: "baz",
+									},
+								),
+							},
+						}),
+					)),
+				}
+
+				return r
+			}(),
+			bundle: &Bundle{
+				Name:     "foo.v1.1.0",
+				Package:  "foo",
+				Channels: []string{"alpha", "stable"},
+				Properties: []Property{
+					{
+						Type: LabelType,
+						Value: mustMarshal(t, LabelProperty{
+							Label: "baz",
+						}),
+					},
+					{
+						Type: PackageType,
+						Value: mustMarshal(t, PackageProperty{
+							PackageName: "foo",
+							Version:     "1.1.0",
+						}),
+					},
+					{
+						Type: GVKType,
+						Value: mustMarshal(t, GVKProperty{
+							Group:   "test.io",
+							Version: "v1",
+							Kind:    "Foo",
+						}),
+					},
+				},
+				Annotations: &Annotations{
+					PackageName:        "foo",
+					Channels:           "alpha,stable",
+					DefaultChannelName: "stable",
+				},
+			},
+		},
+		{
+			name: "PropertiesFile",
+			root: func() fstest.MapFS {
+				r := bundleFS()
+				r["metadata/properties.yaml"] = &fstest.MapFile{
+					Data: format(`
+properties:
+- type: olm.package
+  value:
+    packageName: fizz
+    version: 1.1.0
+					`),
+				}
+
+				return r
+			}(),
+			bundle: &Bundle{
+				Name:     "foo.v1.1.0",
+				Package:  "foo",
+				Channels: []string{"alpha", "stable"},
+				Properties: []Property{
+					// There are no special semantics for specific property types in the parser.
+					// Invalid property type combinations should be handled by client-side validation.
+					{
+						Type: PackageType,
+						Value: mustMarshal(t, PackageProperty{
+							PackageName: "foo",
+							Version:     "1.1.0",
+						}),
+					},
+					{
+						Type: PackageType,
+						Value: mustMarshal(t, PackageProperty{
+							PackageName: "fizz",
+							Version:     "1.1.0",
+						}),
+					},
+					{
+						Type: GVKType,
+						Value: mustMarshal(t, GVKProperty{
+							Group:   "test.io",
+							Version: "v1",
+							Kind:    "Foo",
+						}),
+					},
+				},
+				Annotations: &Annotations{
+					PackageName:        "foo", // This field comes from the annotations file.
+					Channels:           "alpha,stable",
+					DefaultChannelName: "stable",
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := newBundleParser(logrus.NewEntry(logrus.StandardLogger()))
+
+			bundle, err := parser.Parse(tt.root)
+			if tt.err {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, bundle)
+			assert.Equal(t, tt.bundle.Name, bundle.Name)
+			assert.Equal(t, tt.bundle.Package, bundle.Package)
+			assert.ElementsMatch(t, tt.bundle.Channels, bundle.Channels)
+			assert.ElementsMatch(t, tt.bundle.Dependencies, bundle.Dependencies)
+			assert.ElementsMatch(t, tt.bundle.Properties, bundle.Properties)
+			assert.Equal(t, tt.bundle.Annotations, bundle.Annotations)
+		})
+	}
+
+}
+
+func TestDerivedProperties(t *testing.T) {
+	type args struct {
+		csv         *ClusterServiceVersion
+		version     string
+		annotations *Annotations
+		crds        []*apiextensionsv1.CustomResourceDefinition
+	}
+	type expected struct {
+		err        bool
+		properties []Property
+	}
+
+	for _, tt := range []struct {
+		name     string
+		args     args
+		expected expected
+	}{
+		{
+			name: "MissingCSV",
+			expected: expected{
+				err: true,
+			},
+		},
+		{
+			name: "NoProperties",
+			args: args{
+				csv: &ClusterServiceVersion{
+					Spec: json.RawMessage(`{}`),
+				},
+			},
+		},
+		{
+			name: "BadCSVAnnotationsIgnored",
+			args: args{
+				csv: &ClusterServiceVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							PropertyKey: "bad",
+						},
+					},
+					Spec: json.RawMessage(`{}`),
+				},
+			},
+		},
+		{
+			name: "OpaqueFromCSVAnnotations",
+			args: args{
+				csv: &ClusterServiceVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							PropertyKey: string(mustMarshal(t, []Property{
+								{
+									Type:  "foo",
+									Value: json.RawMessage(`{}`),
+								},
+							})),
+						},
+					},
+					Spec: json.RawMessage(`{}`),
+				},
+			},
+			expected: expected{
+				properties: []Property{
+					{
+						Type:  "foo",
+						Value: json.RawMessage(`{}`),
+					},
+				},
+			},
+		},
+		{
+			name: "PackageFromAnnotations",
+			args: args{
+				csv: &ClusterServiceVersion{
+					Spec: json.RawMessage(`{}`),
+				},
+				annotations: &Annotations{PackageName: "bar"},
+				version:     "1.0.0",
+			},
+			expected: expected{
+				properties: []Property{
+					{
+						Type: PackageType,
+						Value: mustMarshal(t, PackageProperty{
+							PackageName: "bar",
+							Version:     "1.0.0",
+						}),
+					},
+				},
+			},
+		},
+		{
+			name: "GVKs",
+			args: args{
+				csv: &ClusterServiceVersion{
+					Spec: json.RawMessage(`{}`),
+				},
+				crds: []*apiextensionsv1.CustomResourceDefinition{
+					{
+						Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+							Group: "test.io",
+							Names: apiextensionsv1.CustomResourceDefinitionNames{
+								Kind:   "Foo",
+								Plural: "Foos",
+							},
+							Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+								{Name: "v1"},
+								{Name: "v2alpha1"},
+							},
+						},
+					},
+					{
+						Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+							Group: "test.io",
+							Names: apiextensionsv1.CustomResourceDefinitionNames{
+								Kind:   "Bar",
+								Plural: "Bars",
+							},
+							Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+								{Name: "v1alpha1"},
+							},
+						},
+					},
+				},
+			},
+			expected: expected{
+				properties: []Property{
+					{
+						Type: GVKType,
+						Value: mustMarshal(t, GVKProperty{
+							Group:   "test.io",
+							Version: "v1",
+							Kind:    "Foo",
+						}),
+					},
+					{
+						Type: GVKType,
+						Value: mustMarshal(t, GVKProperty{
+							Group:   "test.io",
+							Version: "v2alpha1",
+							Kind:    "Foo",
+						}),
+					},
+					{
+						Type: GVKType,
+						Value: mustMarshal(t, GVKProperty{
+							Group:   "test.io",
+							Version: "v1alpha1",
+							Kind:    "Bar",
+						}),
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := newBundleParser(logrus.NewEntry(logrus.StandardLogger()))
+
+			in := &Bundle{
+				csv:         tt.args.csv,
+				version:     tt.args.version,
+				Annotations: tt.args.annotations,
+				v1crds:      tt.args.crds,
+			}
+
+			properties, err := parser.derivedProperties(in)
+			if tt.expected.err {
+				assert.Error(t, err)
+				assert.Nil(t, properties)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tt.expected.properties, properties)
+		})
+	}
+
+}
+
+func TestPropertySet(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   []Property
+		out  []Property
+	}{
+		{
+			name: "RemoveDuplicates",
+			in: []Property{
+				{
+					Type:  "foo",
+					Value: json.RawMessage("bar"),
+				},
+				{
+					Type:  "foo",
+					Value: json.RawMessage("bar"),
+				},
+				{
+					Type:  "foo",
+					Value: json.RawMessage("baz"),
+				},
+			},
+			out: []Property{
+				{
+					Type:  "foo",
+					Value: json.RawMessage("bar"),
+				},
+				{
+					Type:  "foo",
+					Value: json.RawMessage("baz"),
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tt.out, propertySet(tt.in))
+		})
+	}
+}

--- a/pkg/registry/populator.go
+++ b/pkg/registry/populator.go
@@ -4,14 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/blang/semver"
-	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
@@ -171,13 +166,13 @@ func (i *DirectoryPopulator) loadManifests(imagesToAdd []*ImageInput, imagesToRe
 		return i.loadManifestsReplaces(append(imagesToAdd, imagesToReAdd...))
 	case SemVerMode:
 		for _, image := range imagesToAdd {
-			if err := i.loadManifestsSemver(image.Bundle, image.AnnotationsFile, false); err != nil {
+			if err := i.loadManifestsSemver(image.Bundle, false); err != nil {
 				return err
 			}
 		}
 	case SkipPatchMode:
 		for _, image := range imagesToAdd {
-			if err := i.loadManifestsSemver(image.Bundle, image.AnnotationsFile, true); err != nil {
+			if err := i.loadManifestsSemver(image.Bundle, true); err != nil {
 				return err
 			}
 		}
@@ -243,7 +238,7 @@ func (i *DirectoryPopulator) loadManifestsReplaces(images []*ImageInput) error {
 	return utilerrors.NewAggregate(errs)
 }
 
-func (i *DirectoryPopulator) loadManifestsSemver(bundle *Bundle, annotations *AnnotationsFile, skippatch bool) error {
+func (i *DirectoryPopulator) loadManifestsSemver(bundle *Bundle, skippatch bool) error {
 	graph, err := i.graphLoader.Generate(bundle.Package)
 	if err != nil && !errors.Is(err, ErrPackageNotInDatabase) {
 		return err
@@ -251,7 +246,7 @@ func (i *DirectoryPopulator) loadManifestsSemver(bundle *Bundle, annotations *An
 
 	// add to the graph
 	bundleLoader := BundleGraphLoader{}
-	updatedGraph, err := bundleLoader.AddBundleToGraph(bundle, graph, annotations, skippatch)
+	updatedGraph, err := bundleLoader.AddBundleToGraph(bundle, graph, &AnnotationsFile{Annotations: *bundle.Annotations}, skippatch)
 	if err != nil {
 		return err
 	}
@@ -261,93 +256,6 @@ func (i *DirectoryPopulator) loadManifestsSemver(bundle *Bundle, annotations *An
 	}
 
 	return nil
-}
-
-// loadBundle takes the directory that a CSV is in and assumes the rest of the objects in that directory
-// are part of the bundle.
-func loadBundle(csvName string, dir string) (*Bundle, error) {
-	log := logrus.WithFields(logrus.Fields{"dir": dir, "load": "bundle"})
-	files, err := ioutil.ReadDir(dir)
-	if err != nil {
-		return nil, err
-	}
-
-	bundle := &Bundle{
-		Name: csvName,
-	}
-	for _, f := range files {
-		log = log.WithField("file", f.Name())
-		if f.IsDir() {
-			log.Info("skipping directory")
-			continue
-		}
-
-		if strings.HasPrefix(f.Name(), ".") {
-			log.Info("skipping hidden file")
-			continue
-		}
-
-		log.Info("loading bundle file")
-		var (
-			obj  = &unstructured.Unstructured{}
-			path = filepath.Join(dir, f.Name())
-		)
-		if err = DecodeFile(path, obj); err != nil {
-			log.WithError(err).Debugf("could not decode file contents for %s", path)
-			continue
-		}
-
-		// Don't include other CSVs in the bundle
-		if obj.GetKind() == "ClusterServiceVersion" && obj.GetName() != csvName {
-			continue
-		}
-
-		if obj.Object != nil {
-			bundle.Add(obj)
-		}
-	}
-
-	return bundle, nil
-}
-
-// findCSV looks through the bundle directory to find a csv
-func (i *ImageInput) findCSV(manifests string) (*unstructured.Unstructured, error) {
-	log := logrus.WithFields(logrus.Fields{"dir": i.from, "find": "csv"})
-
-	files, err := ioutil.ReadDir(manifests)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read directory %s: %s", manifests, err)
-	}
-
-	for _, f := range files {
-		log = log.WithField("file", f.Name())
-		if f.IsDir() {
-			log.Info("skipping directory")
-			continue
-		}
-
-		if strings.HasPrefix(f.Name(), ".") {
-			log.Info("skipping hidden file")
-			continue
-		}
-
-		var (
-			obj  = &unstructured.Unstructured{}
-			path = filepath.Join(manifests, f.Name())
-		)
-		if err = DecodeFile(path, obj); err != nil {
-			log.WithError(err).Debugf("could not decode file contents for %s", path)
-			continue
-		}
-
-		if obj.GetKind() != clusterServiceVersionKind {
-			continue
-		}
-
-		return obj, nil
-	}
-
-	return nil, fmt.Errorf("no csv found in bundle")
 }
 
 // loadOperatorBundle adds the package information to the loader's store

--- a/pkg/registry/registry_to_model_test.go
+++ b/pkg/registry/registry_to_model_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestConvertRegistryBundleToModelBundle(t *testing.T) {
 	registryBundle, err := testRegistryBundle()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	expected := testModelBundle()
 
 	actual, err := registryBundleToModelBundle(registryBundle)
@@ -35,14 +35,10 @@ func testModelBundle() model.Bundle {
 			property.MustBuildChannel("stable", "etcdoperator.v0.9.0"),
 			property.MustBuildPackage("etcd", "0.9.2"),
 			property.MustBuildSkips("etcdoperator.v0.9.1"),
-			//TODO(anik120): check if etcdclusters. is supposed to be prefixed
 			property.MustBuildGVKRequired("etcd.database.coreos.com", "v1beta2", "EtcdCluster"),
 			property.MustBuildGVKRequired("testapi.coreos.com", "v1", "testapi"),
-			//TODO(anik120): check if etcdclusters. is supposed to be prefixed
 			property.MustBuildGVK("etcd.database.coreos.com", "v1beta2", "EtcdCluster"),
-			//TODO(anik120): check if etcdbackups. is supposed to be prefixed
 			property.MustBuildGVK("etcd.database.coreos.com", "v1beta2", "EtcdBackup"),
-			//TODO(anik120): check if etcdrestores. is supposed to be prefixed
 			property.MustBuildGVK("etcd.database.coreos.com", "v1beta2", "EtcdRestore"),
 		},
 	}

--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -160,19 +160,25 @@ type Annotations struct {
 	DefaultChannelName string `json:"operators.operatorframework.io.bundle.channel.default.v1" yaml:"operators.operatorframework.io.bundle.channel.default.v1"`
 }
 
-// DependenciesFile holds dependency information about a bundle
+// DependenciesFile holds dependency information about a bundle.
 type DependenciesFile struct {
 	// Dependencies is a list of dependencies for a given bundle
 	Dependencies []Dependency `json:"dependencies" yaml:"dependencies"`
 }
 
-// Dependency specifies a single constraint that can be satisfied by a property on another bundle..
+// Dependency specifies a single constraint that can be satisfied by a property on another bundle.
 type Dependency struct {
 	// The type of dependency. This field is required.
 	Type string `json:"type" yaml:"type"`
 
 	// The serialized value of the dependency
 	Value json.RawMessage `json:"value" yaml:"value"`
+}
+
+// PropertiesFile holds the properties associated with a bundle.
+type PropertiesFile struct {
+	// Properties is a list of properties.
+	Properties []Property `json:"properties" yaml:"properties"`
 }
 
 // Property defines a single piece of the public interface for a bundle. Dependencies are specified over properties.
@@ -184,6 +190,10 @@ type Property struct {
 
 	// The serialized value of the propertuy
 	Value json.RawMessage `json:"value" yaml:"value"`
+}
+
+func (p Property) String() string {
+	return fmt.Sprintf("type: %s, value: %s", p.Type, p.Value)
 }
 
 type GVKDependency struct {
@@ -349,11 +359,16 @@ func (a *AnnotationsFile) GetDefaultChannelName() string {
 // SelectDefaultChannel returns the first item in channel list that is sorted
 // in lexicographic order.
 func (a *AnnotationsFile) SelectDefaultChannel() string {
-	if a.Annotations.Channels != "" {
-		channels := strings.Split(a.Annotations.Channels, ",")
-		sort.Strings(channels)
-		return channels[0]
+	return a.SelectDefaultChannel()
+}
+
+func (a Annotations) SelectDefaultChannel() string {
+	if len(a.Channels) < 1 {
+		return ""
 	}
 
-	return ""
+	channels := strings.Split(a.Channels, ",")
+	sort.Strings(channels)
+
+	return channels[0]
 }


### PR DESCRIPTION
**Description of the change:**

Defines a new configuration file that can be provided by bundle authors to explicitly declare properties.

The file itself can have any name, but must _both_ exist in the top-level `metadata` directory of the bundle _and_ consist of YAML with a top-level `properties` element containing an array of type/value tuples.

e.g.

```yaml
properties:
- type: olm.label
  value: "foo"
```

All properties sourced from this file, CSV annotations, and those derived from bundle manifests are exposed on the bundle (after being deduplicated).

**Motivation for the change:**

See the [EP](https://github.com/operator-framework/enhancements/blob/master/enhancements/properties.md) for motivation and details.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
