### PR TITLE
feat: support removing the default channel head in deprecatetruncate

### DIFF
--- a/pkg/lib/indexer/indexer.go
+++ b/pkg/lib/indexer/indexer.go
@@ -640,15 +640,16 @@ func generatePackageYaml(dbQuerier pregistry.Query, packageName, downloadPath st
 
 // DeprecateFromIndexRequest defines the parameters to send to the PruneFromIndex API
 type DeprecateFromIndexRequest struct {
-	Generate          bool
-	Permissive        bool
-	BinarySourceImage string
-	FromIndex         string
-	OutDockerfile     string
-	Bundles           []string
-	Tag               string
-	CaFile            string
-	SkipTLS           bool
+	Generate            bool
+	Permissive          bool
+	BinarySourceImage   string
+	FromIndex           string
+	OutDockerfile       string
+	Bundles             []string
+	Tag                 string
+	CaFile              string
+	SkipTLS             bool
+	AllowPackageRemoval bool
 }
 
 // DeprecateFromIndex takes a DeprecateFromIndexRequest and deprecates the requested
@@ -665,14 +666,14 @@ func (i ImageIndexer) DeprecateFromIndex(request DeprecateFromIndexRequest) erro
 		return err
 	}
 
-	// Run opm registry prune on the database
 	deprecateFromRegistryReq := registry.DeprecateFromRegistryRequest{
-		Bundles:       request.Bundles,
-		InputDatabase: databasePath,
-		Permissive:    request.Permissive,
+		Bundles:             request.Bundles,
+		InputDatabase:       databasePath,
+		Permissive:          request.Permissive,
+		AllowPackageRemoval: request.AllowPackageRemoval,
 	}
 
