### PR TITLE
read stdout for reading container name

### DIFF
--- a/pkg/containertools/runner.go
+++ b/pkg/containertools/runner.go
@@ -130,10 +130,13 @@ func (r *ContainerCommandRunner) Unpack(image, src, dst string) error {
 	r.logger.Infof("running %s create", r.containerTool)
 	r.logger.Debugf("%s", command.Args)
 
-	out, err := command.CombinedOutput()
+	out, err := command.Output()
 	if err != nil {
-		r.logger.Errorf(string(out))
-		return fmt.Errorf("error creating container %s: %v", string(out), err)
+		msg := err.Error()
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			msg = fmt.Sprintf("%s: %s", err, exitErr.Stderr)
+		}
+		return fmt.Errorf("error creating container %s: %s", string(out), msg)
 	}
 
 	id := strings.TrimSuffix(string(out), "\n")


### PR DESCRIPTION
Read container names from only stdout to avoid podman warnings on stderr.

Closes #689 