### PR TITLE
.github/workflows: Replace the e2e-kind job name with e2e in the test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,22 +8,25 @@ on:
       - '**'
       - '!doc/**'
 jobs:
-  e2e-kind:
+  e2e:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
           go-version: '~1.16'
-      - run: |
+      - name: Install podman
+        run: |
           . /etc/os-release
           echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
           curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
           sudo apt-get update
           sudo apt-get -y install conntrack podman
           podman version
-      - run: |
+      - name: Create kind cluster and setup local docker registry
+        run: |
           "${GITHUB_WORKSPACE}/scripts/start_registry.sh" kind-registry
           export DOCKER_REGISTRY_HOST=localhost:443
-      - run: |
+      - name: Run e2e tests
+        run: |
           KUBECONFIG="$HOME/.kube/config" DOCKER_REGISTRY_HOST=localhost:443 make build e2e CLUSTER=kind


### PR DESCRIPTION
Update the test.yml test workflow and replace the `e2e-kind` job name with
`e2e`. Before, the e2e test workflow had ran e2e tests against both kind
and minikube clusters before the latter job was removed entirely.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
