### PR TITLE
opm catalog-snapshot: compile and output all installed operators in a cluster

### DIFF
--- a/cmd/opm/alpha/catalogsnapshot/cmd.go
+++ b/cmd/opm/alpha/catalogsnapshot/cmd.go
@@ -19,17 +19,14 @@ func NewCmd() *cobra.Command {
 	var (
 		snapshot action.CatalogSnapshot
 
-		output         string
-		kubeconfigPath string
-		timeout        time.Duration
+		output  string
+		timeout time.Duration
 	)
 	cmd := &cobra.Command{
 		Use:   "catalog-snapshot [args]",
-		Short: "Generate a snapshot of all catalogs in the cluster as a declarative config",
+		Short: "Generate a snapshot of all installed operators in the cluster as a declarative config",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			snapshot.KubeconfigPath = kubeconfigPath
-
 			var write func(declcfg.DeclarativeConfig, io.Writer) error
 			switch output {
 			case "yaml":
@@ -59,7 +56,7 @@ func NewCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&kubeconfigPath, "output", "o", "json", "Output format (json|yaml)")
+	cmd.Flags().StringVarP(&snapshot.KubeconfigPath, "output", "o", "json", "Output format (json|yaml)")
 	cmd.Flags().DurationVar(&timeout, "timeout", 2*time.Minute, "Command timeout")
 	return cmd
 }

--- a/cmd/opm/alpha/catalogsnapshot/cmd.go
+++ b/cmd/opm/alpha/catalogsnapshot/cmd.go
@@ -1,0 +1,65 @@
+package catalogsnapshot
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/operator-framework/operator-registry/internal/action"
+	"github.com/operator-framework/operator-registry/internal/declcfg"
+)
+
+func NewCmd() *cobra.Command {
+	var (
+		snapshot action.CatalogSnapshot
+
+		output         string
+		kubeconfigPath string
+		timeout        time.Duration
+	)
+	cmd := &cobra.Command{
+		Use:   "catalog-snapshot [args]",
+		Short: "Generate a snapshot of all catalogs in the cluster as a declarative config",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			snapshot.KubeconfigPath = kubeconfigPath
+
+			var write func(declcfg.DeclarativeConfig, io.Writer) error
+			switch output {
+			case "yaml":
+				write = declcfg.WriteYAML
+			case "json":
+				write = declcfg.WriteJSON
+			default:
+				log.Fatalf("invalid --output value %q, expected (json|yaml)", output)
+			}
+
+			// The bundle loading impl is somewhat verbose, even on the happy path,
+			// so discard all logrus default logger logs. Any important failures will be
+			// returned from snapshot.Run and logged as fatal errors.
+			logrus.SetOutput(ioutil.Discard)
+
+			ctx, cancel := context.WithTimeout(cmd.Context(), timeout)
+			defer cancel()
+
+			cfg, err := snapshot.Run(ctx)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if err := write(*cfg, os.Stdout); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&kubeconfigPath, "output", "o", "json", "Output format (json|yaml)")
+	cmd.Flags().DurationVar(&timeout, "timeout", 2*time.Minute, "Command timeout")
+	return cmd
+}

--- a/cmd/opm/alpha/cmd.go
+++ b/cmd/opm/alpha/cmd.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/operator-framework/operator-registry/cmd/opm/alpha/bundle"
+	"github.com/operator-framework/operator-registry/cmd/opm/alpha/catalogsnapshot"
 	initcmd "github.com/operator-framework/operator-registry/cmd/opm/alpha/init"
 	"github.com/operator-framework/operator-registry/cmd/opm/alpha/render"
 	"github.com/operator-framework/operator-registry/cmd/opm/alpha/serve"
@@ -17,6 +18,13 @@ func NewCmd() *cobra.Command {
 		Short:  "Run an alpha subcommand",
 	}
 
-	runCmd.AddCommand(bundle.NewCmd(), initcmd.NewCmd(), serve.NewCmd(), render.NewCmd(), validate.NewCmd())
+	runCmd.AddCommand(
+		bundle.NewCmd(),
+		initcmd.NewCmd(),
+		serve.NewCmd(),
+		render.NewCmd(),
+		validate.NewCmd(),
+		catalogsnapshot.NewCmd(),
+	)
 	return runCmd
 }

