### PR TITLE
declcfg: validation should allow non-existent replaces value

### DIFF
--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -230,13 +230,6 @@ func (b *Bundle) Validate() error {
 	if b.Channel != nil && b.Package != nil && b.Package != b.Channel.Package {
 		result = multierror.Append(result, errors.New("package does not match channel's package"))
 	}
-	if b.Replaces != "" {
-		if b.Channel != nil && b.Channel.Bundles != nil {
-			if _, ok := b.Channel.Bundles[b.Replaces]; !ok {
-				result = multierror.Append(result, fmt.Errorf("replaces %q not found in channel", b.Replaces))
-			}
-		}
-	}
 	props, err := property.Parse(b.Properties)
 	if err != nil {
 		result = multierror.Append(result, err)


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Remove the validation check that ensures all bundle replaces values are present in the channel.

**Motivation for the change:**
It is not necessary for a catalog to contain all referenced bundles. An old catalog may contain a bundle that has been replaced by a bundle that exists in a new catalog. The OLM resolver already handles this case.

Note that it is still a requirement that within a given DC catalog, there must be exactly one channel head per channel (where channel head is defined as a node with 0 incoming edges)

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
