### PR TITLE
**Description of the change:** Log a warning when loading bundle manifests with multiple documents

### DIFF
--- a/pkg/registry/decode.go
+++ b/pkg/registry/decode.go
@@ -8,6 +8,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"github.com/sirupsen/logrus"
 )
 
 // DecodeUnstructured decodes a raw stream into a an
@@ -44,7 +45,7 @@ func DecodePackageManifest(reader io.Reader) (manifest *PackageManifest, err err
 	return
 }
 
-func decodeFileFS(root fs.FS, path string, into interface{}) error {
+func decodeFileFS(root fs.FS, path string, into interface{}, log *logrus.Entry) error {
 	fileReader, err := root.Open(path)
 	if err != nil {
 		return fmt.Errorf("unable to read file %s: %s", path, err)
@@ -53,5 +54,14 @@ func decodeFileFS(root fs.FS, path string, into interface{}) error {
 
 	decoder := yaml.NewYAMLOrJSONDecoder(fileReader, 30)
 
-	return decoder.Decode(into)
+    errRet := decoder.Decode(into)
+
+    // Look for and warn about extra documents
+	extraDocument := &unstructured.Unstructured{}
+    err = decoder.Decode(extraDocument)
+    if err == nil && log != nil {
+        log.Warnf("found more than one document inside %s, using only the first one", path)
+    }
+
+	return errRet
 }

--- a/pkg/registry/decode_test.go
+++ b/pkg/registry/decode_test.go
@@ -101,11 +101,11 @@ func TestDecodeFileFS(t *testing.T) {
 	}
 
 	var nilPtr *foo
-	require.NoError(t, decodeFileFS(root, "foo.yaml", nilPtr))
+	require.NoError(t, decodeFileFS(root, "foo.yaml", nilPtr, nil))
 	require.Nil(t, nilPtr)
 
 	ptr := &foo{}
-	require.NoError(t, decodeFileFS(root, "foo.yaml", ptr))
+	require.NoError(t, decodeFileFS(root, "foo.yaml", ptr, nil))
 	require.NotNil(t, ptr)
 	require.Equal(t, "baz", ptr.Bar)
 }

--- a/pkg/registry/parse.go
+++ b/pkg/registry/parse.go
@@ -74,7 +74,7 @@ func (b *bundleParser) addManifests(manifests fs.FS, bundle *Bundle) error {
 		}
 
 		obj := &unstructured.Unstructured{}
-		if err = decodeFileFS(manifests, name, obj); err != nil {
+		if err = decodeFileFS(manifests, name, obj, b.log); err != nil {
 			b.log.Warnf("failed to decode: %s", err)
 			continue
 		}
@@ -128,7 +128,7 @@ func (b *bundleParser) addMetadata(metadata fs.FS, bundle *Bundle) error {
 		name := f.Name()
 		if af == nil {
 			decoded := AnnotationsFile{}
-			if err = decodeFileFS(metadata, name, &decoded); err == nil {
+			if err = decodeFileFS(metadata, name, &decoded, b.log); err == nil {
 				if decoded != (AnnotationsFile{}) {
 					af = &decoded
 				}
@@ -136,7 +136,7 @@ func (b *bundleParser) addMetadata(metadata fs.FS, bundle *Bundle) error {
 		}
 		if df == nil {
 			decoded := DependenciesFile{}
-			if err = decodeFileFS(metadata, name, &decoded); err == nil {
+			if err = decodeFileFS(metadata, name, &decoded, b.log); err == nil {
 				if len(decoded.Dependencies) > 0 {
 					df = &decoded
 				}
@@ -144,7 +144,7 @@ func (b *bundleParser) addMetadata(metadata fs.FS, bundle *Bundle) error {
 		}
 		if pf == nil {
 			decoded := PropertiesFile{}
-			if err = decodeFileFS(metadata, name, &decoded); err == nil {
+			if err = decodeFileFS(metadata, name, &decoded, b.log); err == nil {
 				if len(decoded.Properties) > 0 {
 					pf = &decoded
 				}


### PR DESCRIPTION
decodeFileFS reads only the first YAML document in a manifest and
ignores the rest of the documents in that file. This commit makes
it so that it will log a warning when more than one document is
encountered in a single manifest file.

**Motivation for the change:**
Inspired by this annoying bug: https://gitlab.com/nvidia/kubernetes/gpu-operator/-/merge_requests/254

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive