### PR TITLE
opm validate: check for cycles and stranded bundles in channel validation

### DIFF
--- a/alpha/model/model.go
+++ b/alpha/model/model.go
@@ -11,6 +11,7 @@ import (
 	"github.com/h2non/filetype/matchers"
 	"github.com/h2non/filetype/types"
 	svg "github.com/h2non/go-is-svg"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/operator-framework/operator-registry/alpha/property"
 )
@@ -184,7 +185,7 @@ func (c *Channel) Validate() error {
 	}
 
 	if len(c.Bundles) > 0 {
-		if _, err := c.Head(); err != nil {
+		if err := c.validateReplacesChain(); err != nil {
 			result.subErrors = append(result.subErrors, err)
 		}
 	}
@@ -201,6 +202,40 @@ func (c *Channel) Validate() error {
 		}
 	}
 	return result.orNil()
+}
+
+// validateReplacesChain checks the replaces chain of a channel.
+// Specifically the following rules must be followed:
+// 1. There must be exactly 1 channel head.
+// 2. Beginning at the head, the replaces chain must reach all non-skipped entries.
+//    Non-skipped entries are defined as entries that are not skipped by any other entry in the channel.
+//    This is basically a re-statement of 1. There must not be two channel heads.
+// 3. There must be no cycles in the replaces chain.
+// 4. The tail entry in the replaces chain is permitted to replace a non-existent entry.
+func (c *Channel) validateReplacesChain() error {
+	head, err := c.Head()
+	if err != nil {
+		return err
+	}
+
+	chainFrom := map[string][]string{}
+	replacesChainFromHead := sets.NewString(head.Name)
+	cur := head
+	for cur != nil {
+		if _, ok := chainFrom[cur.Name]; !ok {
+			chainFrom[cur.Name] = []string{cur.Name}
+		}
+		for k := range chainFrom {
+			chainFrom[k] = append(chainFrom[k], cur.Replaces)
+		}
+		if replacesChainFromHead.Has(cur.Replaces) {
+			return fmt.Errorf("detected cycle in replaces chain of upgrade graph: %q", strings.Join(chainFrom[cur.Replaces], " -> "))
+		}
+		replacesChainFromHead = replacesChainFromHead.Insert(cur.Replaces)
+		cur = c.Bundles[cur.Replaces]
+	}
+
+	return nil
 }
 
 type Bundle struct {

--- a/alpha/model/model_test.go
+++ b/alpha/model/model_test.go
@@ -141,7 +141,7 @@ func TestValidReplacesChain(t *testing.T) {
 				"anakin.v0.0.4": {Name: "anakin.v0.0.4", Replaces: "anakin.v0.0.4"},
 				"anakin.v0.0.5": {Name: "anakin.v0.0.5", Replaces: "anakin.v0.0.4"},
 			}},
-			assertion: hasError(`detected cycle in replaces chain of upgrade graph: "anakin.v0.0.4 -> anakin.v0.0.4"`),
+			assertion: hasError(`detected cycle in replaces chain of upgrade graph: anakin.v0.0.4 -> anakin.v0.0.4`),
 		},
 		{
 			name: "Error/CycleMultipleHops",
@@ -151,7 +151,16 @@ func TestValidReplacesChain(t *testing.T) {
 				"anakin.v0.0.3": {Name: "anakin.v0.0.3", Replaces: "anakin.v0.0.2"},
 				"anakin.v0.0.4": {Name: "anakin.v0.0.4", Replaces: "anakin.v0.0.3"},
 			}},
-			assertion: hasError(`detected cycle in replaces chain of upgrade graph: "anakin.v0.0.3 -> anakin.v0.0.2 -> anakin.v0.0.1 -> anakin.v0.0.3"`),
+			assertion: hasError(`detected cycle in replaces chain of upgrade graph: anakin.v0.0.3 -> anakin.v0.0.2 -> anakin.v0.0.1 -> anakin.v0.0.3`),
+		},
+		{
+			name: "Error/Stranded",
+			ch: Channel{Bundles: map[string]*Bundle{
+				"anakin.v0.0.1": {Name: "anakin.v0.0.1"},
+				"anakin.v0.0.2": {Name: "anakin.v0.0.2", Replaces: "anakin.v0.0.1"},
+				"anakin.v0.0.3": {Name: "anakin.v0.0.3", Skips: []string{"anakin.v0.0.2"}},
+			}},
+			assertion: hasError(`channel contains one or more stranded bundles: anakin.v0.0.1`),
 		},
 	}
 	for _, s := range specs {


### PR DESCRIPTION
Signed-off-by: Joe Lanford <joe.lanford@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This PR adds an additional validation check on indexes that verifies that no cycles are present in the replaces chain of a channel's upgrade graph. It also verifies that there are no stranded bundles.

**Motivation for the change:**
Cycles in the replaces chain of a channel's upgrade graph and stranded bundles are invalid.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
