### PR TITLE
Add command to generate DC dockerfile

### DIFF
--- a/cmd/opm/alpha/cmd.go
+++ b/cmd/opm/alpha/cmd.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/operator-framework/operator-registry/cmd/opm/alpha/bundle"
+	"github.com/operator-framework/operator-registry/cmd/opm/alpha/generate"
 	"github.com/operator-framework/operator-registry/cmd/opm/alpha/list"
 )
 
@@ -14,6 +15,10 @@ func NewCmd() *cobra.Command {
 		Short:  "Run an alpha subcommand",
 	}
 
-	runCmd.AddCommand(bundle.NewCmd(), list.NewCmd())
+	runCmd.AddCommand(
+		bundle.NewCmd(),
+		generate.NewCmd(),
+		list.NewCmd(),
+	)
 	return runCmd
 }

--- a/cmd/opm/alpha/generate/cmd.go
+++ b/cmd/opm/alpha/generate/cmd.go
@@ -54,7 +54,7 @@ Dockerfile with the same name already exists, this command will fail.`,
 			if s, err := os.Stat(fromDir); err != nil {
 				return err
 			} else if !s.IsDir() {
-				return fmt.Errorf("provided root path %q is not a directory")
+				return fmt.Errorf("provided root path %q is not a directory", fromDir)
 			}
 
 			f, err := os.OpenFile(dockerfilePath, os.O_CREATE|os.O_WRONLY, 0666)

--- a/cmd/opm/alpha/generate/cmd.go
+++ b/cmd/opm/alpha/generate/cmd.go
@@ -15,7 +15,10 @@ import (
 )
 
 func NewCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "generate"}
+	cmd := &cobra.Command{
+		Use:   "generate",
+		Short: "Generate various artifacts for declarative config indexes",
+	}
 	cmd.AddCommand(
 		newDockerfileCmd(),
 	)

--- a/cmd/opm/alpha/generate/cmd.go
+++ b/cmd/opm/alpha/generate/cmd.go
@@ -1,0 +1,104 @@
+package generate
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/operator-framework/operator-registry/internal/action"
+	"github.com/operator-framework/operator-registry/pkg/containertools"
+)
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "generate"}
+	cmd.AddCommand(
+		newDockerfileCmd(),
+	)
+	return cmd
+}
+
+func newDockerfileCmd() *cobra.Command {
+	var (
+		baseImage      string
+		extraLabelStrs []string
+	)
+	cmd := &cobra.Command{
+		Use:   "dockerfile <dcRootDir>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Generate a Dockerfile for a declarative config index",
+		Long: `Generate a Dockerfile for a declarative config index.
+
+This command creates a Dockerfile in the same directory as the <dcRootDir>
+(named <dcDirName>.Dockerfile) that can be used to build the index. If a
+Dockerfile with the same name already exists, this command will fail.`,
+		RunE: func(_ *cobra.Command, args []string) error {
+			fromDir := args[0]
+
+			extraLabels, err := parseLabels(extraLabelStrs)
+			if err != nil {
+				return err
+			}
+
+			dir, indexName := filepath.Split(fromDir)
+			dockerfilePath := filepath.Join(dir, fmt.Sprintf("%s.Dockerfile", indexName))
+
+			if err := ensureNotExist(dockerfilePath); err != nil {
+				logrus.Fatal(err)
+			}
+
+			if s, err := os.Stat(fromDir); err != nil {
+				return err
+			} else if !s.IsDir() {
+				return fmt.Errorf("provided root path %q is not a directory")
+			}
+
+			f, err := os.OpenFile(dockerfilePath, os.O_CREATE|os.O_WRONLY, 0666)
+			if err != nil {
+				logrus.Fatal(err)
+			}
+			defer f.Close()
+
+			gen := action.GenerateDockerfile{
+				BaseImage:   baseImage,
+				FromDir:     indexName,
+				ExtraLabels: extraLabels,
+				Writer:      f,
+			}
+			if err := gen.Run(); err != nil {
+				log.Fatal(err)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&baseImage, "binary-image", "i", containertools.DefaultBinarySourceImage, "Image in which to build catalog.")
+	cmd.Flags().StringSliceVarP(&extraLabelStrs, "extra-labels", "l", []string{}, "Extra labels to include in the generated Dockerfile. Labels should be of the form 'key=value'.")
+	return cmd
+}
+
+func parseLabels(labelStrs []string) (map[string]string, error) {
+	labels := map[string]string{}
+	for _, l := range labelStrs {
+		spl := strings.SplitN(l, "=", 2)
+		if len(spl) != 2 {
+			return nil, fmt.Errorf("invalid label %q", l)
+		}
+		labels[spl[0]] = spl[1]
+	}
+	return labels, nil
+}
+
+func ensureNotExist(path string) error {
+	_, err := os.Stat(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err == nil {
+		return fmt.Errorf("path %q: %w", path, os.ErrExist)
+	}
+	return nil
+}

--- a/cmd/opm/alpha/generate/cmd.go
+++ b/cmd/opm/alpha/generate/cmd.go
@@ -35,7 +35,11 @@ func newDockerfileCmd() *cobra.Command {
 
 This command creates a Dockerfile in the same directory as the <dcRootDir>
 (named <dcDirName>.Dockerfile) that can be used to build the index. If a
-Dockerfile with the same name already exists, this command will fail.`,
+Dockerfile with the same name already exists, this command will fail.
+
+When specifying extra labels, note that if duplicate keys exist, only the last
+value of each duplicate key will be added to the generated Dockerfile.
+`,
 		RunE: func(_ *cobra.Command, args []string) error {
 			fromDir := args[0]
 
@@ -65,7 +69,7 @@ Dockerfile with the same name already exists, this command will fail.`,
 
 			gen := action.GenerateDockerfile{
 				BaseImage:   baseImage,
-				FromDir:     indexName,
+				IndexDir:    indexName,
 				ExtraLabels: extraLabels,
 				Writer:      f,
 			}

