### PR TITLE
declcfg: improve and fix model tests to eliminate possibility of false negatives

### DIFF
--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -269,9 +269,6 @@ type RelatedImage struct {
 
 func (i RelatedImage) Validate() error {
 	result := newValidationError("invalid related image")
-	if i.Name == "" {
-		result.subErrors = append(result.subErrors, fmt.Errorf("name must be set"))
-	}
 	if i.Image == "" {
 		result.subErrors = append(result.subErrors, fmt.Errorf("image must be set"))
 	}


### PR DESCRIPTION
Signed-off-by: Joe Lanford <joe.lanford@gmail.com>

**Description of the change:**
This PR removes all positive error expectations and replaces them with a custom assertion function that looks for a specific error string. This guarantees that the expected error is actually being checked.

**Motivation for the change:**
The existing model validation tests check for simply error presence, (e.g. expect an error or not).

These test expectations worked as expected when the model was initially introduced because model validation returned the very first error that was encountered, and the test input was crafted to trip the specific error being tested in each test case.

However, the declarative config validation was later updated to return a hierarchy of errors. Since the test case input was not designed with this in mind, it meant that it may contain unrelated errors that the validation now catches. This problem became apparent in #691 because a validation was removed without removing the related test, and the related test continued passing because it expected _any_ error to occur, and it turned out that the expected error had disappeared, and it was another error in the hierarchy that kept it passing.


**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
