### PR TITLE
feat(release): X.Y, X, and latest opm image tags

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -128,7 +128,29 @@ dockers:
     build_flag_templates:
       - --platform=linux/s390x
 docker_manifests:
+  # IMAGE_TAG is either set by the Makefile or the goreleaser action workflow,
+  # This image is intended to be tagged/pushed on all trunk (master, release branch) commits and tags.
   - name_template: "{{ .Env.OPM_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}"
+    image_templates:
+      - "{{ .Env.OPM_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-amd64"
+      - "{{ .Env.OPM_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-arm64"
+      - "{{ .Env.OPM_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-ppc64le"
+      - "{{ .Env.OPM_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-s390x"
+  # Release image builds will be skipped if *_IMAGE_OR_EMPTY variables are empty.
+  # https://github.com/goreleaser/goreleaser/blob/9ed3c0c/internal/pipe/docker/manifest.go#L105
+  - name_template: "{{ .Env.MAJ_MIN_IMAGE_OR_EMPTY }}"
+    image_templates:
+      - "{{ .Env.OPM_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-amd64"
+      - "{{ .Env.OPM_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-arm64"
+      - "{{ .Env.OPM_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-ppc64le"
+      - "{{ .Env.OPM_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-s390x"
+  - name_template: "{{ .Env.MAJ_IMAGE_OR_EMPTY }}"
+    image_templates:
+      - "{{ .Env.OPM_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-amd64"
+      - "{{ .Env.OPM_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-arm64"
+      - "{{ .Env.OPM_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-ppc64le"
+      - "{{ .Env.OPM_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-s390x"
+  - name_template: "{{ .Env.LATEST_IMAGE_OR_EMPTY }}"
     image_templates:
       - "{{ .Env.OPM_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-amd64"
       - "{{ .Env.OPM_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-arm64"

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ comma := ,
 # default to json1 for sqlite3
 TAGS := -tags=json1
 
-# Cluster to use for e2e testing 
+# Cluster to use for e2e testing
 CLUSTER ?= ""
 ifeq ($(CLUSTER), kind)
 # add kind to the list of tags
@@ -113,12 +113,38 @@ clean:
 
 .PHONY: e2e
 e2e:
-	$(GO) run github.com/onsi/ginkgo/ginkgo --v --randomizeAllSpecs --randomizeSuites --race $(if $(TEST),-focus '$(TEST)') $(TAGS) ./test/e2e -- $(if $(SKIPTLS),-skip-tls true) 
+	$(GO) run github.com/onsi/ginkgo/ginkgo --v --randomizeAllSpecs --randomizeSuites --race $(if $(TEST),-focus '$(TEST)') $(TAGS) ./test/e2e -- $(if $(SKIPTLS),-skip-tls true)
 
 
 .PHONY: release
 export OPM_IMAGE_REPO ?= quay.io/operator-framework/opm
 export IMAGE_TAG ?= $(OPM_VERSION)
-release: RELEASE_ARGS?=release --rm-dist --snapshot
+export MAJ_MIN_IMAGE_OR_EMPTY ?= $(call tagged-or-empty,$(shell echo $(OPM_VERSION) | grep -Eo 'v[0-9]+\.[0-9]+'))
+export MAJ_IMAGE_OR_EMPTY ?= $(call tagged-or-empty,$(shell echo $(OPM_VERSION) | grep -Eo 'v[0-9]+'))
+# LATEST_TAG is the latest semver tag in HEAD. Used to deduce whether
+# OPM_VERSION is the new latest tag, or a prior minor/patch tag, below.
+# NOTE: this can only be relied upon if full git history is present.
+# An actions/checkout step must use "fetch-depth: 0", for example.
+LATEST_TAG := $(shell git tag -l | tr - \~ | sort -V | tr \~ - | tail -n1)
+# LATEST_IMAGE_OR_EMPTY is set to OPM_IMAGE_REPO:latest when OPM_VERSION
+# is not a prerelase tag and == LATEST_TAG, otherwise the empty string.
+# An empty string causes goreleaser to skip building the manifest image for latest,
+# which we do not want when cutting a non-latest release (old minor/patch tag).
+export LATEST_IMAGE_OR_EMPTY ?= $(shell \
+	echo $(OPM_VERSION) | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$$' \
+	&& [ "$(shell echo -e "$(OPM_VERSION)\n$(LATEST_TAG)" | sort -rV | head -n1)" == "$(OPM_VERSION)" ] \
+	&& echo "$(OPM_IMAGE_REPO):latest" || echo "")
+release: RELEASE_ARGS ?= release --rm-dist --snapshot
 release:
 	./scripts/fetch goreleaser 0.173.2 && ./bin/goreleaser $(RELEASE_ARGS)
+
+# tagged-or-empty returns $(OPM_IMAGE_REPO):$(1) when HEAD is assigned a non-prerelease semver tag,
+# otherwise the empty string. An empty string causes goreleaser to skip building
+# the manifest image for a trunk commit when it is not a release commit.
+# In other words, this function will return "" if the tag is not in vX.Y.Z format.
+define tagged-or-empty
+$(shell \
+	echo $(OPM_VERSION) | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$$' \
+	&& git describe --exact-match HEAD >/dev/null 2>&1 \
+	&& echo "$(OPM_IMAGE_REPO):$(1)" || echo "" )
+endef


### PR DESCRIPTION
**Description of the change:** build X.Y, X, and latest opm images but only latest if X.Y.Z is latest semver in HEAD.

**Motivation for the change:** `quay.io/operator-framework/opm` image consumers should be able to subscribe to patch releases automatically via X.Y tags, and to X/`latest` tags for the latest `opm` features.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive