### PR TITLE
feat(opm diff): include packages, channels, and versions in diff output

### DIFF
--- a/alpha/declcfg/diff_include.go
+++ b/alpha/declcfg/diff_include.go
@@ -1,14 +1,193 @@
 package declcfg
 
 import (
+	"fmt"
+
+	"github.com/blang/semver"
+	"github.com/sirupsen/logrus"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
 	"github.com/operator-framework/operator-registry/alpha/model"
 )
+
+// DiffIncluder knows how to add packages, channels, and bundles
+// from a source to a destination model.Model.
+type DiffIncluder struct {
+	// Packages to add.
+	Packages []DiffIncludePackage
+	Logger   *logrus.Entry
+}
+
+// DiffIncludePackage specifies a package, and optionally channels
+// or a set of bundles from all channels (wrapped by a DiffIncludeChannel),
+// to include.
+type DiffIncludePackage struct {
+	// Name of package.
+	Name string
+	// Channels in package.
+	Channels []DiffIncludeChannel
+	// AllChannels contains bundle versions in package.
+	// Upgrade graphs from all channels in the named package containing a version
+	// from this field are included.
+	AllChannels DiffIncludeChannel
+}
+
+// DiffIncludeChannel specifies a channel, and optionally bundle versions to include.
+type DiffIncludeChannel struct {
+	// Name of channel.
+	Name string
+	// Versions of bundles.
+	Versions []semver.Version
+}
+
+// Run adds all packages and channels in DiffIncluder with matching names
+// directly, and all versions plus their upgrade graphs to channel heads,
+// from newModel to outputModel.
+func (i DiffIncluder) Run(newModel, outputModel model.Model) error {
+	var includeErrs []error
+	for _, ipkg := range i.Packages {
+		pkgLog := i.Logger.WithField("package", ipkg.Name)
+		includeErrs = append(includeErrs, ipkg.includeNewInOutputModel(newModel, outputModel, pkgLog)...)
+	}
+	if len(includeErrs) != 0 {
+		return fmt.Errorf("error including items:\n%v", utilerrors.NewAggregate(includeErrs))
+	}
+	return nil
+}
+
+// includeNewInOutputModel adds all packages, channels, and versions (bundles)
+// specified by ipkg that exist in newModel to outputModel. Any package, channel,
+// or version in ipkg not satisfied by newModel is an error.
+func (ipkg DiffIncludePackage) includeNewInOutputModel(newModel, outputModel model.Model, logger *logrus.Entry) (ierrs []error) {
+
+	newPkg, newHasPkg := newModel[ipkg.Name]
+	if !newHasPkg {
+		ierrs = append(ierrs, fmt.Errorf("[package=%q] package does not exist in new model", ipkg.Name))
+		return ierrs
+	}
+	pkgLog := logger.WithField("package", newPkg.Name)
+
+	// No channels or versions were specified, meaning "include the full package".
+	if len(ipkg.Channels) == 0 && len(ipkg.AllChannels.Versions) == 0 {
+		outputModel[ipkg.Name] = newPkg
+		return nil
+	}
+
+	outputPkg := copyPackageNoChannels(newPkg)
+	outputModel[outputPkg.Name] = outputPkg
+
+	// Add all channels to ipkg.Channels if versions were specified to include across all channels.
+	// skipMissingVerForChannels's value for a channel will be true IFF at least one version is specified,
+	// since some other channel may contain that version.
+	skipMissingVerForChannels := map[string]bool{}
+	if len(ipkg.AllChannels.Versions) != 0 {
+		for newChName := range newPkg.Channels {
+			ipkg.Channels = append(ipkg.Channels, DiffIncludeChannel{
+				Name:     newChName,
+				Versions: ipkg.AllChannels.Versions,
+			})
+			skipMissingVerForChannels[newChName] = true
+		}
+	}
+
+	for _, ich := range ipkg.Channels {
+		newCh, pkgHasCh := newPkg.Channels[ich.Name]
+		if !pkgHasCh {
+			ierrs = append(ierrs, fmt.Errorf("[package=%q channel=%q] channel does not exist in new model", newPkg.Name, ich.Name))
+			continue
+		}
+		chLog := pkgLog.WithField("channel", newCh.Name)
+
+		bundles, err := getBundlesForVersions(newCh, ich.Versions, chLog, skipMissingVerForChannels[newCh.Name])
+		if err != nil {
+			ierrs = append(ierrs, fmt.Errorf("[package=%q channel=%q] %v", newPkg.Name, newCh.Name, err))
+			continue
+		}
+		outputCh := copyChannelNoBundles(newCh, outputPkg)
+		outputPkg.Channels[outputCh.Name] = outputCh
+		for _, b := range bundles {
+			tb := copyBundle(b, outputCh, outputPkg)
+			outputCh.Bundles[tb.Name] = tb
+		}
+	}
+
+	return ierrs
+}
+
+// getBundlesForVersions returns all bundles matching a version in vers
+// and their upgrade graph(s) to ch.Head().
+// If skipMissingVersions is true, versions not satisfied by bundles in ch
+// will not result in errors.
+func getBundlesForVersions(ch *model.Channel, vers []semver.Version, logger *logrus.Entry, skipMissingVersions bool) (bundles []*model.Bundle, err error) {
+
+	// Short circuit when no versions were specified, meaning "include the whole channel".
+	if len(vers) == 0 {
+		for _, b := range ch.Bundles {
+			bundles = append(bundles, b)
+		}
+		return bundles, nil
+	}
+
+	// Add every bundle directly satisfying a version to bundles.
+	versionsToInclude := make(map[string]struct{}, len(vers))
+	for _, ver := range vers {
+		versionsToInclude[ver.String()] = struct{}{}
+	}
+	for _, b := range ch.Bundles {
+		if _, includeBundle := versionsToInclude[b.Version.String()]; includeBundle {
+			bundles = append(bundles, b)
+		}
+	}
+
+	// Some version was not satisfied by this channel.
+	if len(bundles) != len(versionsToInclude) && !skipMissingVersions {
+		for _, b := range bundles {
+			delete(versionsToInclude, b.Version.String())
+		}
+		verStrs := []string{}
+		for verStr := range versionsToInclude {
+			verStrs = append(verStrs, verStr)
+		}
+		return nil, fmt.Errorf("versions do not exist in channel: %+q", verStrs)
+	}
+
+	// Fill in the upgrade graph between each bundle and head.
+	// Regardless of semver order, this step needs to be performed
+	// for each included bundle because there might be leaf nodes
+	// in the upgrade graph for a particular version not captured
+	// by any other fill due to skips not being honored here.
+	head, err := ch.Head()
+	if err != nil {
+		return nil, err
+	}
+	graph := makeUpgradeGraph(ch)
+	bundleSet := map[string]*model.Bundle{}
+	for _, ib := range bundles {
+		if _, addedBundle := bundleSet[ib.Name]; addedBundle {
+			// A prior graph traverse already included this bundle.
+			continue
+		}
+		intersectingBundles, intersectionFound := findIntersectingBundles(ch, ib, head, graph)
+		if !intersectionFound {
+			logger.Debugf("channel head %q not reachable from bundle %q, adding without upgrade graph", head.Name, ib.Name)
+			bundleSet[ib.Name] = ib
+		}
+
+		for _, rb := range intersectingBundles {
+			bundleSet[rb.Name] = rb
+		}
+	}
+	for _, b := range bundleSet {
+		bundles = append(bundles, b)
+	}
+
+	return bundles, nil
+}
 
 // makeUpgradeGraph creates a DAG of bundles with map key Bundle.Replaces.
 func makeUpgradeGraph(ch *model.Channel) map[string][]*model.Bundle {
 	graph := map[string][]*model.Bundle{}
 	for _, b := range ch.Bundles {
-		b := b
 		if b.Replaces != "" {
 			graph[b.Replaces] = append(graph[b.Replaces], b)
 		}


### PR DESCRIPTION
**Description of the change:** use `--include-file,-i` to include a set of packages, channels, and/or versions in `opm alpha diff` output.

**Motivation for the change:** you may want to explicitly include an upgrade graph (especially in heads-only mode) in your diff, ex. when you have a specific version requirement.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

TODO:
- [ ] tests
- [ ] code comments

/kind feature
