### PR TITLE
fix(deprecate): explicit pkg rm drops latest deprecated

### DIFF
--- a/pkg/lib/registry/registry.go
+++ b/pkg/lib/registry/registry.go
@@ -212,7 +212,7 @@ func (r RegistryUpdater) DeleteFromRegistry(request DeleteFromRegistryRequest) e
 	}
 	defer db.Close()
 
-	dbLoader, err := sqlite.NewSQLLiteLoader(db)
+	dbLoader, err := sqlite.NewDeprecationAwareLoader(db)
 	if err != nil {
 		return err
 	}

--- a/pkg/sqlite/migrations/013_rm_truncated_deprecations.go
+++ b/pkg/sqlite/migrations/013_rm_truncated_deprecations.go
@@ -1,0 +1,31 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+)
+
+const RmTruncatedDeprecationsMigrationKey = 13
+
+// Register this migration
+func init() {
+	registerMigration(RmTruncatedDeprecationsMigrationKey, rmTruncatedDeprecationsMigration)
+}
+
+var rmTruncatedDeprecationsMigration = &Migration{
+	Id: RmTruncatedDeprecationsMigrationKey,
+	Up: func(ctx context.Context, tx *sql.Tx) error {
+
+		// Delete deprecation history for all bundles that no longer exist in the channel_entries table
+		// These bundles have been truncated by more recent deprecations and would only confuse future operations on an index;
+		// e.g. adding a previously truncated bundle to a package removed via `opm index|registry rm` would lead to that bundle
+		// being deprecated
+		_, err := tx.ExecContext(ctx, `DELETE FROM deprecated WHERE deprecated.operatorbundle_name NOT IN (SELECT DISTINCT deprecated.operatorbundle_name FROM (deprecated INNER JOIN channel_entry ON deprecated.operatorbundle_name = channel_entry.operatorbundle_name))`)
+
+		return err
+	},
+	Down: func(ctx context.Context, tx *sql.Tx) error {
+		// No-op
+		return nil
+	},
+}

--- a/pkg/sqlite/migrations/013_rm_truncated_deprecations_test.go
+++ b/pkg/sqlite/migrations/013_rm_truncated_deprecations_test.go
@@ -1,0 +1,49 @@
+package migrations_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/operator-framework/operator-registry/pkg/sqlite/migrations"
+)
+
+func TestRmTruncatedDeprecations(t *testing.T) {
+	db, migrator, cleanup := CreateTestDbAt(t, migrations.RmTruncatedDeprecationsMigrationKey-1)
+	defer cleanup()
+
+	// Insert fixtures to satisfy foreign key constraints
+	insertBundle := "INSERT INTO operatorbundle(name, version, bundlepath, csv) VALUES (?, ?, ?, ?)"
+	insertChannel := "INSERT INTO channel(name, package_name, head_operatorbundle_name) VALUES (?, ?, ?)"
+	insertChannelEntry := "INSERT INTO channel_entry(entry_id, channel_name, package_name, operatorbundle_name) VALUES (?, ?, ?, ?)"
+	insertDeprecated := "INSERT INTO deprecated(operatorbundle_name) VALUES (?)"
+
+	// Add a deprecated bundle
+	_, err := db.Exec(insertBundle, "operator.v1.0.0", "1.0.0", "quay.io/operator:v1.0.0", "operator.v1.0.0's csv")
+	require.NoError(t, err)
+	_, err = db.Exec(insertChannel, "stable", "apple", "operator.v1.0.0")
+	require.NoError(t, err)
+	_, err = db.Exec(insertChannelEntry, 0, "stable", "apple", "operator.v1.0.0")
+	require.NoError(t, err)
+	_, err = db.Exec(insertDeprecated, "operator.v1.0.0")
+	require.NoError(t, err)
+
+	// Add a truncated bundle; i.e. doesn't exist in the channel_entry table
+	_, err = db.Exec(insertDeprecated, "operator.v1.0.0-pre")
+
+	// This migration should delete all bundles that are not referenced by the channel_entry table
+	require.NoError(t, migrator.Up(context.Background(), migrations.Only(migrations.RmTruncatedDeprecationsMigrationKey)))
+
+	deprecated, err := db.Query("SELECT * FROM deprecated")
+	require.NoError(t, err)
+	defer deprecated.Close()
+
+	require.True(t, deprecated.Next(), "failed to detect deprecated bundle")
+	var name sql.NullString
+	require.NoError(t, deprecated.Scan(&name))
+	require.True(t, name.Valid)
+	require.Equal(t, "operator.v1.0.0", name.String)
+	require.False(t, deprecated.Next(), "incorrect number of deprecated bundles")
+}


### PR DESCRIPTION
- When using opm index|registry rm <pkg>, drop the "latest" related bundles
from the deprecated table. This makes "un-deprecating" a bundle
possible, which is useful if that  bundle was deprecated by
accident
- Add a migration and logic on deprecatetruncate that drops
truncated bundles (i.e. w/o assoc. channel_entry rows) from the deprecated
table, clearing the "deprecation history" so that operations post package
removal don't assume a truncated bundle should be deprecated

See https://bugzilla.redhat.com/show_bug.cgi?id=1982781 for motivation
