### PR TITLE
bug(declcfg): load and render both sort properties and bundle objects

### DIFF
--- a/internal/action/render.go
+++ b/internal/action/render.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/h2non/filetype"
@@ -343,7 +344,11 @@ func combineConfigs(cfgs []declcfg.DeclarativeConfig) *declcfg.DeclarativeConfig
 	out := &declcfg.DeclarativeConfig{}
 	for _, in := range cfgs {
 		out.Packages = append(out.Packages, in.Packages...)
-		out.Bundles = append(out.Bundles, in.Bundles...)
+		for _, b := range in.Bundles {
+			sort.Sort(property.PropertyList(b.Properties))
+			sort.Strings(b.Objects)
+			out.Bundles = append(out.Bundles, b)
+		}
 		out.Others = append(out.Others, in.Others...)
 	}
 	return out

--- a/internal/action/render_test.go
+++ b/internal/action/render_test.go
@@ -82,6 +82,8 @@ func TestRender(t *testing.T) {
 						Package: "foo",
 						Image:   "test.registry/foo-operator/foo-bundle:v0.1.0",
 						Properties: []property.Property{
+							property.MustBuildBundleObjectData(foov1crd),
+							property.MustBuildBundleObjectData(foov1csv),
 							property.MustBuildChannel("beta", ""),
 							property.MustBuildChannel("stable", ""),
 							property.MustBuildGVK("test.foo", "v1", "Foo"),
@@ -89,8 +91,6 @@ func TestRender(t *testing.T) {
 							property.MustBuildPackage("foo", "0.1.0"),
 							property.MustBuildPackageRequired("bar", "v0.1.0"),
 							property.MustBuildSkipRange("<0.1.0"),
-							property.MustBuildBundleObjectData(foov1csv),
-							property.MustBuildBundleObjectData(foov1crd),
 						},
 						RelatedImages: []declcfg.RelatedImage{
 							{
@@ -102,7 +102,7 @@ func TestRender(t *testing.T) {
 							},
 						},
 						CsvJSON: string(foov1csv),
-						Objects: []string{string(foov1csv), string(foov1crd)},
+						Objects: []string{string(foov1crd), string(foov1csv)},
 					},
 					{
 						Schema:  "olm.bundle",
@@ -110,6 +110,8 @@ func TestRender(t *testing.T) {
 						Package: "foo",
 						Image:   "test.registry/foo-operator/foo-bundle:v0.2.0",
 						Properties: []property.Property{
+							property.MustBuildBundleObjectData(foov2crd),
+							property.MustBuildBundleObjectData(foov2csv),
 							property.MustBuildChannel("beta", "foo.v0.1.0"),
 							property.MustBuildChannel("stable", "foo.v0.1.0"),
 							property.MustBuildGVK("test.foo", "v1", "Foo"),
@@ -119,8 +121,6 @@ func TestRender(t *testing.T) {
 							property.MustBuildSkipRange("<0.2.0"),
 							property.MustBuildSkips("foo.v0.1.1"),
 							property.MustBuildSkips("foo.v0.1.2"),
-							property.MustBuildBundleObjectData(foov2csv),
-							property.MustBuildBundleObjectData(foov2crd),
 						},
 						RelatedImages: []declcfg.RelatedImage{
 							{
@@ -132,7 +132,7 @@ func TestRender(t *testing.T) {
 							},
 						},
 						CsvJSON: string(foov2csv),
-						Objects: []string{string(foov2csv), string(foov2crd)},
+						Objects: []string{string(foov2crd), string(foov2csv)},
 					},
 				},
 			},
@@ -159,6 +159,8 @@ func TestRender(t *testing.T) {
 						Package: "foo",
 						Image:   "test.registry/foo-operator/foo-bundle:v0.1.0",
 						Properties: []property.Property{
+							property.MustBuildBundleObjectData(foov1crd),
+							property.MustBuildBundleObjectData(foov1csv),
 							property.MustBuildChannel("beta", ""),
 							property.MustBuildChannel("stable", ""),
 							property.MustBuildGVK("test.foo", "v1", "Foo"),
@@ -166,8 +168,6 @@ func TestRender(t *testing.T) {
 							property.MustBuildPackage("foo", "0.1.0"),
 							property.MustBuildPackageRequired("bar", "v0.1.0"),
 							property.MustBuildSkipRange("<0.1.0"),
-							property.MustBuildBundleObjectData(foov1csv),
-							property.MustBuildBundleObjectData(foov1crd),
 						},
 						RelatedImages: []declcfg.RelatedImage{
 							{
@@ -179,7 +179,7 @@ func TestRender(t *testing.T) {
 							},
 						},
 						CsvJSON: string(foov1csv),
-						Objects: []string{string(foov1csv), string(foov1crd)},
+						Objects: []string{string(foov1crd), string(foov1csv)},
 					},
 					{
 						Schema:  "olm.bundle",
@@ -187,6 +187,8 @@ func TestRender(t *testing.T) {
 						Package: "foo",
 						Image:   "test.registry/foo-operator/foo-bundle:v0.2.0",
 						Properties: []property.Property{
+							property.MustBuildBundleObjectData(foov2crd),
+							property.MustBuildBundleObjectData(foov2csv),
 							property.MustBuildChannel("beta", "foo.v0.1.0"),
 							property.MustBuildChannel("stable", "foo.v0.1.0"),
 							property.MustBuildGVK("test.foo", "v1", "Foo"),
@@ -196,8 +198,6 @@ func TestRender(t *testing.T) {
 							property.MustBuildSkipRange("<0.2.0"),
 							property.MustBuildSkips("foo.v0.1.1"),
 							property.MustBuildSkips("foo.v0.1.2"),
-							property.MustBuildBundleObjectData(foov2csv),
-							property.MustBuildBundleObjectData(foov2crd),
 						},
 						RelatedImages: []declcfg.RelatedImage{
 							{
@@ -209,7 +209,7 @@ func TestRender(t *testing.T) {
 							},
 						},
 						CsvJSON: string(foov2csv),
-						Objects: []string{string(foov2csv), string(foov2crd)},
+						Objects: []string{string(foov2crd), string(foov2csv)},
 					},
 				},
 			},
@@ -236,14 +236,14 @@ func TestRender(t *testing.T) {
 						Package: "foo",
 						Image:   "test.registry/foo-operator/foo-bundle:v0.1.0",
 						Properties: []property.Property{
+							property.MustBuildBundleObjectData(foov1crd),
+							property.MustBuildBundleObjectData(foov1csv),
 							property.MustBuildChannel("beta", ""),
 							property.MustBuildGVK("test.foo", "v1", "Foo"),
 							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
 							property.MustBuildPackage("foo", "0.1.0"),
 							property.MustBuildPackageRequired("bar", "v0.1.0"),
 							property.MustBuildSkipRange("<0.1.0"),
-							property.MustBuildBundleObjectData(foov1csv),
-							property.MustBuildBundleObjectData(foov1crd),
 						},
 						RelatedImages: []declcfg.RelatedImage{
 							{
@@ -255,7 +255,7 @@ func TestRender(t *testing.T) {
 							},
 						},
 						CsvJSON: string(foov1csv),
-						Objects: []string{string(foov1csv), string(foov1crd)},
+						Objects: []string{string(foov1crd), string(foov1csv)},
 					},
 					{
 						Schema:  "olm.bundle",
@@ -263,6 +263,8 @@ func TestRender(t *testing.T) {
 						Package: "foo",
 						Image:   "test.registry/foo-operator/foo-bundle:v0.2.0",
 						Properties: []property.Property{
+							property.MustBuildBundleObjectData(foov2crd),
+							property.MustBuildBundleObjectData(foov2csv),
 							property.MustBuildChannel("beta", "foo.v0.1.0"),
 							property.MustBuildChannel("stable", "foo.v0.1.0"),
 							property.MustBuildGVK("test.foo", "v1", "Foo"),
@@ -272,8 +274,6 @@ func TestRender(t *testing.T) {
 							property.MustBuildSkipRange("<0.2.0"),
 							property.MustBuildSkips("foo.v0.1.1"),
 							property.MustBuildSkips("foo.v0.1.2"),
-							property.MustBuildBundleObjectData(foov2csv),
-							property.MustBuildBundleObjectData(foov2crd),
 						},
 						RelatedImages: []declcfg.RelatedImage{
 							{
@@ -285,7 +285,7 @@ func TestRender(t *testing.T) {
 							},
 						},
 						CsvJSON: string(foov2csv),
-						Objects: []string{string(foov2csv), string(foov2crd)},
+						Objects: []string{string(foov2crd), string(foov2csv)},
 					},
 				},
 			},
@@ -312,14 +312,14 @@ func TestRender(t *testing.T) {
 						Package: "foo",
 						Image:   "test.registry/foo-operator/foo-bundle:v0.1.0",
 						Properties: []property.Property{
+							property.MustBuildBundleObjectData(foov1crd),
+							property.MustBuildBundleObjectData(foov1csv),
 							property.MustBuildChannel("beta", ""),
 							property.MustBuildGVK("test.foo", "v1", "Foo"),
 							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
 							property.MustBuildPackage("foo", "0.1.0"),
 							property.MustBuildPackageRequired("bar", "v0.1.0"),
 							property.MustBuildSkipRange("<0.1.0"),
-							property.MustBuildBundleObjectData(foov1csv),
-							property.MustBuildBundleObjectData(foov1crd),
 						},
 						RelatedImages: []declcfg.RelatedImage{
 							{
@@ -331,7 +331,7 @@ func TestRender(t *testing.T) {
 							},
 						},
 						CsvJSON: string(foov1csv),
-						Objects: []string{string(foov1csv), string(foov1crd)},
+						Objects: []string{string(foov1crd), string(foov1csv)},
 					},
 					{
 						Schema:  "olm.bundle",
@@ -339,6 +339,8 @@ func TestRender(t *testing.T) {
 						Package: "foo",
 						Image:   "test.registry/foo-operator/foo-bundle:v0.2.0",
 						Properties: []property.Property{
+							property.MustBuildBundleObjectData(foov2crd),
+							property.MustBuildBundleObjectData(foov2csv),
 							property.MustBuildChannel("beta", "foo.v0.1.0"),
 							property.MustBuildChannel("stable", "foo.v0.1.0"),
 							property.MustBuildGVK("test.foo", "v1", "Foo"),
@@ -348,8 +350,6 @@ func TestRender(t *testing.T) {
 							property.MustBuildSkipRange("<0.2.0"),
 							property.MustBuildSkips("foo.v0.1.1"),
 							property.MustBuildSkips("foo.v0.1.2"),
-							property.MustBuildBundleObjectData(foov2csv),
-							property.MustBuildBundleObjectData(foov2crd),
 						},
 						RelatedImages: []declcfg.RelatedImage{
 							{
@@ -361,7 +361,7 @@ func TestRender(t *testing.T) {
 							},
 						},
 						CsvJSON: string(foov2csv),
-						Objects: []string{string(foov2csv), string(foov2crd)},
+						Objects: []string{string(foov2crd), string(foov2csv)},
 					},
 				},
 			},

--- a/internal/declcfg/load.go
+++ b/internal/declcfg/load.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/fs"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/joelanford/ignore"
@@ -116,6 +117,7 @@ func readYAMLOrJSON(r io.Reader) (*DeclarativeConfig, error) {
 			if err := json.Unmarshal(doc, &b); err != nil {
 				return nil, fmt.Errorf("parse bundle: %v", err)
 			}
+			sort.Sort(property.PropertyList(b.Properties))
 			cfg.Bundles = append(cfg.Bundles, b)
 		case "":
 			return nil, fmt.Errorf("object '%s' is missing root schema field", string(doc))

--- a/internal/declcfg/model_to_declcfg.go
+++ b/internal/declcfg/model_to_declcfg.go
@@ -69,12 +69,8 @@ func traverseModelChannels(mpkg model.Package) []Bundle {
 	for _, b := range bundles {
 		b.Properties = property.Deduplicate(b.Properties)
 
-		sort.Slice(b.Properties, func(i, j int) bool {
-			if b.Properties[i].Type != b.Properties[j].Type {
-				return b.Properties[i].Type < b.Properties[j].Type
-			}
-			return string(b.Properties[i].Value) < string(b.Properties[j].Value)
-		})
+		sort.Sort(property.PropertyList(b.Properties))
+		sort.Strings(b.Objects)
 
 		out = append(out, *b)
 	}

--- a/internal/property/property.go
+++ b/internal/property/property.go
@@ -9,11 +9,26 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
+	"sort"
 )
 
 type Property struct {
 	Type  string          `json:"type"`
 	Value json.RawMessage `json:"value"`
+}
+
+var _ sort.Interface = PropertyList{}
+
+// PropertyList is a sortable list of Property.
+type PropertyList []Property
+
+func (l PropertyList) Len() int      { return len(l) }
+func (l PropertyList) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
+func (l PropertyList) Less(i, j int) bool {
+	if l[i].Type != l[j].Type {
+		return l[i].Type < l[j].Type
+	}
+	return string(l[i].Value) < string(l[j].Value)
 }
 
 func (p Property) Validate() error {


### PR DESCRIPTION
**Description of the change:** sort both properties and bundle objects.

**Motivation for the change:** I noticed that property and bundle object order can get out of sync depending on when objects are loaded from properties and whether a config was loaded or converted. This follows up on #706.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

/cc @joelanford 
