### PR TITLE
fix(opm): assume default db location in image

### DIFF
--- a/pkg/lib/indexer/indexer.go
+++ b/pkg/lib/indexer/indexer.go
@@ -354,7 +354,8 @@ func (i ImageIndexer) getDatabaseFile(workingDir, fromIndex, caFile string, skip
 
 	dbLocation, ok := labels[containertools.DbLocationLabel]
 	if !ok {
-		return "", fmt.Errorf("index image %s missing label %s", fromIndex, containertools.DbLocationLabel)
+		dbLocation = containertools.DefaultDbLocation
+		i.Logger.Warnf("index image %v missing label %v. Trying to unpacking using default db location %v", fromIndex, containertools.DbLocationLabel, containertools.DefaultDbLocation)
 	}
 
 	if err := reg.Unpack(context.TODO(), imageRef, workingDir); err != nil {


### PR DESCRIPTION


**Description of the change:**

Currently, all opm index command operations fail on container images
that do not have the `containertools.DbLocationLabel` set. This PR
introduces a change that tries to continue the opm index operation
by assuming a default db location while printing out a warning. If
the assumption holds wrong, users will see the error when there is
an attempt to access the db from within the binary, while the warning
would serve as the accurate indicator of the missing lable.


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
