### PR TITLE
Aggregate properties/dependencies in-query for ListBundles.

### DIFF
--- a/pkg/sqlite/query_sql_test.go
+++ b/pkg/sqlite/query_sql_test.go
@@ -42,7 +42,7 @@ func TestListBundlesQuery(t *testing.T) {
 						c            interface{}
 						name, actual sql.NullString
 					)
-					if err := rows.Scan(&c, &c, &c, &name, &c, &c, &actual, &c, &c, &c, &c, &c, &c, &c); err != nil {
+					if err := rows.Scan(&c, &c, &c, &name, &c, &c, &actual, &c, &c, &c, &c, &c); err != nil {
 						t.Fatalf("unexpected error during row scan: %v", err)
 					}
 					expected, ok := replacements[name]
@@ -107,7 +107,7 @@ func TestListBundlesQuery(t *testing.T) {
 						c      interface{}
 						actual result
 					)
-					if err := rows.Scan(&c, &c, &c, &actual.Name, &c, &c, &actual.Replaces, &actual.Skips, &c, &c, &c, &c, &c, &c); err != nil {
+					if err := rows.Scan(&c, &c, &c, &actual.Name, &c, &c, &actual.Replaces, &actual.Skips, &c, &c, &c, &c); err != nil {
 						t.Fatalf("unexpected error during row scan: %v", err)
 					}
 					r, ok := expected[actual.Name]

--- a/pkg/sqlite/query_test.go
+++ b/pkg/sqlite/query_test.go
@@ -15,20 +15,18 @@ import (
 
 func TestListBundles(t *testing.T) {
 	type Columns struct {
-		EntryID         sql.NullInt64
-		Bundle          sql.NullString
-		BundlePath      sql.NullString
-		BundleName      sql.NullString
-		PackageName     sql.NullString
-		ChannelName     sql.NullString
-		Replaces        sql.NullString
-		Skips           sql.NullString
-		Version         sql.NullString
-		SkipRange       sql.NullString
-		DependencyType  sql.NullString
-		DependencyValue sql.NullString
-		PropertyType    sql.NullString
-		PropertyValue   sql.NullString
+		EntryID      sql.NullInt64
+		Bundle       sql.NullString
+		BundlePath   sql.NullString
+		BundleName   sql.NullString
+		PackageName  sql.NullString
+		ChannelName  sql.NullString
+		Replaces     sql.NullString
+		Skips        sql.NullString
+		Version      sql.NullString
+		SkipRange    sql.NullString
+		Dependencies sql.NullString
+		Properties   sql.NullString
 	}
 
 	var NoRows sqlitefakes.FakeRowScanner
@@ -195,27 +193,14 @@ func TestListBundles(t *testing.T) {
 				q.QueryContextReturns(&NoRows, nil)
 				q.QueryContextReturnsOnCall(0, &r, nil)
 				r.NextReturnsOnCall(0, true)
-				r.NextReturnsOnCall(1, true)
 				cols := []Columns{
 					{
-						BundleName:      sql.NullString{Valid: true, String: "BundleName"},
-						Version:         sql.NullString{Valid: true, String: "Version"},
-						ChannelName:     sql.NullString{Valid: true, String: "ChannelName"},
-						BundlePath:      sql.NullString{Valid: true, String: "BundlePath"},
-						DependencyType:  sql.NullString{Valid: true, String: "Dependency1Type"},
-						DependencyValue: sql.NullString{Valid: true, String: "Dependency1Value"},
-						PropertyType:    sql.NullString{Valid: true, String: "Property1Type"},
-						PropertyValue:   sql.NullString{Valid: true, String: "Property1Value"},
-					},
-					{
-						BundleName:      sql.NullString{Valid: true, String: "BundleName"},
-						Version:         sql.NullString{Valid: true, String: "Version"},
-						ChannelName:     sql.NullString{Valid: true, String: "ChannelName"},
-						BundlePath:      sql.NullString{Valid: true, String: "BundlePath"},
-						DependencyType:  sql.NullString{Valid: true, String: "Dependency2Type"},
-						DependencyValue: sql.NullString{Valid: true, String: "Dependency2Value"},
-						PropertyType:    sql.NullString{Valid: true, String: "Property2Type"},
-						PropertyValue:   sql.NullString{Valid: true, String: "Property2Value"},
+						BundleName:   sql.NullString{Valid: true, String: "BundleName"},
+						Version:      sql.NullString{Valid: true, String: "Version"},
+						ChannelName:  sql.NullString{Valid: true, String: "ChannelName"},
+						BundlePath:   sql.NullString{Valid: true, String: "BundlePath"},
+						Dependencies: sql.NullString{Valid: true, String: `[{"type":"Dependency1Type","value":"Dependency1Value"},{"type":"Dependency2Type","value":"Dependency2Value"}]`},
+						Properties:   sql.NullString{Valid: true, String: `[{"type":"Property1Type","value":"Property1Value"},{"type":"Property2Type","value":"Property2Value"}]`},
 					},
 				}
 				var i int


### PR DESCRIPTION
This fixes the result set to contain one row per result Bundle instead
of potentially several, which should allow for gRPC result streaming.
