### PR TITLE
cmd/opm: Fix panic in opm alpha diff when accessing the --skip-tls flag

### DIFF
--- a/cmd/opm/alpha/diff/cmd.go
+++ b/cmd/opm/alpha/diff/cmd.go
@@ -93,7 +93,7 @@ docker push registry.org/my-catalog:headsonly-def456
 func (a *diff) addFunc(cmd *cobra.Command, args []string) error {
 	a.parseArgs(args)
 
-	skipTLS, err := cmd.PersistentFlags().GetBool("skip-tls")
+	skipTLS, err := cmd.Flags().GetBool("skip-tls")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Update the cmd/opm/alpha/diff command package and access the parent
skip-tls flag using cmd.Flags() instead of cmd.PersistentFlags().

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
