### PR TITLE
Omit manifests from ListBundles result if bundle image is available.

### DIFF
--- a/cmd/opm/registry/serve.go
+++ b/cmd/opm/registry/serve.go
@@ -95,7 +95,7 @@ func serveFunc(cmd *cobra.Command, args []string) error {
 		logger.WithError(err).Warnf("couldn't migrate db")
 	}
 
-	store := sqlite.NewSQLLiteQuerierFromDb(db)
+	store := sqlite.NewSQLLiteQuerierFromDb(db, sqlite.OmitManifests(true))
 
 	// sanity check that the db is available
 	tables, err := store.ListTables(context.TODO())

--- a/cmd/registry-server/main.go
+++ b/cmd/registry-server/main.go
@@ -96,7 +96,7 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 		logger.WithError(err).Warnf("couldn't migrate db")
 	}
 
-	store := sqlite.NewSQLLiteQuerierFromDb(db)
+	store := sqlite.NewSQLLiteQuerierFromDb(db, sqlite.OmitManifests(true))
 
 	// sanity check that the db is available
 	tables, err := store.ListTables(context.TODO())

--- a/pkg/registry/query.go
+++ b/pkg/registry/query.go
@@ -56,6 +56,14 @@ func (q Querier) SendBundles(_ context.Context, s BundleSender) error {
 				if err != nil {
 					return fmt.Errorf("convert bundle %q: %v", b.Name, err)
 				}
+				if apiBundle.BundlePath != "" {
+					// The SQLite-based server
+					// configures its querier to
+					// omit these fields when
+					// bundle path is set.
+					apiBundle.CsvJson = ""
+					apiBundle.Object = nil
+				}
 				if err := s.Send(apiBundle); err != nil {
 					return err
 				}

--- a/pkg/registry/query_test.go
+++ b/pkg/registry/query_test.go
@@ -164,7 +164,11 @@ func TestQuerier_ListBundles(t *testing.T) {
 	bundles, err := testModelQuerier.ListBundles(context.TODO())
 	require.NoError(t, err)
 	require.NotNil(t, bundles)
-	require.Equal(t, 12, len(bundles))
+	require.Len(t, bundles, 12)
+	for _, b := range bundles {
+		require.Zero(t, b.CsvJson)
+		require.Zero(t, b.Object)
+	}
 }
 
 func TestQuerier_ListPackages(t *testing.T) {

--- a/pkg/sqlite/query_sql_test.go
+++ b/pkg/sqlite/query_sql_test.go
@@ -12,9 +12,10 @@ import (
 
 func TestListBundlesQuery(t *testing.T) {
 	for _, tt := range []struct {
-		Name   string
-		Setup  func(t *testing.T, db *sql.DB)
-		Expect func(t *testing.T, rows *sql.Rows)
+		Name         string
+		Setup        func(t *testing.T, db *sql.DB)
+		Expect       func(t *testing.T, rows *sql.Rows)
+		OmitManfests bool
 	}{
 		{
 			Name: "replacement comes from channel entry",
@@ -126,6 +127,62 @@ func TestListBundlesQuery(t *testing.T) {
 				}
 			},
 		},
+		{
+			Name:         "manifests omitted without bundlepath",
+			OmitManfests: true,
+			Setup: func(t *testing.T, db *sql.DB) {
+				for _, stmt := range []string{
+					`insert into package (name, default_channel) values ("package", "channel")`,
+					`insert into channel (name, package_name, head_operatorbundle_name) values ("channel", "package", "bundle")`,
+					`insert into operatorbundle (name, bundle) values ("bundle-a", "{}")`,
+					`insert into channel_entry (package_name, channel_name, operatorbundle_name, entry_id, depth) values ("package", "channel", "bundle-a", 1, 0)`,
+				} {
+					if _, err := db.Exec(stmt); err != nil {
+						t.Fatalf("unexpected error executing setup statements: %v", err)
+					}
+				}
+
+			},
+			Expect: func(t *testing.T, rows *sql.Rows) {
+				require := require.New(t)
+				require.True(rows.Next())
+				var (
+					c      interface{}
+					bundle sql.NullString
+				)
+				require.NoError(rows.Scan(&c, &bundle, &c, &c, &c, &c, &c, &c, &c, &c, &c, &c))
+				require.Equal(sql.NullString{Valid: true, String: "{}"}, bundle)
+				require.False(rows.Next())
+			},
+		},
+		{
+			Name:         "manifests not omitted with bundlepath",
+			OmitManfests: true,
+			Setup: func(t *testing.T, db *sql.DB) {
+				for _, stmt := range []string{
+					`insert into package (name, default_channel) values ("package", "channel")`,
+					`insert into channel (name, package_name, head_operatorbundle_name) values ("channel", "package", "bundle")`,
+					`insert into operatorbundle (name, bundle, bundlepath) values ("bundle-a", "{}", "path")`,
+					`insert into channel_entry (package_name, channel_name, operatorbundle_name, entry_id, depth) values ("package", "channel", "bundle-a", 1, 0)`,
+				} {
+					if _, err := db.Exec(stmt); err != nil {
+						t.Fatalf("unexpected error executing setup statements: %v", err)
+					}
+				}
+
+			},
+			Expect: func(t *testing.T, rows *sql.Rows) {
+				require := require.New(t)
+				require.True(rows.Next())
+				var (
+					c      interface{}
+					bundle sql.NullString
+				)
+				require.NoError(rows.Scan(&c, &bundle, &c, &c, &c, &c, &c, &c, &c, &c, &c, &c))
+				require.Equal(sql.NullString{Valid: false, String: ""}, bundle)
+				require.False(rows.Next())
+			},
+		},
 	} {
 		t.Run(tt.Name, func(t *testing.T) {
 			ctx := context.Background()
@@ -143,7 +200,7 @@ func TestListBundlesQuery(t *testing.T) {
 			_, err = db.Exec("PRAGMA foreign_keys = ON")
 			require.NoError(t, err)
 
-			rows, err := db.QueryContext(ctx, listBundlesQuery)
+			rows, err := db.QueryContext(ctx, listBundlesQuery, sql.Named("omit_manifests", tt.OmitManfests))
 			if err != nil {
 				t.Fatalf("unexpected error executing list bundles query: %v", err)
 			}


### PR DESCRIPTION
The "object" and "csvJson" fields of bundles returned from ListBundles
is only consumed by the catalog operator in cases where no bundle
image reference is present.
