### PR TITLE
Set soft_heap_limit for SQLite-based registry servers.

### DIFF
--- a/cmd/opm/registry/serve.go
+++ b/cmd/opm/registry/serve.go
@@ -90,6 +90,10 @@ func serveFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if _, err := db.ExecContext(context.TODO(), `PRAGMA soft_heap_limit=1`); err != nil {
+		logger.WithError(err).Warnf("error setting soft heap limit for sqlite")
+	}
+
 	// migrate to the latest version
 	if err := migrate(cmd, db); err != nil {
 		logger.WithError(err).Warnf("couldn't migrate db")

--- a/cmd/registry-server/main.go
+++ b/cmd/registry-server/main.go
@@ -91,6 +91,10 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if _, err := db.ExecContext(context.TODO(), `PRAGMA soft_heap_limit=1`); err != nil {
+		logger.WithError(err).Warnf("error setting soft heap limit for sqlite")
+	}
+
 	// migrate to the latest version
 	if err := migrate(cmd, db); err != nil {
 		logger.WithError(err).Warnf("couldn't migrate db")


### PR DESCRIPTION
Registry pods receive low request volumes and are not
latency-sensitive, so there's little downside to advising SQLite to
keep its page cache as small as possible.