--- a/internal/action/generate_dockerfile.go
+++ b/internal/action/generate_dockerfile.go
@@ -1,0 +1,63 @@
+package action
+
+import (
+	"fmt"
+	"io"
+	"text/template"
+
+	"github.com/operator-framework/operator-registry/pkg/containertools"
+)
+
+type GenerateDockerfile struct {
+	BaseImage   string
+	FromDir     string
+	ExtraLabels map[string]string
+	Writer      io.Writer
+}
+
+func (i GenerateDockerfile) Run() error {
+	if err := i.validate(); err != nil {
+		return err
+	}
+
+	t, err := template.New("dockerfile").Parse(dockerfileTmpl)
+	if err != nil {
+		// The template is hardcoded in the binary, so if
+		// there is a parse error, it was a programmer error.
+		panic(err)
+	}
+	return t.Execute(i.Writer, i)
+}
+
+func (i GenerateDockerfile) validate() error {
+	if i.BaseImage == "" {
+		return fmt.Errorf("base image is unset")
+	}
+	if i.FromDir == "" {
+		return fmt.Errorf("index path is unset")
+	}
+	return nil
+}
+
+const dockerfileTmpl = `# The base image is expected to contain
+# /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
+FROM {{.BaseImage}}
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs"]
+
+# Copy declarative config root into image at /configs
+ADD {{.FromDir}} /configs
+
+# Set DC-specific label for the location of the DC root directory
+# in the image
+LABEL ` + containertools.ConfigsLocationLabel + `=/configs
+{{- if .ExtraLabels }}
+
+# Set other custom labels
+{{- range $key, $value := .ExtraLabels }}
+LABEL "{{ $key }}"="{{ $value }}"
+{{- end }}
+{{- end }}
+`

