### PR TITLE
cli doc: opm serve does not detect DC changes after startup

### DIFF
--- a/cmd/opm/serve/serve.go
+++ b/cmd/opm/serve/serve.go
@@ -39,8 +39,13 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "serve <source_path>",
 		Short: "serve declarative configs",
-		Long:  `serve declarative configs via grpc`,
-		Args:  cobra.ExactArgs(1),
+		Long: `This command serves declarative configs via a GRPC server.
+
+NOTE: The declarative config directory is loaded by the serve command at
+startup. Changes made to the declarative config after the this command starts
+will not be reflected in the served content.
+`,
+		Args: cobra.ExactArgs(1),
 		PreRunE: func(_ *cobra.Command, args []string) error {
 			s.configDir = args[0]
 			if s.debug {


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
A CLI documentation change for `opm serve`

**Motivation for the change:**
Clarify that `opm serve` will not reload served content when underlying files in the served directory change.

See https://github.com/operator-framework/olm-docs/pull/177#discussion_r687929694

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [x] Docs updated or added to `/docs` 
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