--- a/internal/action/catalogsnapshot.go
+++ b/internal/action/catalogsnapshot.go
@@ -1,0 +1,144 @@
+package action
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/connectivity"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/operator-framework/operator-registry/internal/declcfg"
+	"github.com/operator-framework/operator-registry/internal/model"
+	"github.com/operator-framework/operator-registry/pkg/api"
+	grpc "github.com/operator-framework/operator-registry/pkg/client"
+)
+
+// CatalogSnapshot configures Run to read CatalogSources from a k8s cluster.
+type CatalogSnapshot struct {
+	// Non-default path to kubeconfig. This kubeconfig must contain
+	// a context with permission to list CatalogSources in all namespaces.
+	KubeconfigPath string
+
+	// Client to read CatalogSources.
+	client ctrlclient.Client
+	// Client to query the underlying catalog server for bundles.
+	newGRPCClient func(string) (*grpc.Client, error)
+}
+
+// Run reads all bundles via gRPC from all CatalogSources in all namespaces
+// and adds them in CatalogSource priority order to a declarative config.
+// NOTE: Run assumes the k8s config context used has permission to list
+// CatalogSources across all namespaces.
+func (a *CatalogSnapshot) Run(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
+	// Get kubeconfig, optionally at the path specified via CLI.
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	rules.ExplicitPath = a.KubeconfigPath
+	overrides := clientcmd.ConfigOverrides{}
+	cc := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, &overrides)
+	cfg, err := cc.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// k8s client for CatalogSources.
+	schemeBuilder := runtime.NewSchemeBuilder(
+		operatorsv1alpha1.AddToScheme,
+	)
+	if err := schemeBuilder.AddToScheme(scheme.Scheme); err != nil {
+		return nil, err
+	}
+	clientOpts := ctrlclient.Options{Scheme: scheme.Scheme}
+	if a.client, err = ctrlclient.New(cfg, clientOpts); err != nil {
+		return nil, err
+	}
+
+	// Standard, insecure gRPC client.
+	// QUESTION: does this need auth config?
+	a.newGRPCClient = grpc.NewClient
+	return a.run(ctx)
+}
+
+func (a *CatalogSnapshot) run(ctx context.Context) (_ *declcfg.DeclarativeConfig, err error) {
+	// List CatalogSources across all namespaces.
+	csList := v1alpha1.CatalogSourceList{}
+	if err = a.client.List(ctx, &csList); err != nil {
+		return nil, err
+	}
+	// Sort CatalogSources by priority so iterators are added in priority order.
+	sort.Slice(csList.Items, func(i, j int) bool {
+		return csList.Items[i].Spec.Priority < csList.Items[j].Spec.Priority
+	})
+	prioritizedIterators := make([]*grpc.BundleIterator, len(csList.Items))
+
+	// Add gRPC bundle iterators for available catalogs to prioritized list.
+	// TODO: paralellize but maintain priority.
+	catalogState := model.Model{}
+	for i, item := range csList.Items {
+		// TODO: support non-gRPC CatalogSources.
+		if item.Spec.SourceType != operatorsv1alpha1.SourceTypeGrpc {
+			continue
+		}
+
+		// Only READY CatalogSources will be available to open a connection.
+		csKey := ctrlclient.ObjectKeyFromObject(&item)
+		connState := item.Status.GRPCConnectionState
+		switch connState.LastObservedState {
+		case connectivity.Ready.String():
+		case connectivity.Connecting.String():
+			// Wait until READY.
+			wait.PollUntil(200*time.Millisecond, func() (bool, error) {
+				cs := v1alpha1.CatalogSource{}
+				if err := a.client.Get(ctx, csKey, &cs); err != nil {
+					return false, err
+				}
+				return cs.Status.GRPCConnectionState.LastObservedState == connectivity.Ready.String(), nil
+			}, ctx.Done())
+		default:
+			logrus.Debugf("CatalogSource %s has gRPC connection state %q, skipping", csKey, connState.LastObservedState)
+			continue
+		}
+
+		// gRPC address is required here.
+		addr := connState.Address
+		if addr == "" {
+			logrus.Debugf("CatalogSource %s address is empty", csKey)
+			continue
+		}
+		// QUESTION: are these addresses accessible outside of the cluster?
+		grpcclient, err := a.newGRPCClient(addr)
+		if err != nil {
+			return nil, err
+		}
+		if prioritizedIterators[i], err = grpcclient.ListBundles(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	// Iterate in reverse priority so lower priority bundles are overridden by AddBundle().
+	for i := len(prioritizedIterators) - 1; i >= 0; i-- {
+		iterator := prioritizedIterators[i]
+		for apiBundle := iterator.Next(); apiBundle != nil; apiBundle = iterator.Next() {
+			if err := iterator.Error(); err != nil {
+				return nil, err
+			}
+			b, err := api.ConvertAPIBundleToModelBundle(apiBundle)
+			if err != nil {
+				return nil, err
+			}
+			// TODO: this might add the wrong default channel, since catalogState's packages
+			// were not initialized with default channels.
+			catalogState.AddBundle(*b)
+		}
+	}
+
+	dc := declcfg.ConvertFromModel(catalogState)
+	return &dc, nil
+}

--- a/internal/action/catalogsnapshot.go
+++ b/internal/action/catalogsnapshot.go
@@ -2,41 +2,32 @@ package action
 
 import (
 	"context"
-	"sort"
-	"time"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/sirupsen/logrus"
-	"google.golang.org/grpc/connectivity"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/operator-framework/operator-registry/internal/declcfg"
 	"github.com/operator-framework/operator-registry/internal/model"
-	"github.com/operator-framework/operator-registry/pkg/api"
-	grpc "github.com/operator-framework/operator-registry/pkg/client"
+	"github.com/operator-framework/operator-registry/internal/property"
 )
 
-// CatalogSnapshot configures Run to read CatalogSources from a k8s cluster.
+// CatalogSnapshot configures Run to read Subscriptions from a k8s cluster.
 type CatalogSnapshot struct {
 	// Non-default path to kubeconfig. This kubeconfig must contain
-	// a context with permission to list CatalogSources in all namespaces.
+	// a context with permission to list Subscriptions in all namespaces.
 	KubeconfigPath string
 
-	// Client to read CatalogSources.
+	// Client to read Subscriptions.
 	client ctrlclient.Client
-	// Client to query the underlying catalog server for bundles.
-	newGRPCClient func(string) (*grpc.Client, error)
 }
 
-// Run reads all bundles via gRPC from all CatalogSources in all namespaces
-// and adds them in CatalogSource priority order to a declarative config.
+// Run gets installed bundle data from every Subscription in every namespace
+// and adds them to a declarative config.
 // NOTE: Run assumes the k8s config context used has permission to list
-// CatalogSources across all namespaces.
+// Subscriptions across all namespaces.
 func (a *CatalogSnapshot) Run(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
 	// Get kubeconfig, optionally at the path specified via CLI.
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
@@ -48,97 +39,53 @@ func (a *CatalogSnapshot) Run(ctx context.Context) (*declcfg.DeclarativeConfig, 
 		return nil, err
 	}
 
-	// k8s client for CatalogSources.
-	schemeBuilder := runtime.NewSchemeBuilder(
-		operatorsv1alpha1.AddToScheme,
-	)
-	if err := schemeBuilder.AddToScheme(scheme.Scheme); err != nil {
+	// k8s client for Subscriptions.
+	sch := runtime.NewScheme()
+	if err := operatorsv1alpha1.AddToScheme(sch); err != nil {
 		return nil, err
 	}
-	clientOpts := ctrlclient.Options{Scheme: scheme.Scheme}
+	clientOpts := ctrlclient.Options{Scheme: sch}
 	if a.client, err = ctrlclient.New(cfg, clientOpts); err != nil {
 		return nil, err
 	}
-
-	// Standard, insecure gRPC client.
-	// QUESTION: does this need auth config?
-	a.newGRPCClient = grpc.NewClient
 	return a.run(ctx)
 }
 
 func (a *CatalogSnapshot) run(ctx context.Context) (_ *declcfg.DeclarativeConfig, err error) {
-	// List CatalogSources across all namespaces.
-	csList := v1alpha1.CatalogSourceList{}
-	if err = a.client.List(ctx, &csList); err != nil {
+	// List Subscriptions across all namespaces.
+	subList := v1alpha1.SubscriptionList{}
+	if err = a.client.List(ctx, &subList); err != nil {
 		return nil, err
 	}
-	// Sort CatalogSources by priority so iterators are added in priority order.
-	sort.Slice(csList.Items, func(i, j int) bool {
-		return csList.Items[i].Spec.Priority < csList.Items[j].Spec.Priority
-	})
-	prioritizedIterators := make([]*grpc.BundleIterator, len(csList.Items))
 
-	// Add gRPC bundle iterators for available catalogs to prioritized list.
-	// TODO: paralellize but maintain priority.
-	catalogState := model.Model{}
-	for i, item := range csList.Items {
-		// TODO: support non-gRPC CatalogSources.
-		if item.Spec.SourceType != operatorsv1alpha1.SourceTypeGrpc {
-			continue
+	latestState := model.Model{}
+	for _, sub := range subList.Items {
+		// If the Subscription is in the process of upgrading,
+		// then CurrentCSV will be set to the latest CSV.
+		// Otherwise use the currently InstalledCSV.
+		name := sub.Status.InstalledCSV
+		if sub.Status.CurrentCSV != "" {
+			name = sub.Status.CurrentCSV
 		}
-
-		// Only READY CatalogSources will be available to open a connection.
-		csKey := ctrlclient.ObjectKeyFromObject(&item)
-		connState := item.Status.GRPCConnectionState
-		switch connState.LastObservedState {
-		case connectivity.Ready.String():
-		case connectivity.Connecting.String():
-			// Wait until READY.
-			wait.PollUntil(200*time.Millisecond, func() (bool, error) {
-				cs := v1alpha1.CatalogSource{}
-				if err := a.client.Get(ctx, csKey, &cs); err != nil {
-					return false, err
-				}
-				return cs.Status.GRPCConnectionState.LastObservedState == connectivity.Ready.String(), nil
-			}, ctx.Done())
-		default:
-			logrus.Debugf("CatalogSource %s has gRPC connection state %q, skipping", csKey, connState.LastObservedState)
-			continue
+		pkg := &model.Package{
+			Name: sub.Spec.Package,
 		}
-
-		// gRPC address is required here.
-		addr := connState.Address
-		if addr == "" {
-			logrus.Debugf("CatalogSource %s address is empty", csKey)
-			continue
+		ch := &model.Channel{
+			Name:    sub.Spec.Channel,
+			Package: pkg,
 		}
-		// QUESTION: are these addresses accessible outside of the cluster?
-		grpcclient, err := a.newGRPCClient(addr)
-		if err != nil {
-			return nil, err
+		b := model.Bundle{
+			Name:    name,
+			Channel: ch,
+			Package: pkg,
 		}
-		if prioritizedIterators[i], err = grpcclient.ListBundles(ctx); err != nil {
-			return nil, err
+		b.Properties = []property.Property{
+			property.MustBuildChannel(ch.Name, ""),
+			property.MustBuildPackage(pkg.Name, ""),
 		}
+		latestState.AddBundle(b)
 	}
 
-	// Iterate in reverse priority so lower priority bundles are overridden by AddBundle().
-	for i := len(prioritizedIterators) - 1; i >= 0; i-- {
-		iterator := prioritizedIterators[i]
-		for apiBundle := iterator.Next(); apiBundle != nil; apiBundle = iterator.Next() {
-			if err := iterator.Error(); err != nil {
-				return nil, err
-			}
-			b, err := api.ConvertAPIBundleToModelBundle(apiBundle)
-			if err != nil {
-				return nil, err
-			}
-			// TODO: this might add the wrong default channel, since catalogState's packages
-			// were not initialized with default channels.
-			catalogState.AddBundle(*b)
-		}
-	}
-
-	dc := declcfg.ConvertFromModel(catalogState)
+	dc := declcfg.ConvertFromModel(latestState)
 	return &dc, nil
 }

--- a/internal/action/catalogsnapshot_test.go
+++ b/internal/action/catalogsnapshot_test.go
@@ -1,0 +1,212 @@
+package action
+
+import (
+	"context"
+	"testing"
+
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/operator-framework/operator-registry/internal/declcfg"
+	"github.com/operator-framework/operator-registry/internal/property"
+)
+
+func TestCatalogSnapShot(t *testing.T) {
+	schemeBuilder := runtime.NewSchemeBuilder(
+		operatorsv1alpha1.AddToScheme,
+	)
+	if err := schemeBuilder.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	type spec struct {
+		name      string
+		subs      []runtime.Object
+		expectDC  *declcfg.DeclarativeConfig
+		assertion require.ErrorAssertionFunc
+	}
+
+	specs := []spec{
+		{
+			name:     "Success/NoSub",
+			subs:     []runtime.Object{},
+			expectDC: &declcfg.DeclarativeConfig{},
+		},
+		{
+			name: "Success/OneSub",
+			subs: []runtime.Object{
+				newSubscription("sub-1", "ns", "foo", "stable", "foo.v0.1.0", ""),
+			},
+			expectDC: &declcfg.DeclarativeConfig{
+				Packages: []declcfg.Package{
+					{
+						Schema:         "olm.package",
+						Name:           "foo",
+						DefaultChannel: "stable",
+					},
+				},
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.1.0",
+						Package: "foo",
+						Properties: []property.Property{
+							property.MustBuildChannel("stable", ""),
+							property.MustBuildPackage("foo", ""),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Success/MultipleSubs",
+			subs: []runtime.Object{
+				newSubscription("sub-1", "ns", "foo", "stable", "foo.v0.1.0", ""),
+				newSubscription("sub-2", "ns", "bar", "stable", "bar.v0.1.0", ""),
+				newSubscription("sub-3", "ns", "baz", "fast", "baz.v0.1.0", ""),
+			},
+			expectDC: &declcfg.DeclarativeConfig{
+				Packages: []declcfg.Package{
+					{
+						Schema:         "olm.package",
+						Name:           "bar",
+						DefaultChannel: "stable",
+					},
+					{
+						Schema:         "olm.package",
+						Name:           "baz",
+						DefaultChannel: "fast",
+					},
+					{
+						Schema:         "olm.package",
+						Name:           "foo",
+						DefaultChannel: "stable",
+					},
+				},
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  "olm.bundle",
+						Name:    "bar.v0.1.0",
+						Package: "bar",
+						Properties: []property.Property{
+							property.MustBuildChannel("stable", ""),
+							property.MustBuildPackage("bar", ""),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "baz.v0.1.0",
+						Package: "baz",
+						Properties: []property.Property{
+							property.MustBuildChannel("fast", ""),
+							property.MustBuildPackage("baz", ""),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.1.0",
+						Package: "foo",
+						Properties: []property.Property{
+							property.MustBuildChannel("stable", ""),
+							property.MustBuildPackage("foo", ""),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Success/TwoSubsSamePackage",
+			subs: []runtime.Object{
+				newSubscription("foo-sub", "ns-1", "foo", "stable", "foo.v0.1.0", ""),
+				newSubscription("foo-sub", "ns-2", "foo", "fast", "foo.v0.2.0-alpha.1", ""),
+			},
+			expectDC: &declcfg.DeclarativeConfig{
+				Packages: []declcfg.Package{
+					{
+						Schema:         "olm.package",
+						Name:           "foo",
+						DefaultChannel: "stable",
+					},
+				},
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.1.0",
+						Package: "foo",
+						Properties: []property.Property{
+							property.MustBuildChannel("stable", ""),
+							property.MustBuildPackage("foo", ""),
+						},
+					},
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.2.0-alpha.1",
+						Package: "foo",
+						Properties: []property.Property{
+							property.MustBuildChannel("fast", ""),
+							property.MustBuildPackage("foo", ""),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Success/TwoSubsIdentical",
+			subs: []runtime.Object{
+				newSubscription("foo-sub", "ns-1", "foo", "stable", "foo.v0.1.0", ""),
+				newSubscription("foo-sub", "ns-2", "foo", "stable", "foo.v0.1.0", ""),
+			},
+			expectDC: &declcfg.DeclarativeConfig{
+				Packages: []declcfg.Package{
+					{
+						Schema:         "olm.package",
+						Name:           "foo",
+						DefaultChannel: "stable",
+					},
+				},
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.1.0",
+						Package: "foo",
+						Properties: []property.Property{
+							property.MustBuildChannel("stable", ""),
+							property.MustBuildPackage("foo", ""),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, s := range specs {
+		t.Run(s.name, func(t *testing.T) {
+			snapshot := CatalogSnapshot{}
+			snapshot.client = fake.NewFakeClientWithScheme(scheme.Scheme, s.subs...)
+			cfg, err := snapshot.run(context.TODO())
+			if s.assertion == nil {
+				s.assertion = require.NoError
+			}
+			s.assertion(t, err)
+			require.Equal(t, s.expectDC, cfg)
+		})
+	}
+}
+
+func newSubscription(name, namespace, pkg, channel, installedCSV, currentCSV string) *operatorsv1alpha1.Subscription {
+	return &operatorsv1alpha1.Subscription{
+		ObjectMeta: v1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: &operatorsv1alpha1.SubscriptionSpec{
+			Package: pkg,
+			Channel: channel,
+		},
+		Status: operatorsv1alpha1.SubscriptionStatus{
+			InstalledCSV: installedCSV,
+			CurrentCSV:   currentCSV,
+		},
+	}
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -307,8 +307,14 @@ func (m Model) AddBundle(b Bundle) {
 	p := m[b.Package.Name]
 	b.Package = p
 
+	if p.Channels == nil {
+		p.Channels = map[string]*Channel{}
+	}
 	if ch, ok := p.Channels[b.Channel.Name]; ok {
 		b.Channel = ch
+		if ch.Bundles == nil {
+			ch.Bundles = map[string]*Bundle{}
+		}
 		ch.Bundles[b.Name] = &b
 	} else {
 		newCh := &Channel{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -923,6 +923,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client
 ## explicit
 sigs.k8s.io/controller-runtime/pkg/client
 sigs.k8s.io/controller-runtime/pkg/client/apiutil
+sigs.k8s.io/controller-runtime/pkg/client/fake
+sigs.k8s.io/controller-runtime/pkg/internal/objectutil
 sigs.k8s.io/controller-runtime/pkg/scheme
 # sigs.k8s.io/kind v0.11.1
 ## explicit

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/client.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/client.go
@@ -1,0 +1,629 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/internal/objectutil"
+)
+
+type versionedTracker struct {
+	testing.ObjectTracker
+	scheme *runtime.Scheme
+}
+
+type fakeClient struct {
+	tracker versionedTracker
+	scheme  *runtime.Scheme
+}
+
+var _ client.Client = &fakeClient{}
+
+const (
+	maxNameLength          = 63
+	randomLength           = 5
+	maxGeneratedNameLength = maxNameLength - randomLength
+)
+
+// NewFakeClient creates a new fake client for testing.
+// You can choose to initialize it with a slice of runtime.Object.
+//
+// Deprecated: Please use NewClientBuilder instead.
+func NewFakeClient(initObjs ...runtime.Object) client.Client {
+	return NewClientBuilder().WithRuntimeObjects(initObjs...).Build()
+}
+
+// NewFakeClientWithScheme creates a new fake client with the given scheme
+// for testing.
+// You can choose to initialize it with a slice of runtime.Object.
+//
+// Deprecated: Please use NewClientBuilder instead.
+func NewFakeClientWithScheme(clientScheme *runtime.Scheme, initObjs ...runtime.Object) client.Client {
+	return NewClientBuilder().WithScheme(clientScheme).WithRuntimeObjects(initObjs...).Build()
+}
+
+// NewClientBuilder returns a new builder to create a fake client.
+func NewClientBuilder() *ClientBuilder {
+	return &ClientBuilder{}
+}
+
+// ClientBuilder builds a fake client.
+type ClientBuilder struct {
+	scheme             *runtime.Scheme
+	initObject         []client.Object
+	initLists          []client.ObjectList
+	initRuntimeObjects []runtime.Object
+}
+
+// WithScheme sets this builder's internal scheme.
+// If not set, defaults to client-go's global scheme.Scheme.
+func (f *ClientBuilder) WithScheme(scheme *runtime.Scheme) *ClientBuilder {
+	f.scheme = scheme
+	return f
+}
+
+// WithObjects can be optionally used to initialize this fake client with client.Object(s).
+func (f *ClientBuilder) WithObjects(initObjs ...client.Object) *ClientBuilder {
+	f.initObject = append(f.initObject, initObjs...)
+	return f
+}
+
+// WithLists can be optionally used to initialize this fake client with client.ObjectList(s).
+func (f *ClientBuilder) WithLists(initLists ...client.ObjectList) *ClientBuilder {
+	f.initLists = append(f.initLists, initLists...)
+	return f
+}
+
+// WithRuntimeObjects can be optionally used to initialize this fake client with runtime.Object(s).
+func (f *ClientBuilder) WithRuntimeObjects(initRuntimeObjs ...runtime.Object) *ClientBuilder {
+	f.initRuntimeObjects = append(f.initRuntimeObjects, initRuntimeObjs...)
+	return f
+}
+
+// Build builds and returns a new fake client.
+func (f *ClientBuilder) Build() client.Client {
+	if f.scheme == nil {
+		f.scheme = scheme.Scheme
+	}
+
+	tracker := versionedTracker{ObjectTracker: testing.NewObjectTracker(f.scheme, scheme.Codecs.UniversalDecoder()), scheme: f.scheme}
+	for _, obj := range f.initObject {
+		if err := tracker.Add(obj); err != nil {
+			panic(fmt.Errorf("failed to add object %v to fake client: %w", obj, err))
+		}
+	}
+	for _, obj := range f.initLists {
+		if err := tracker.Add(obj); err != nil {
+			panic(fmt.Errorf("failed to add list %v to fake client: %w", obj, err))
+		}
+	}
+	for _, obj := range f.initRuntimeObjects {
+		if err := tracker.Add(obj); err != nil {
+			panic(fmt.Errorf("failed to add runtime object %v to fake client: %w", obj, err))
+		}
+	}
+	return &fakeClient{
+		tracker: tracker,
+		scheme:  f.scheme,
+	}
+}
+
+const trackerAddResourceVersion = "999"
+
+func (t versionedTracker) Add(obj runtime.Object) error {
+	var objects []runtime.Object
+	if meta.IsListType(obj) {
+		var err error
+		objects, err = meta.ExtractList(obj)
+		if err != nil {
+			return err
+		}
+	} else {
+		objects = []runtime.Object{obj}
+	}
+	for _, obj := range objects {
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return fmt.Errorf("failed to get accessor for object: %w", err)
+		}
+		if accessor.GetResourceVersion() == "" {
+			// We use a "magic" value of 999 here because this field
+			// is parsed as uint and and 0 is already used in Update.
+			// As we can't go lower, go very high instead so this can
+			// be recognized
+			accessor.SetResourceVersion(trackerAddResourceVersion)
+		}
+		if err := t.ObjectTracker.Add(obj); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (t versionedTracker) Create(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return fmt.Errorf("failed to get accessor for object: %v", err)
+	}
+	if accessor.GetName() == "" {
+		return apierrors.NewInvalid(
+			obj.GetObjectKind().GroupVersionKind().GroupKind(),
+			accessor.GetName(),
+			field.ErrorList{field.Required(field.NewPath("metadata.name"), "name is required")})
+	}
+	if accessor.GetResourceVersion() != "" {
+		return apierrors.NewBadRequest("resourceVersion can not be set for Create requests")
+	}
+	accessor.SetResourceVersion("1")
+	if err := t.ObjectTracker.Create(gvr, obj, ns); err != nil {
+		accessor.SetResourceVersion("")
+		return err
+	}
+	return nil
+}
+
+func (t versionedTracker) Update(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return fmt.Errorf("failed to get accessor for object: %v", err)
+	}
+
+	if accessor.GetName() == "" {
+		return apierrors.NewInvalid(
+			obj.GetObjectKind().GroupVersionKind().GroupKind(),
+			accessor.GetName(),
+			field.ErrorList{field.Required(field.NewPath("metadata.name"), "name is required")})
+	}
+
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	if gvk.Empty() {
+		gvk, err = apiutil.GVKForObject(obj, t.scheme)
+		if err != nil {
+			return err
+		}
+	}
+
+	oldObject, err := t.ObjectTracker.Get(gvr, ns, accessor.GetName())
+	if err != nil {
+		// If the resource is not found and the resource allows create on update, issue a
+		// create instead.
+		if apierrors.IsNotFound(err) && allowsCreateOnUpdate(gvk) {
+			return t.Create(gvr, obj, ns)
+		}
+		return err
+	}
+
+	oldAccessor, err := meta.Accessor(oldObject)
+	if err != nil {
+		return err
+	}
+
+	// If the new object does not have the resource version set and it allows unconditional update,
+	// default it to the resource version of the existing resource
+	if accessor.GetResourceVersion() == "" && allowsUnconditionalUpdate(gvk) {
+		accessor.SetResourceVersion(oldAccessor.GetResourceVersion())
+	}
+	if accessor.GetResourceVersion() != oldAccessor.GetResourceVersion() {
+		return apierrors.NewConflict(gvr.GroupResource(), accessor.GetName(), errors.New("object was modified"))
+	}
+	if oldAccessor.GetResourceVersion() == "" {
+		oldAccessor.SetResourceVersion("0")
+	}
+	intResourceVersion, err := strconv.ParseUint(oldAccessor.GetResourceVersion(), 10, 64)
+	if err != nil {
+		return fmt.Errorf("can not convert resourceVersion %q to int: %v", oldAccessor.GetResourceVersion(), err)
+	}
+	intResourceVersion++
+	accessor.SetResourceVersion(strconv.FormatUint(intResourceVersion, 10))
+	return t.ObjectTracker.Update(gvr, obj, ns)
+}
+
+func (c *fakeClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	o, err := c.tracker.Get(gvr, key.Namespace, key.Name)
+	if err != nil {
+		return err
+	}
+
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	ta, err := meta.TypeAccessor(o)
+	if err != nil {
+		return err
+	}
+	ta.SetKind(gvk.Kind)
+	ta.SetAPIVersion(gvk.GroupVersion().String())
+
+	j, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+	decoder := scheme.Codecs.UniversalDecoder()
+	_, _, err = decoder.Decode(j, nil, obj)
+	return err
+}
+
+func (c *fakeClient) List(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) error {
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+
+	OriginalKind := gvk.Kind
+
+	if !strings.HasSuffix(gvk.Kind, "List") {
+		return fmt.Errorf("non-list type %T (kind %q) passed as output", obj, gvk)
+	}
+	// we need the non-list GVK, so chop off the "List" from the end of the kind
+	gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
+
+	listOpts := client.ListOptions{}
+	listOpts.ApplyOptions(opts)
+
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	o, err := c.tracker.List(gvr, gvk, listOpts.Namespace)
+	if err != nil {
+		return err
+	}
+
+	ta, err := meta.TypeAccessor(o)
+	if err != nil {
+		return err
+	}
+	ta.SetKind(OriginalKind)
+	ta.SetAPIVersion(gvk.GroupVersion().String())
+
+	j, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+	decoder := scheme.Codecs.UniversalDecoder()
+	_, _, err = decoder.Decode(j, nil, obj)
+	if err != nil {
+		return err
+	}
+
+	if listOpts.LabelSelector != nil {
+		objs, err := meta.ExtractList(obj)
+		if err != nil {
+			return err
+		}
+		filteredObjs, err := objectutil.FilterWithLabels(objs, listOpts.LabelSelector)
+		if err != nil {
+			return err
+		}
+		err = meta.SetList(obj, filteredObjs)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *fakeClient) Scheme() *runtime.Scheme {
+	return c.scheme
+}
+
+func (c *fakeClient) RESTMapper() meta.RESTMapper {
+	// TODO: Implement a fake RESTMapper.
+	return nil
+}
+
+func (c *fakeClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	createOptions := &client.CreateOptions{}
+	createOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range createOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	if accessor.GetName() == "" && accessor.GetGenerateName() != "" {
+		base := accessor.GetGenerateName()
+		if len(base) > maxGeneratedNameLength {
+			base = base[:maxGeneratedNameLength]
+		}
+		accessor.SetName(fmt.Sprintf("%s%s", base, utilrand.String(randomLength)))
+	}
+
+	return c.tracker.Create(gvr, obj, accessor.GetNamespace())
+}
+
+func (c *fakeClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	delOptions := client.DeleteOptions{}
+	delOptions.ApplyOptions(opts)
+
+	//TODO: implement propagation
+	return c.tracker.Delete(gvr, accessor.GetNamespace(), accessor.GetName())
+}
+
+func (c *fakeClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+
+	dcOptions := client.DeleteAllOfOptions{}
+	dcOptions.ApplyOptions(opts)
+
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	o, err := c.tracker.List(gvr, gvk, dcOptions.Namespace)
+	if err != nil {
+		return err
+	}
+
+	objs, err := meta.ExtractList(o)
+	if err != nil {
+		return err
+	}
+	filteredObjs, err := objectutil.FilterWithLabels(objs, dcOptions.LabelSelector)
+	if err != nil {
+		return err
+	}
+	for _, o := range filteredObjs {
+		accessor, err := meta.Accessor(o)
+		if err != nil {
+			return err
+		}
+		err = c.tracker.Delete(gvr, accessor.GetNamespace(), accessor.GetName())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *fakeClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	updateOptions := &client.UpdateOptions{}
+	updateOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range updateOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	return c.tracker.Update(gvr, obj, accessor.GetNamespace())
+}
+
+func (c *fakeClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	patchOptions := &client.PatchOptions{}
+	patchOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range patchOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	data, err := patch.Data(obj)
+	if err != nil {
+		return err
+	}
+
+	reaction := testing.ObjectReaction(c.tracker)
+	handled, o, err := reaction(testing.NewPatchAction(gvr, accessor.GetNamespace(), accessor.GetName(), patch.Type(), data))
+	if err != nil {
+		return err
+	}
+	if !handled {
+		panic("tracker could not handle patch method")
+	}
+
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	ta, err := meta.TypeAccessor(o)
+	if err != nil {
+		return err
+	}
+	ta.SetKind(gvk.Kind)
+	ta.SetAPIVersion(gvk.GroupVersion().String())
+
+	j, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+	decoder := scheme.Codecs.UniversalDecoder()
+	_, _, err = decoder.Decode(j, nil, obj)
+	return err
+}
+
+func (c *fakeClient) Status() client.StatusWriter {
+	return &fakeStatusWriter{client: c}
+}
+
+func getGVRFromObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionResource, error) {
+	gvk, err := apiutil.GVKForObject(obj, scheme)
+	if err != nil {
+		return schema.GroupVersionResource{}, err
+	}
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	return gvr, nil
+}
+
+type fakeStatusWriter struct {
+	client *fakeClient
+}
+
+func (sw *fakeStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	// TODO(droot): This results in full update of the obj (spec + status). Need
+	// a way to update status field only.
+	return sw.client.Update(ctx, obj, opts...)
+}
+
+func (sw *fakeStatusWriter) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	// TODO(droot): This results in full update of the obj (spec + status). Need
+	// a way to update status field only.
+	return sw.client.Patch(ctx, obj, patch, opts...)
+}
+
+func allowsUnconditionalUpdate(gvk schema.GroupVersionKind) bool {
+	switch gvk.Group {
+	case "apps":
+		switch gvk.Kind {
+		case "ControllerRevision", "DaemonSet", "Deployment", "ReplicaSet", "StatefulSet":
+			return true
+		}
+	case "autoscaling":
+		switch gvk.Kind {
+		case "HorizontalPodAutoscaler":
+			return true
+		}
+	case "batch":
+		switch gvk.Kind {
+		case "CronJob", "Job":
+			return true
+		}
+	case "certificates":
+		switch gvk.Kind {
+		case "Certificates":
+			return true
+		}
+	case "flowcontrol":
+		switch gvk.Kind {
+		case "FlowSchema", "PriorityLevelConfiguration":
+			return true
+		}
+	case "networking":
+		switch gvk.Kind {
+		case "Ingress", "IngressClass", "NetworkPolicy":
+			return true
+		}
+	case "policy":
+		switch gvk.Kind {
+		case "PodSecurityPolicy":
+			return true
+		}
+	case "rbac":
+		switch gvk.Kind {
+		case "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding":
+			return true
+		}
+	case "scheduling":
+		switch gvk.Kind {
+		case "PriorityClass":
+			return true
+		}
+	case "settings":
+		switch gvk.Kind {
+		case "PodPreset":
+			return true
+		}
+	case "storage":
+		switch gvk.Kind {
+		case "StorageClass":
+			return true
+		}
+	case "":
+		switch gvk.Kind {
+		case "ConfigMap", "Endpoint", "Event", "LimitRange", "Namespace", "Node",
+			"PersistentVolume", "PersistentVolumeClaim", "Pod", "PodTemplate",
+			"ReplicationController", "ResourceQuota", "Secret", "Service",
+			"ServiceAccount", "EndpointSlice":
+			return true
+		}
+	}
+
+	return false
+}
+
+func allowsCreateOnUpdate(gvk schema.GroupVersionKind) bool {
+	switch gvk.Group {
+	case "coordination":
+		switch gvk.Kind {
+		case "Lease":
+			return true
+		}
+	case "node":
+		switch gvk.Kind {
+		case "RuntimeClass":
+			return true
+		}
+	case "rbac":
+		switch gvk.Kind {
+		case "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding":
+			return true
+		}
+	case "":
+		switch gvk.Kind {
+		case "Endpoint", "Event", "LimitRange", "Service":
+			return true
+		}
+	}
+
+	return false
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/doc.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/doc.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package fake provides a fake client for testing.
+
+A fake client is backed by its simple object store indexed by GroupVersionResource.
+You can create a fake client with optional objects.
+
+	client := NewFakeClientWithScheme(scheme, initObjs...) // initObjs is a slice of runtime.Object
+
+You can invoke the methods defined in the Client interface.
+
+When in doubt, it's almost always better not to use this package and instead use
+envtest.Environment with a real client and API server.
+
+WARNING: ⚠️ Current Limitations / Known Issues with the fake Client ⚠️
+- This client does not have a way to inject specific errors to test handled vs. unhandled errors.
+- There is some support for sub resources which can cause issues with tests if you're trying to update
+  e.g. metadata and status in the same reconcile.
+- No OpeanAPI validation is performed when creating or updating objects.
+- ObjectMeta's `Generation` and `ResourceVersion` don't behave properly, Patch or Update
+operations that rely on these fields will fail, or give false positives.
+
+*/
+package fake

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/objectutil/filter.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/objectutil/filter.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objectutil
+
+import (
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// FilterWithLabels returns a copy of the items in objs matching labelSel
+func FilterWithLabels(objs []runtime.Object, labelSel labels.Selector) ([]runtime.Object, error) {
+	outItems := make([]runtime.Object, 0, len(objs))
+	for _, obj := range objs {
+		meta, err := apimeta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		if labelSel != nil {
+			lbls := labels.Set(meta.GetLabels())
+			if !labelSel.Matches(lbls) {
+				continue
+			}
+		}
+		outItems = append(outItems, obj.DeepCopyObject())
+	}
+	return outItems, nil
+}


### PR DESCRIPTION
**Description of the change:** `opm catalog-snapshot` takes a snapshot of all operators installed in a cluster via their Subscriptions and writes them to a (relatively bare) declarative config.

**Motivation for the change:** useful for creating a diff (#696) between some current and new state.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

/kind feature
