### PR TITLE
feat(opm): configure diff to not include dependency bundles with --skip-deps

### DIFF
--- a/internal/action/diff.go
+++ b/internal/action/diff.go
@@ -17,6 +17,9 @@ type Diff struct {
 
 	OldRefs []string
 	NewRefs []string
+	// SkipDependencies directs Run() to not include dependencies
+	// of bundles included in the diff if true.
+	SkipDependencies bool
 
 	Logger *logrus.Entry
 }
@@ -59,7 +62,11 @@ func (a Diff) Run(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
 		return nil, fmt.Errorf("error converting new declarative config to model: %v", err)
 	}
 
-	diffModel, err := declcfg.Diff(oldModel, newModel)
+	g := &declcfg.DiffGenerator{
+		Logger:           a.Logger,
+		SkipDependencies: a.SkipDependencies,
+	}
+	diffModel, err := g.Run(oldModel, newModel)
 	if err != nil {
 		return nil, fmt.Errorf("error generating diff: %v", err)
 	}


### PR DESCRIPTION
**Description of the change:** configure `opm alpha diff` to not include dependency bundles with `--skip-deps`

**Motivation for the change:** there are situations where dependencies are not desired, ex. they are fulfilled by another catalog and this is known prior to invoking `opm alpha diff`.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

/kind feature