### PR TITLE
chore(opm): note that whole dependency packages are added to the diff

### DIFF
--- a/cmd/opm/alpha/diff/cmd.go
+++ b/cmd/opm/alpha/diff/cmd.go
@@ -56,6 +56,11 @@ in which case they are not included in the diff, or a new ref, in which
 case they are included. Dependencies provided by some catalog unknown to
 'opm alpha diff' will not cause the command to error, but an error will occur
 if that catalog is not serving these dependencies at runtime.
+
+NOTE: for now, if any dependency exists, the entire dependency's package is added to the diff.
+In the future, these packages will be pruned such that only the latest dependencies
+satisfying a package version range or GVK, and their upgrade graph(s) to their latest
+channel head(s), are included in the diff.
 `),
 		Example: templates.Examples(`
 # Diff a catalog at some old state and latest state into a declarative config index.


### PR DESCRIPTION
**Description of the change:** note that whole dependency packages are added to the diff for now

**Motivation for the change:** See this [TODO](https://github.com/operator-framework/operator-registry/blob/3c2677ea67da9bb96d9f1db9e45dd4e46b81dd8e/internal/declcfg/diff.go#L169-L170). This will be accomplished in the near future.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive