### PR TITLE
fix(opm): clarify that bundle declcfgs are not valid refs alone

### DIFF
--- a/cmd/opm/alpha/diff/cmd.go
+++ b/cmd/opm/alpha/diff/cmd.go
@@ -45,7 +45,10 @@ func NewCmd() *cobra.Command {
 Diff a set of old and new catalog references ("refs") to produce a
 declarative config containing only packages channels, and versions not present
 in the old set, and versions that differ between the old and new sets. This is known as "latest" mode.
+
 These references are passed through 'opm render' to produce a single declarative config.
+Bundle image refs are not supported directly;
+a valid "olm.package" declarative config object referring to the bundle's package must exist in all input refs.
 
 This command has special behavior when old-refs are omitted, called "heads-only" mode:
 instead of the output being that of 'opm render refs...'

--- a/cmd/opm/alpha/diff/cmd.go
+++ b/cmd/opm/alpha/diff/cmd.go
@@ -47,8 +47,8 @@ declarative config containing only packages channels, and versions not present
 in the old set, and versions that differ between the old and new sets. This is known as "latest" mode.
 
 These references are passed through 'opm render' to produce a single declarative config.
-Bundle image refs are not supported directly;
-a valid "olm.package" declarative config object referring to the bundle's package must exist in all input refs.
+Bundle image refs are not supported directly; a valid "olm.package" declarative config object
+referring to the bundle's package must exist in all input refs.
 
 This command has special behavior when old-refs are omitted, called "heads-only" mode:
 instead of the output being that of 'opm render refs...'

--- a/internal/action/diff.go
+++ b/internal/action/diff.go
@@ -35,8 +35,8 @@ func (a Diff) Run(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
 		oldRender := Render{Refs: a.OldRefs, Registry: a.Registry, AllowedRefMask: mask}
 		oldCfg, err := oldRender.Run(ctx)
 		if err != nil {
-			if isNotAllowedError(err) {
-				return nil, fmt.Errorf("%v (diff does not permit direct bundle references)", err)
+			if errors.Is(err, ErrNotAllowed) {
+				return nil, fmt.Errorf("%w (diff does not permit direct bundle references)", err)
 			}
 			return nil, fmt.Errorf("error rendering old refs: %v", err)
 		}
@@ -49,8 +49,8 @@ func (a Diff) Run(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
 	newRender := Render{Refs: a.NewRefs, Registry: a.Registry, AllowedRefMask: mask}
 	newCfg, err := newRender.Run(ctx)
 	if err != nil {
-		if isNotAllowedError(err) {
-			return nil, fmt.Errorf("%v (diff does not permit direct bundle references)", err)
+		if errors.Is(err, ErrNotAllowed) {
+			return nil, fmt.Errorf("%w (diff does not permit direct bundle references)", err)
 		}
 		return nil, fmt.Errorf("error rendering new refs: %v", err)
 	}
@@ -73,9 +73,4 @@ func (p Diff) validate() error {
 		return fmt.Errorf("no new refs to diff")
 	}
 	return nil
-}
-
-func isNotAllowedError(err error) bool {
-	errNotAllowed := &ErrNotAllowed{}
-	return errors.As(err, &errNotAllowed)
 }

--- a/internal/action/list.go
+++ b/internal/action/list.go
@@ -206,7 +206,7 @@ func indexRefToModel(ctx context.Context, ref string) (model.Model, error) {
 	}
 	cfg, err := render.Run(ctx)
 	if err != nil {
-		if errors.Is(err, &ErrNotAllowed{}) {
+		if errors.Is(err, ErrNotAllowed) {
 			return nil, fmt.Errorf("cannot list non-index %q", ref)
 		}
 		return nil, err

--- a/internal/action/render_test.go
+++ b/internal/action/render_test.go
@@ -448,7 +448,7 @@ func TestAllowRefMask(t *testing.T) {
 				Registry:       reg,
 				AllowedRefMask: action.RefDCImage | action.RefDCDir | action.RefSqliteFile | action.RefBundleImage,
 			},
-			expectErr: &action.ErrNotAllowed{},
+			expectErr: action.ErrNotAllowed,
 		},
 		{
 			name: "SqliteFile/Allowed",
@@ -466,7 +466,7 @@ func TestAllowRefMask(t *testing.T) {
 				Registry:       reg,
 				AllowedRefMask: action.RefDCImage | action.RefDCDir | action.RefSqliteImage | action.RefBundleImage,
 			},
-			expectErr: &action.ErrNotAllowed{},
+			expectErr: action.ErrNotAllowed,
 		},
 		{
 			name: "DeclcfgImage/Allowed",
@@ -484,7 +484,7 @@ func TestAllowRefMask(t *testing.T) {
 				Registry:       reg,
 				AllowedRefMask: action.RefDCDir | action.RefSqliteImage | action.RefSqliteFile | action.RefBundleImage,
 			},
-			expectErr: &action.ErrNotAllowed{},
+			expectErr: action.ErrNotAllowed,
 		},
 		{
 			name: "DeclcfgDir/Allowed",
@@ -502,7 +502,7 @@ func TestAllowRefMask(t *testing.T) {
 				Registry:       reg,
 				AllowedRefMask: action.RefDCImage | action.RefSqliteImage | action.RefSqliteFile | action.RefBundleImage,
 			},
-			expectErr: &action.ErrNotAllowed{},
+			expectErr: action.ErrNotAllowed,
 		},
 		{
 			name: "BundleImage/Allowed",
@@ -520,7 +520,7 @@ func TestAllowRefMask(t *testing.T) {
 				Registry:       reg,
 				AllowedRefMask: action.RefDCImage | action.RefDCDir | action.RefSqliteImage | action.RefSqliteFile,
 			},
-			expectErr: &action.ErrNotAllowed{},
+			expectErr: action.ErrNotAllowed,
 		},
 		{
 			name: "All/Allowed",


### PR DESCRIPTION
**Description of the change:** clarify that bundle declcfgs are not valid refs alone, and require an `olm.package` declcfg. An error is returned if a bundle is directly specified.

**Motivation for the change:** diff is really intended for indices. There's no way to infer which channel is the default for a package if more than one bundle in the same package is passed to diff either, so we could get non-deterministic behavior unless diff imposes some ordering on channels. Assuming icon doesn't exist (or other future `olm.package` fields) for a package may cause issues when using the diff'ed catalog in-cluster too.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive