### PR TITLE
docs(diff): add point about versions that differ

### DIFF
--- a/cmd/opm/alpha/diff/cmd.go
+++ b/cmd/opm/alpha/diff/cmd.go
@@ -44,7 +44,7 @@ func NewCmd() *cobra.Command {
 		Long: templates.LongDesc(`
 Diff a set of old and new catalog references ("refs") to produce a
 declarative config containing only packages channels, and versions not present
-in the old set. This is known as "latest" mode.
+in the old set, and versions that differ between the old and new sets. This is known as "latest" mode.
 These references are passed through 'opm render' to produce a single declarative config.
 
 This command has special behavior when old-refs are omitted, called "heads-only" mode:


### PR DESCRIPTION
**Description of the change:** clarify command docs

**Motivation for the change:** docs incorrect

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

/kind documentation
