### PR TITLE
add further console customization types

### DIFF
--- a/pkg/lib/bundle/supported_resources.go
+++ b/pkg/lib/bundle/supported_resources.go
@@ -17,6 +17,9 @@ const (
 	PriorityClassKind         = "PriorityClass"
 	VerticalPodAutoscalerKind = "VerticalPodAutoscaler"
 	ConsoleYamlSampleKind     = "ConsoleYamlSample"
+	ConsoleQuickStartKind     = "ConsoleQuickStart"
+	ConsoleCLIDownloadKind    = "ConsoleCLIDownload"
+	ConsoleLinkKind           = "ConsoleLink"
 )
 
 // Namespaced indicates whether the resource is namespace scoped (true) or cluster-scoped (false).
@@ -41,6 +44,9 @@ var supportedResources = map[string]Namespaced{
 	PriorityClassKind:         false,
 	VerticalPodAutoscalerKind: false,
 	ConsoleYamlSampleKind:     false,
+	ConsoleQuickStartKind:     false,
+	ConsoleCLIDownloadKind:    false,
+	ConsoleLinkKind:           false,
 }
 
 // IsSupported checks if the object kind is OLM-supported and if it is namespaced


### PR DESCRIPTION
**Description of the change:** 
Allow Operators to ship customization extensions for graphical consoles


**Motivation for the change:**
Make it easier to get started with operator provided services by guiding users with quick starts, CLI download links or links to standalone consoles in graphical console for Kubernetes

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

