### PR TITLE
render: support rendering FBC from bundle directories

### DIFF
--- a/alpha/action/render.go
+++ b/alpha/action/render.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"text/template"
 
 	"github.com/h2non/filetype"
 	"github.com/h2non/filetype/matchers"
@@ -39,6 +40,7 @@ const (
 	RefSqliteFile
 	RefDCImage
 	RefDCDir
+	RefBundleDir
 
 	RefAll = 0
 )
@@ -50,10 +52,11 @@ func (r RefType) Allowed(refType RefType) bool {
 var ErrNotAllowed = errors.New("not allowed")
 
 type Render struct {
-	Refs           []string
-	Registry       image.Registry
-	AllowedRefMask RefType
-	Migrate        bool
+	Refs             []string
+	Registry         image.Registry
+	AllowedRefMask   RefType
+	Migrate          bool
+	ImageRefTemplate *template.Template
 
 	skipSqliteDeprecationLog bool
 }
@@ -125,25 +128,44 @@ func (r Render) createRegistry() (*containerdregistry.Registry, error) {
 }
 
 func (r Render) renderReference(ctx context.Context, ref string) (*declcfg.DeclarativeConfig, error) {
-	if stat, serr := os.Stat(ref); serr == nil {
-		if stat.IsDir() {
-			if !r.AllowedRefMask.Allowed(RefDCDir) {
-				return nil, fmt.Errorf("cannot render declarative config directory: %w", ErrNotAllowed)
-			}
-			return declcfg.LoadFS(ctx, os.DirFS(ref))
-		} else {
-			// The only supported file type is an sqlite DB file,
-			// since declarative configs will be in a directory.
-			if err := checkDBFile(ref); err != nil {
-				return nil, err
-			}
-			if !r.AllowedRefMask.Allowed(RefSqliteFile) {
-				return nil, fmt.Errorf("cannot render sqlite file: %w", ErrNotAllowed)
-			}
-			return sqliteToDeclcfg(ctx, ref)
-		}
+	stat, err := os.Stat(ref)
+	if err != nil {
+		return r.imageToDeclcfg(ctx, ref)
 	}
-	return r.imageToDeclcfg(ctx, ref)
+	if stat.IsDir() {
+		dirEntries, err := os.ReadDir(ref)
+		if err != nil {
+			return nil, err
+		}
+		if isBundle(dirEntries) {
+			// Looks like a bundle directory
+			if !r.AllowedRefMask.Allowed(RefBundleDir) {
+				return nil, fmt.Errorf("cannot render bundle directory %q: %w", ref, ErrNotAllowed)
+			}
+			return r.renderBundleDirectory(ref)
+		}
+
+		// Otherwise, assume it is a declarative config root directory.
+		if !r.AllowedRefMask.Allowed(RefDCDir) {
+			return nil, fmt.Errorf("cannot render declarative config directory: %w", ErrNotAllowed)
+		}
+		return declcfg.LoadFS(ctx, os.DirFS(ref))
+	}
+	// The only supported file type is an sqlite DB file,
+	// since declarative configs will be in a directory.
+	if err := checkDBFile(ref); err != nil {
+		return nil, err
+	}
+	if !r.AllowedRefMask.Allowed(RefSqliteFile) {
+		return nil, fmt.Errorf("cannot render sqlite file: %w", ErrNotAllowed)
+	}
+
+	db, err := sqlite.Open(ref)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+	return sqliteToDeclcfg(ctx, db)
 }
 
 func (r Render) imageToDeclcfg(ctx context.Context, imageRef string) (*declcfg.DeclarativeConfig, error) {
@@ -169,7 +191,12 @@ func (r Render) imageToDeclcfg(ctx context.Context, imageRef string) (*declcfg.D
 		if !r.AllowedRefMask.Allowed(RefSqliteImage) {
 			return nil, fmt.Errorf("cannot render sqlite image: %w", ErrNotAllowed)
 		}
-		cfg, err = sqliteToDeclcfg(ctx, filepath.Join(tmpDir, dbFile))
+		db, err := sqlite.Open(filepath.Join(tmpDir, dbFile))
+		if err != nil {
+			return nil, err
+		}
+		defer db.Close()
+		cfg, err = sqliteToDeclcfg(ctx, db)
 		if err != nil {
 			return nil, err
 		}
@@ -190,10 +217,11 @@ func (r Render) imageToDeclcfg(ctx context.Context, imageRef string) (*declcfg.D
 			return nil, err
 		}
 
-		cfg, err = bundleToDeclcfg(img.Bundle)
+		bundle, err := bundleToDeclcfg(img.Bundle)
 		if err != nil {
 			return nil, err
 		}
+		cfg = &declcfg.DeclarativeConfig{Bundles: []declcfg.Bundle{*bundle}}
 	} else {
 		labelKeys := sets.StringKeySet(labels)
 		labelVals := []string{}
@@ -221,16 +249,10 @@ func checkDBFile(ref string) error {
 	return nil
 }
 
-func sqliteToDeclcfg(ctx context.Context, dbFile string) (*declcfg.DeclarativeConfig, error) {
+func sqliteToDeclcfg(ctx context.Context, db *sql.DB) (*declcfg.DeclarativeConfig, error) {
 	logDeprecationMessage.Do(func() {
 		sqlite.LogSqliteDeprecation()
 	})
-
-	db, err := sqlite.Open(dbFile)
-	if err != nil {
-		return nil, err
-	}
-	defer db.Close()
 
 	migrator, err := sqlite.NewSQLLiteMigrator(db)
 	if err != nil {
@@ -303,7 +325,7 @@ func populateDBRelatedImages(ctx context.Context, cfg *declcfg.DeclarativeConfig
 	return nil
 }
 
-func bundleToDeclcfg(bundle *registry.Bundle) (*declcfg.DeclarativeConfig, error) {
+func bundleToDeclcfg(bundle *registry.Bundle) (*declcfg.Bundle, error) {
 	objs, props, err := registry.ObjectsAndPropertiesFromBundle(bundle)
 	if err != nil {
 		return nil, fmt.Errorf("get properties for bundle %q: %v", bundle.Name, err)
@@ -323,7 +345,7 @@ func bundleToDeclcfg(bundle *registry.Bundle) (*declcfg.DeclarativeConfig, error
 		}
 	}
 
-	dBundle := declcfg.Bundle{
+	return &declcfg.Bundle{
 		Schema:        "olm.bundle",
 		Name:          bundle.Name,
 		Package:       bundle.Package,
@@ -332,9 +354,7 @@ func bundleToDeclcfg(bundle *registry.Bundle) (*declcfg.DeclarativeConfig, error
 		RelatedImages: relatedImages,
 		Objects:       objs,
 		CsvJSON:       string(csvJson),
-	}
-
-	return &declcfg.DeclarativeConfig{Bundles: []declcfg.Bundle{dBundle}}, nil
+	}, nil
 }
 
 func getRelatedImages(b *registry.Bundle) ([]declcfg.RelatedImage, error) {
@@ -363,7 +383,7 @@ func getRelatedImages(b *registry.Bundle) ([]declcfg.RelatedImage, error) {
 		allImages = allImages.Insert(ri.Image)
 	}
 
-	if !allImages.Has(b.BundleImage) {
+	if b.BundleImage != "" && !allImages.Has(b.BundleImage) {
 		relatedImages = append(relatedImages, declcfg.RelatedImage{
 			Image: b.BundleImage,
 		})
@@ -453,4 +473,73 @@ func combineConfigs(cfgs []declcfg.DeclarativeConfig) *declcfg.DeclarativeConfig
 		out.Merge(&in)
 	}
 	return out
+}
+
+func isBundle(entries []os.DirEntry) bool {
+	foundManifests := false
+	foundMetadata := false
+	for _, e := range entries {
+		if e.IsDir() {
+			switch e.Name() {
+			case "manifests":
+				foundManifests = true
+			case "metadata":
+				foundMetadata = true
+			}
+		}
+		if foundMetadata && foundManifests {
+			return true
+		}
+	}
+	return false
+}
+
+type imageReferenceTemplateData struct {
+	Package string
+	Name    string
+	Version string
+}
+
+func (r *Render) renderBundleDirectory(ref string) (*declcfg.DeclarativeConfig, error) {
+	img, err := registry.NewImageInput(image.SimpleReference(""), ref)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.templateBundleImageRef(img.Bundle); err != nil {
+		return nil, fmt.Errorf("failed templating image reference from bundle for %q: %v", ref, err)
+	}
+	fbcBundle, err := bundleToDeclcfg(img.Bundle)
+	if err != nil {
+		return nil, err
+	}
+	return &declcfg.DeclarativeConfig{Bundles: []declcfg.Bundle{*fbcBundle}}, nil
+}
+
+func (r *Render) templateBundleImageRef(bundle *registry.Bundle) error {
+	if r.ImageRefTemplate == nil {
+		return nil
+	}
+
+	var pkgProp property.Package
+	for _, p := range bundle.Properties {
+		if p.Type != property.TypePackage {
+			continue
+		}
+		if err := json.Unmarshal(p.Value, &pkgProp); err != nil {
+			return err
+		}
+		break
+	}
+
+	var buf strings.Builder
+	tmplInput := imageReferenceTemplateData{
+		Package: bundle.Package,
+		Name:    bundle.Name,
+		Version: pkgProp.Version,
+	}
+	if err := r.ImageRefTemplate.Execute(&buf, tmplInput); err != nil {
+		return err
+	}
+	bundle.BundleImage = buf.String()
+	return nil
 }

--- a/cmd/opm/alpha/cmd.go
+++ b/cmd/opm/alpha/cmd.go
@@ -9,13 +9,16 @@ import (
 	"github.com/operator-framework/operator-registry/cmd/opm/alpha/template"
 )
 
-func NewCmd() *cobra.Command {
+func NewCmd(showAlphaHelp bool) *cobra.Command {
 	runCmd := &cobra.Command{
-		Hidden: true,
-		Use:    "alpha",
-		Short:  "Run an alpha subcommand",
-		Args:   cobra.NoArgs,
-		Run:    func(_ *cobra.Command, _ []string) {}, // adding an empty function here to preserve non-zero exit status for misstated subcommands/flags for the command hierarchy
+		Use:   "alpha",
+		Short: "Run an alpha subcommand",
+		Args:  cobra.NoArgs,
+		Run:   func(_ *cobra.Command, _ []string) {}, // adding an empty function here to preserve non-zero exit status for misstated subcommands/flags for the command hierarchy
+	}
+
+	if !showAlphaHelp {
+		runCmd.Hidden = true
 	}
 
 	runCmd.AddCommand(

--- a/cmd/opm/index/add.go
+++ b/cmd/opm/index/add.go
@@ -41,7 +41,7 @@ var (
 	`)
 )
 
-func addIndexAddCmd(parent *cobra.Command) {
+func addIndexAddCmd(parent *cobra.Command, showAlphaHelp bool) {
 	indexCmd := &cobra.Command{
 		Use:   "add",
 		Short: "Add operator bundles to an index.",
@@ -78,8 +78,10 @@ func addIndexAddCmd(parent *cobra.Command) {
 		logrus.Panic(err.Error())
 	}
 	indexCmd.Flags().Bool("enable-alpha", false, "enable unsupported alpha features of the OPM CLI")
-	if err := indexCmd.Flags().MarkHidden("enable-alpha"); err != nil {
-		logrus.Panic(err.Error())
+	if !showAlphaHelp {
+		if err := indexCmd.Flags().MarkHidden("enable-alpha"); err != nil {
+			logrus.Panic(err.Error())
+		}
 	}
 	if err := indexCmd.Flags().MarkHidden("debug"); err != nil {
 		logrus.Panic(err.Error())

--- a/cmd/opm/index/cmd.go
+++ b/cmd/opm/index/cmd.go
@@ -8,7 +8,7 @@ import (
 )
 
 // AddCommand adds the index subcommand to the given parent command.
-func AddCommand(parent *cobra.Command) {
+func AddCommand(parent *cobra.Command, showAlphaHelp bool) {
 	cmd := &cobra.Command{
 		Use:   "index",
 		Short: "generate operator index container images",
@@ -34,7 +34,7 @@ func AddCommand(parent *cobra.Command) {
 	parent.AddCommand(cmd)
 
 	cmd.AddCommand(newIndexDeleteCmd())
-	addIndexAddCmd(cmd)
+	addIndexAddCmd(cmd, showAlphaHelp)
 	cmd.AddCommand(newIndexExportCmd())
 	cmd.AddCommand(newIndexPruneCmd())
 	cmd.AddCommand(newIndexDeprecateTruncateCmd())

--- a/cmd/opm/main.go
+++ b/cmd/opm/main.go
@@ -10,7 +10,8 @@ import (
 )
 
 func main() {
-	cmd := root.NewCmd()
+	showAlphaHelp := os.Getenv("HELP_ALPHA") == "true"
+	cmd := root.NewCmd(showAlphaHelp)
 	if err := cmd.Execute(); err != nil {
 		agg, ok := err.(utilerrors.Aggregate)
 		if !ok {

--- a/cmd/opm/registry/add.go
+++ b/cmd/opm/registry/add.go
@@ -14,7 +14,7 @@ import (
 	"github.com/operator-framework/operator-registry/pkg/sqlite"
 )
 
-func newRegistryAddCmd() *cobra.Command {
+func newRegistryAddCmd(showAlphaHelp bool) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "add",
 		Short: "add operator bundle to operator registry DB",
@@ -48,8 +48,10 @@ func newRegistryAddCmd() *cobra.Command {
 		logrus.Panic(err.Error())
 	}
 	rootCmd.Flags().Bool("enable-alpha", false, "enable unsupported alpha features of the OPM CLI")
-	if err := rootCmd.Flags().MarkHidden("enable-alpha"); err != nil {
-		logrus.Panic(err.Error())
+	if !showAlphaHelp {
+		if err := rootCmd.Flags().MarkHidden("enable-alpha"); err != nil {
+			logrus.Panic(err.Error())
+		}
 	}
 	if err := rootCmd.Flags().MarkDeprecated("skip-tls", "use --use-http and --skip-tls-verify instead"); err != nil {
 		logrus.Panic(err.Error())

--- a/cmd/opm/registry/cmd.go
+++ b/cmd/opm/registry/cmd.go
@@ -8,7 +8,7 @@ import (
 )
 
 // NewOpmRegistryCmd returns the appregistry-server command
-func NewOpmRegistryCmd() *cobra.Command {
+func NewOpmRegistryCmd(showAlphaHelp bool) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "registry",
 		Short: "interact with operator-registry database",
@@ -28,7 +28,7 @@ func NewOpmRegistryCmd() *cobra.Command {
 	}
 
 	rootCmd.AddCommand(newRegistryServeCmd())
-	rootCmd.AddCommand(newRegistryAddCmd())
+	rootCmd.AddCommand(newRegistryAddCmd(showAlphaHelp))
 	rootCmd.AddCommand(newRegistryRmCmd())
 	rootCmd.AddCommand(newRegistryPruneCmd())
 	rootCmd.AddCommand(newRegistryPruneStrandedCmd())

--- a/cmd/opm/render/cmd.go
+++ b/cmd/opm/render/cmd.go
@@ -15,7 +15,7 @@ import (
 	"github.com/operator-framework/operator-registry/pkg/sqlite"
 )
 
-func NewCmd() *cobra.Command {
+func NewCmd(showAlphaHelp bool) *cobra.Command {
 	var (
 		render           action.Render
 		output           string
@@ -27,17 +27,7 @@ func NewCmd() *cobra.Command {
 		Long: `Generate a stream of file-based catalog objects to stdout from the provided
 catalog images, file-based catalog directories, bundle images, and sqlite
 database files.
-
-If rendering sources that do not carry bundle image reference information
-(e.g. bundle directories), the --image-ref-template flag can be used to
-generate image references for the rendered file-based catalog objects.
-This is useful when generating a catalog with image references prior to
-those images actually existing. Available template variables are:
-  - {{.Package}} : the package name the bundle belongs to
-  - {{.Name}}    : the name of the bundle (for registry+v1 bundles, this is the CSV name)
-  - {{.Version}} : the version of the bundle
-
-` + sqlite.DeprecationMessage,
+`,
 		Args: cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			render.Refs = args
@@ -85,7 +75,23 @@ those images actually existing. Available template variables are:
 	}
 	cmd.Flags().StringVarP(&output, "output", "o", "json", "Output format of the streamed file-based catalog objects (json|yaml)")
 	cmd.Flags().BoolVar(&render.Migrate, "migrate", false, "Perform migrations on the rendered FBC")
-	cmd.Flags().StringVar(&imageRefTemplate, "image-ref-template", "", "When bundle image reference information is unavailable, populate it with this template")
+
+	// Alpha flags
+	cmd.Flags().StringVar(&imageRefTemplate, "alpha-image-ref-template", "", "When bundle image reference information is unavailable, populate it with this template")
+
+	if showAlphaHelp {
+		cmd.Long += `
+If rendering sources that do not carry bundle image reference information
+(e.g. bundle directories), the --alpha-image-ref-template flag can be used to
+generate image references for the rendered file-based catalog objects.
+This is useful when generating a catalog with image references prior to
+those images actually existing. Available template variables are:
+  - {{.Package}} : the package name the bundle belongs to
+  - {{.Name}}    : the name of the bundle (for registry+v1 bundles, this is the CSV name)
+  - {{.Version}} : the version of the bundle
+`
+	}
+	cmd.Long += "\n" + sqlite.DeprecationMessage
 	return cmd
 }
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -55,7 +55,7 @@ var _ = BeforeSuite(func() {
 
 	deprovision = ctx.MustProvision(ctx.Ctx())
 
-	opm = opmroot.NewCmd() // Creating multiple instances would cause flag registration conflicts
+	opm = opmroot.NewCmd(false) // Creating multiple instances would cause flag registration conflicts
 })
 
 func configureRegistry() {


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This PR adds support to the `opm render` command for bundle directories.

When rendering bundle directories, there is no metadata about the bundle image reference, so the FBC rendered from a bundle directory contains inlined `olm.bundle.object` properties but lacks an `image` value.

However callers of `opm render` with bundle directories will generally know the image that will contain the bundle directory, so they can insert the bundle image reference themselves. To facilitate this image reference injection, this PR adds a `--image-ref-template` flag that supports templating based on package, name, and version of the bundle.

If specified, `render` will populate `olm.bundle` objects' image field with the templated value and use the `olm.csv.metadata` property. If not specified, `render` will leave the image field empty and will instead include all of the bundle manifests in the catalog as `olm.bundle.object` properties.

**Motivation for the change:**
Some catalog pipelines build the bundle images based on the bundle sources that are included in a source repository. This structure works well in imperative flows where bundle sources alone are sufficient to construct a valid catalog.

However with catalogs themselves now being declarative, a new use case has appeared. Operator authors would like to be able to provide the pipeline with their bundle sources _and_ their catalog metadata. But there is a chicken and egg problem because existing `opm` tooling only supports generating catalog metadata from a bundle image. If a pipeline builds the bundle images and `opm` expects the bundle images to exist in order to generate catalog metadata, it is impossible for an operator author to provide catalog and bundle sources at the same time.

In order to fully support this style of pipeline, a follow-on PR may be necessary to update `opm`'s template to support using bundle directory references and supplying an image reference template.

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
