### PR TITLE
feat(render): render sqlite database files

### DIFF
--- a/cmd/opm/alpha/render/cmd.go
+++ b/cmd/opm/alpha/render/cmd.go
@@ -19,8 +19,8 @@ func NewCmd() *cobra.Command {
 		output string
 	)
 	cmd := &cobra.Command{
-		Use:   "render [index-image | bundle-image]...",
-		Short: "Generate declarative config blobs from the provided index and bundle images",
+		Use:   "render [index-image | bundle-image | sqlite-file]...",
+		Short: "Generate a declarative config blob from the provided index images, bundle images, and sqlite database files",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			render.Refs = args


### PR DESCRIPTION
**Description of the change:** render sqlite db files directly

**Motivation for the change:** follow up on https://github.com/operator-framework/operator-registry/pull/661#discussion_r639255740

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