--- a/internal/action/generate_dockerfile.go
+++ b/internal/action/generate_dockerfile.go
@@ -10,7 +10,7 @@ import (
 
 type GenerateDockerfile struct {
 	BaseImage   string
-	FromDir     string
+	IndexDir    string
 	ExtraLabels map[string]string
 	Writer      io.Writer
 }
@@ -33,8 +33,8 @@ func (i GenerateDockerfile) validate() error {
 	if i.BaseImage == "" {
 		return fmt.Errorf("base image is unset")
 	}
-	if i.FromDir == "" {
-		return fmt.Errorf("index path is unset")
+	if i.IndexDir == "" {
+		return fmt.Errorf("index directory is unset")
 	}
 	return nil
 }
@@ -48,7 +48,7 @@ ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs"]
 
 # Copy declarative config root into image at /configs
-ADD {{.FromDir}} /configs
+ADD {{.IndexDir}} /configs
 
 # Set DC-specific label for the location of the DC root directory
 # in the image

--- a/internal/action/generate_dockerfile_test.go
+++ b/internal/action/generate_dockerfile_test.go
@@ -1,0 +1,108 @@
+package action
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateDockerfile(t *testing.T) {
+	type spec struct {
+		name               string
+		gen                GenerateDockerfile
+		expectedDockerfile string
+		expectedErr        string
+	}
+
+	specs := []spec{
+		{
+			name: "Fail/EmptyBaseImage",
+			gen: GenerateDockerfile{
+				IndexDir: "bar",
+				ExtraLabels: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			expectedErr: "base image is unset",
+		},
+		{
+			name: "Fail/EmptyFromDir",
+			gen: GenerateDockerfile{
+				BaseImage: "foo",
+				ExtraLabels: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			expectedErr: "index directory is unset",
+		},
+		{
+			name: "Success/WithoutExtraLabels",
+			gen: GenerateDockerfile{
+				BaseImage: "foo",
+				IndexDir:  "bar",
+			},
+			expectedDockerfile: `# The base image is expected to contain
+# /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
+FROM foo
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs"]
+
+# Copy declarative config root into image at /configs
+ADD bar /configs
+
+# Set DC-specific label for the location of the DC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs
+`,
+		},
+		{
+			name: "Success/WithExtraLabels",
+			gen: GenerateDockerfile{
+				BaseImage: "foo",
+				IndexDir:  "bar",
+				ExtraLabels: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			expectedDockerfile: `# The base image is expected to contain
+# /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
+FROM foo
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs"]
+
+# Copy declarative config root into image at /configs
+ADD bar /configs
+
+# Set DC-specific label for the location of the DC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs
+
+# Set other custom labels
+LABEL "key1"="value1"
+LABEL "key2"="value2"
+`,
+		},
+	}
+
+	for _, s := range specs {
+		t.Run(s.name, func(t *testing.T) {
+			buf := bytes.Buffer{}
+			s.gen.Writer = &buf
+			err := s.gen.Run()
+			if s.expectedErr != "" {
+				require.EqualError(t, err, s.expectedErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, s.expectedDockerfile, buf.String())
+			}
+		})
+	}
+}

--- a/internal/action/render.go
+++ b/internal/action/render.go
@@ -153,8 +153,7 @@ func (r Render) imageToDeclcfg(ctx context.Context, imageRef string) (*declcfg.D
 		if err != nil {
 			return nil, err
 		}
-	} else if configsDir, ok := labels["operators.operatorframework.io.index.configs.v1"]; ok {
-		// TODO(joelanford): Make a constant for above configs location label
+	} else if configsDir, ok := labels[containertools.ConfigsLocationLabel]; ok {
 		if !r.AllowedRefMask.Allowed(RefDCImage) {
 			return nil, fmt.Errorf("cannot render DC image: %w", &ErrNotAllowed{})
 		}

--- a/pkg/containertools/dockerfilegenerator.go
+++ b/pkg/containertools/dockerfilegenerator.go
@@ -8,9 +8,10 @@ import (
 )
 
 const (
-	defaultBinarySourceImage = "quay.io/operator-framework/upstream-opm-builder"
+	DefaultBinarySourceImage = "quay.io/operator-framework/upstream-opm-builder"
 	DefaultDbLocation        = "/database/index.db"
 	DbLocationLabel          = "operators.operatorframework.io.index.database.v1"
+	ConfigsLocationLabel     = "operators.operatorframework.io.index.configs.v1"
 )
 
 // DockerfileGenerator defines functions to generate index dockerfiles
@@ -36,7 +37,7 @@ func (g *IndexDockerfileGenerator) GenerateIndexDockerfile(binarySourceImage, da
 	var dockerfile string
 
 	if binarySourceImage == "" {
-		binarySourceImage = defaultBinarySourceImage
+		binarySourceImage = DefaultBinarySourceImage
 	}
 
 	g.Logger.Info("Generating dockerfile")


### PR DESCRIPTION
**Description of the change:**
Add subcommand `opm alpha generate dockerfile` to generate a dockerfile for declarative config indexes.


**Motivation for the change:**
Make it easier for users to onboard onto declarative config

**Example**
```sh
mkdir index
opm render quay.io/openshift-community-operators/catalog:latest -o yaml > index/index.yaml
opm alpha generate dockerfile index
docker build -f index.Dockerfile -t quay.io/<myorg>/catalog:latest-dc .
docker run -it --rm -p 50051:50051 quay.io/<myorg>/catalog:latest-dc

# in another terminal
grpcurl -plaintext localhost:50051 api.Registry/ListBundles | head -10
```

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