-	// Prune the bundles from the registry
+	// Deprecate the bundles from the registry
 	err = i.RegistryDeprecator.DeprecateFromRegistry(deprecateFromRegistryReq)
 	if err != nil {
 		return err

--- a/pkg/lib/registry/registry.go
+++ b/pkg/lib/registry/registry.go
@@ -322,9 +322,10 @@ func (r RegistryUpdater) PruneFromRegistry(request PruneFromRegistryRequest) err
 }
 
 type DeprecateFromRegistryRequest struct {
-	Permissive    bool
-	InputDatabase string
-	Bundles       []string
+	Permissive          bool
+	InputDatabase       string
+	Bundles             []string
+	AllowPackageRemoval bool
 }
 
 func (r RegistryUpdater) DeprecateFromRegistry(request DeprecateFromRegistryRequest) error {
@@ -357,6 +358,23 @@ func (r RegistryUpdater) DeprecateFromRegistry(request DeprecateFromRegistryRequ
 	}
 
 	deprecator := sqlite.NewSQLDeprecatorForBundles(dbLoader, toDeprecate)
+
+	// Check for deprecation of head of default channel. If deprecation request includes heads of all other channels,
+	// then remove the package entirely. Otherwise, deprecate provided bundles. This enables deprecating an entire package.
+	// By default deprecating the head of default channel is not permitted.
+	if request.AllowPackageRemoval {
+		packageDeprecator := sqlite.NewSQLDeprecatorForBundlesAndPackages(deprecator, dbQuerier)
+		if err := packageDeprecator.MaybeRemovePackages(); err != nil {
+			r.Logger.Debugf("unable to deprecate package from database: %s", err)
+			if !request.Permissive {
+				r.Logger.WithError(err).Error("permissive mode disabled")
+				return err
+			}
+			r.Logger.WithError(err).Warn("permissive mode enabled")
+		}
+	}
+
+	// Any bundles associated with removed packages are now removed from the list of bundles to deprecate.
 	if err := deprecator.Deprecate(); err != nil {
 		r.Logger.Debugf("unable to deprecate bundles from database: %s", err)
 		if !request.Permissive {

--- a/pkg/sqlite/deprecate.go
+++ b/pkg/sqlite/deprecate.go
@@ -1,6 +1,7 @@
 package sqlite
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -20,12 +21,26 @@ type BundleDeprecator struct {
 	bundles []string
 }
 
+// PackageDeprecator removes bundles and optionally entire packages from the index
+type PackageDeprecator struct {
+	*BundleDeprecator
+	querier *SQLQuerier
+}
+
 var _ SQLDeprecator = &BundleDeprecator{}
+var _ SQLDeprecator = &PackageDeprecator{}
 
 func NewSQLDeprecatorForBundles(store registry.Load, bundles []string) *BundleDeprecator {
 	return &BundleDeprecator{
 		store:   store,
 		bundles: bundles,
+	}
+}
+
+func NewSQLDeprecatorForBundlesAndPackages(deprecator *BundleDeprecator, querier *SQLQuerier) *PackageDeprecator {
+	return &PackageDeprecator{
+		BundleDeprecator: deprecator,
+		querier:          querier,
 	}
 }
 
@@ -44,4 +59,88 @@ func (d *BundleDeprecator) Deprecate() error {
 	}
 
 	return utilerrors.NewAggregate(errs)
+}
+
+// MaybeRemovePackages queries the DB to establish if any provided bundles are the head of the default channel of a package.
+// If so, the list of bundles must also contain the head of all other channels in the package, otherwise an error is produced.
+// If the heads of all channels are being deprecated (including the default channel), the package is removed entirely from the index.
+// MaybeRemovePackages deletes all bundles from the associated package from the bundles array, so that the subsequent
+// Deprecate() call can proceed with deprecating other potential bundles from other packages.
+func (d *PackageDeprecator) MaybeRemovePackages() error {
+	log := logrus.WithField("bundles", d.bundles)
+	log.Info("allow-package-removal enabled: checking default channel heads for package removal")
+
+	var errs []error
+	var removedBundlePaths []string
+	var remainingBundlePaths []string
+
+	// Iterate over bundles list - see if any bundle is the head of a default channel in a package
+	var packages []string
+	for _, bundle := range d.bundles {
+		found, err := d.querier.PackageFromDefaultChannelHeadBundle(context.TODO(), bundle)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("error checking if bundle is default channel head %s: %s", bundle, err))
+		}
+		if found != "" {
+			packages = append(packages, found)
+		}
+	}
+
+	if len(packages) == 0 {
+		log.Info("no head of default channel found - skipping package removal")
+		return nil
+	}
+
+	// If so, ensure list contains head of all other channels in that package
+	// If not, return error
+	for _, pkg := range packages {
+		channels, err := d.querier.ListChannels(context.TODO(), pkg)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("error listing channels for package %s: %s", pkg, err))
+		}
+		for _, channel := range channels {
+			found, err := d.querier.BundlePathForChannelHead(context.TODO(), pkg, channel)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("error listing channel head for package %s: %s", pkg, err))
+			}
+			if !contains(found, d.bundles) {
+				// terminal error
+				errs = append(errs, fmt.Errorf("cannot deprecate default channel head from package without removing all other channel heads in package %s: must deprecate %s, head of channel %s", pkg, found, channel))
+				return utilerrors.NewAggregate(errs)
+			}
+			removedBundlePaths = append(removedBundlePaths, found)
+		}
+	}
+
+	// Remove associated package from index
+	log.Infof("removing packages %#v", packages)
+	for _, pkg := range packages {
+		err := d.store.RemovePackage(pkg)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("error removing package %s: %s", pkg, err))
+		}
+	}
+
+	// Remove bundles from the removed package from the deprecation request
+	// This enables other bundles to be deprecated via the expected flow
+	// Build a new array with just the outstanding bundles
+	for _, bundlePath := range d.bundles {
+		if contains(bundlePath, removedBundlePaths) {
+			continue
+		}
+		remainingBundlePaths = append(remainingBundlePaths, bundlePath)
+	}
+	d.bundles = remainingBundlePaths
+	log.Infof("remaining bundles to deprecate %#v", d.bundles)
+
+	return utilerrors.NewAggregate(errs)
+}
+
+func contains(bundlePath string, bundles []string) bool {
+	for _, b := range bundles {
+		if b == bundlePath {
+			return true
+		}
+	}
+	return false
 }

--- a/test/e2e/opm_test.go
+++ b/test/e2e/opm_test.go
@@ -332,7 +332,6 @@ var _ = Describe("opm", func() {
 			By("loading manifests from a directory")
 			err = initialize()
 			Expect(err).NotTo(HaveOccurred())
-
 		})
 
 		It("build bundles and index via inference", func() {


### PR DESCRIPTION
Signed-off-by: Daniel Sover <dsover@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
OPM currently does not allow an end user to call deprecatetruncate on a bundle if that bundle is the head of the default channel. This is intended to prevent an ambiguous case – if all the bundles from a channel are removed and as a result the channel itself is removed, then the default channel no longer exists and the package is in an invalid state.

However, if the deprecatetruncate command would result in all channels being removed, there is no ambiguity to deal with. Functionally, that is equivalent to that package becoming unavailable in the index.

This PR adds a flag to the deprecatetruncate command --allow-package-removal that, if set, removes the entire package ala `opm registry rm` so that all package metadata is removed if all of the channels would be removed without that channel head requirement. It does not touch the existing deprecate codepath, and enables other bundles (not in the removed package) to continue to be deprecated normally via the command. 

**Motivation for the change:**
Support pipeline usecases 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
