### PR TITLE
fix(diff): heads-only mode should not attempt to parse old refs

### DIFF
--- a/cmd/opm/alpha/diff/cmd.go
+++ b/cmd/opm/alpha/diff/cmd.go
@@ -153,6 +153,8 @@ func (a *diff) parseArgs(args []string) {
 	default:
 		panic("should never be here, CLI must enforce arg size")
 	}
-	a.oldRefs = strings.Split(old, ",")
+	if old != "" {
+		a.oldRefs = strings.Split(old, ",")
+	}
 	a.newRefs = strings.Split(new, ",")
 }


### PR DESCRIPTION
Signed-off-by: Joe Lanford <joe.lanford@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Resolves an issue in `opm alpha diff` that tries to parse an empty string as an old reference when there was not old reference specified on the command line.

/cc @estroz 

**Motivation for the change:**
heads-only mode should not attempt to parse old refs

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
