### PR TITLE
internal/action: Fix opm render outputting empty related image names

### DIFF
--- a/internal/action/render.go
+++ b/internal/action/render.go
@@ -111,17 +111,16 @@ func (r Render) renderReference(ctx context.Context, ref string) (*declcfg.Decla
 				return nil, fmt.Errorf("cannot render DC directory: %w", &ErrNotAllowed{})
 			}
 			return declcfg.LoadFS(os.DirFS(ref))
-		} else {
-			// The only supported file type is an sqlite DB file,
-			// since declarative configs will be in a directory.
-			if err := checkDBFile(ref); err != nil {
-				return nil, err
-			}
-			if !r.AllowedRefMask.Allowed(RefSqliteFile) {
-				return nil, fmt.Errorf("cannot render sqlite file: %w", &ErrNotAllowed{})
-			}
-			return sqliteToDeclcfg(ctx, ref)
 		}
+		// The only supported file type is an sqlite DB file,
+		// since declarative configs will be in a directory.
+		if err := checkDBFile(ref); err != nil {
+			return nil, err
+		}
+		if !r.AllowedRefMask.Allowed(RefSqliteFile) {
+			return nil, fmt.Errorf("cannot render sqlite file: %w", &ErrNotAllowed{})
+		}
+		return sqliteToDeclcfg(ctx, ref)
 	}
 	return r.imageToDeclcfg(ctx, ref)
 }
@@ -272,7 +271,7 @@ func populateDBRelatedImages(ctx context.Context, cfg *declcfg.DeclarativeConfig
 			}
 		}
 		for ri := range ris {
-			cfg.Bundles[i].RelatedImages = append(cfg.Bundles[i].RelatedImages, declcfg.RelatedImage{Image: ri})
+			cfg.Bundles[i].RelatedImages = append(cfg.Bundles[i].RelatedImages, declcfg.RelatedImage{Name: b.Name, Image: ri})
 		}
 	}
 	return nil


### PR DESCRIPTION
Update internal/action/render.go and ensure the RelatedImage.Name key is
being populated when converting a sqlite-based index image to a
declarative config one.

When constructing a declarative config representation from a
sqlite-based index image, we extract the related images properties from
the related_images table name. When extracting that data and building up
a list of related images for the rendered declarative config, we neglect
to populate the RelatedImage.Name field when iterating over processed
row results.

This can lead to situations where an individual bundle's relatedImages
properties have an empty "name" key, but a populated image key:

```json
    "relatedImages": [
        {
            "name": "",
            "image": "quay.io/olmqe/cockroachdb-operator:5.0.3-2199"
        },
        {
            "name": "",
            "image": "quay.io/helmoperators/cockroachdb:v5.0.3"
        },
        {
            "name": "",
            "image": "gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0"
        }
```

Reference to BZ tracking this: https://bugzilla.redhat.com/show_bug.cgi?id=1988948.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
