### PR TITLE
feat(opm): fine-grained dependency selection in diffs

### DIFF
--- a/alpha/action/testdata/index-declcfgs/exp-headsonly/index.yaml
+++ b/alpha/action/testdata/index-declcfgs/exp-headsonly/index.yaml
@@ -9,6 +9,7 @@ schema: olm.channel
 entries:
   - name: bar.v0.1.0
   - name: bar.v0.2.0
+    replaces: bar.v0.1.0
     skips:
       - bar.v0.1.0
   - name: bar.v1.0.0

--- a/alpha/action/testdata/index-declcfgs/latest/index.yaml
+++ b/alpha/action/testdata/index-declcfgs/latest/index.yaml
@@ -9,6 +9,7 @@ schema: olm.channel
 entries:
   - name: bar.v0.1.0
   - name: bar.v0.2.0
+    replaces: bar.v0.1.0
     skipRange: <0.2.0
     skips:
       - bar.v0.1.0

--- a/alpha/action/testdata/index-declcfgs/old/index.yaml
+++ b/alpha/action/testdata/index-declcfgs/old/index.yaml
@@ -9,6 +9,7 @@ name: alpha
 entries:
   - name: bar.v0.1.0
   - name: bar.v0.2.0
+    replaces: bar.v0.1.0
     skipRange: <0.2.0
     skips:
       - bar.v0.1.0

--- a/alpha/declcfg/diff_include.go
+++ b/alpha/declcfg/diff_include.go
@@ -1,0 +1,87 @@
+package declcfg
+
+import (
+	"github.com/operator-framework/operator-registry/alpha/model"
+)
+
+// makeUpgradeGraph creates a DAG of bundles with map key Bundle.Replaces.
+func makeUpgradeGraph(ch *model.Channel) map[string][]*model.Bundle {
+	graph := map[string][]*model.Bundle{}
+	for _, b := range ch.Bundles {
+		b := b
+		if b.Replaces != "" {
+			graph[b.Replaces] = append(graph[b.Replaces], b)
+		}
+	}
+	return graph
+}
+
+// findIntersectingBundles finds the intersecting bundle of start and end in the
+// replaces upgrade graph graph by traversing down to the lowest graph node,
+// then returns every bundle higher than the intersection. It is possible
+// to find no intersection; this should only happen when start and end
+// are not part of the same upgrade graph.
+// Output bundle order is not guaranteed.
+// Precondition: start must be a bundle in ch.
+// Precondition: end must be ch's head.
+func findIntersectingBundles(ch *model.Channel, start, end *model.Bundle, graph map[string][]*model.Bundle) ([]*model.Bundle, bool) {
+	// The intersecting set is equal to end if start is end.
+	if start.Name == end.Name {
+		return []*model.Bundle{end}, true
+	}
+
+	// Construct start's replaces chain for comparison against end's.
+	startChain := map[string]*model.Bundle{start.Name: nil}
+	for curr := start; curr != nil && curr.Replaces != ""; curr = ch.Bundles[curr.Replaces] {
+		startChain[curr.Replaces] = curr
+	}
+
+	// Trace end's replaces chain until it intersects with start's, or the root is reached.
+	var intersection string
+	if _, inChain := startChain[end.Name]; inChain {
+		intersection = end.Name
+	} else {
+		for curr := end; curr != nil && curr.Replaces != ""; curr = ch.Bundles[curr.Replaces] {
+			if _, inChain := startChain[curr.Replaces]; inChain {
+				intersection = curr.Replaces
+				break
+			}
+		}
+	}
+
+	// No intersection is found, delegate behavior to caller.
+	if intersection == "" {
+		return nil, false
+	}
+
+	// Find all bundles that replace the intersection via BFS,
+	// i.e. the set of bundles that fill the update graph between start and end.
+	replacesIntersection := graph[intersection]
+	replacesSet := map[string]*model.Bundle{}
+	for _, b := range replacesIntersection {
+		currName := ""
+		for next := []*model.Bundle{b}; len(next) > 0; next = next[1:] {
+			currName = next[0].Name
+			if _, hasReplaces := replacesSet[currName]; !hasReplaces {
+				replacers := graph[currName]
+				next = append(next, replacers...)
+				replacesSet[currName] = ch.Bundles[currName]
+			}
+		}
+	}
+
+	// Remove every bundle between start and intersection exclusively,
+	// since these bundles must already exist in the destination channel.
+	for rep := start; rep != nil && rep.Name != intersection; rep = ch.Bundles[rep.Replaces] {
+		delete(replacesSet, rep.Name)
+	}
+
+	// Ensure both start and end are added to the output.
+	replacesSet[start.Name] = start
+	replacesSet[end.Name] = end
+	var intersectingBundles []*model.Bundle
+	for _, b := range replacesSet {
+		intersectingBundles = append(intersectingBundles, b)
+	}
+	return intersectingBundles, true
+}

--- a/alpha/declcfg/diff_include_test.go
+++ b/alpha/declcfg/diff_include_test.go
@@ -1,0 +1,183 @@
+package declcfg
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/operator-framework/operator-registry/alpha/model"
+	"github.com/operator-framework/operator-registry/alpha/property"
+)
+
+func TestFindIntersectingBundles(t *testing.T) {
+	type bundleSpec struct {
+		name, replaces string
+		skips          []string
+	}
+
+	inputBundles1 := []bundleSpec{
+		{"foo.v0.1.0", "", nil},
+		{"foo.v0.1.1", "foo.v0.1.0", nil},
+		{"foo.v0.2.0", "foo.v0.1.1", nil},
+		{"foo.v0.3.0", "foo.v0.2.0", nil},
+		{"foo.v1.0.0", "foo.v0.1.0", []string{"foo.v0.1.1", "foo.v0.2.0", "foo.v0.3.0"}},
+		{"foo.v1.1.0", "foo.v1.0.0", nil},
+		{"foo.v2.0.0", "foo.v0.1.0", []string{"foo.v0.1.1", "foo.v0.2.0", "foo.v0.3.0", "foo.v1.0.0", "foo.v1.1.0"}},
+		{"foo.v2.1.0", "foo.v2.0.0", nil},
+		{"foo.v3.0.0", "foo.v1.1.0", []string{"foo.v2.0.0", "foo.v2.1.0"}},
+	}
+
+	type spec struct {
+		name            string
+		pkgName         string
+		channelName     string
+		inputBundles    []bundleSpec
+		start, end      bundleSpec
+		headName        string
+		assertion       require.BoolAssertionFunc
+		expIntersecting []bundleSpec
+	}
+
+	specs := []spec{
+		{
+			name:            "Success/StartEndEqual",
+			inputBundles:    inputBundles1,
+			start:           bundleSpec{"foo.v0.2.0", "foo.v0.1.1", nil},
+			end:             bundleSpec{"foo.v0.2.0", "foo.v0.1.1", nil},
+			headName:        "foo.v3.0.0",
+			assertion:       require.True,
+			expIntersecting: []bundleSpec{{"foo.v0.2.0", "foo.v0.1.1", nil}},
+		},
+		{
+			name:            "Success/FullGraph",
+			inputBundles:    inputBundles1,
+			start:           bundleSpec{"foo.v0.1.0", "", nil},
+			end:             bundleSpec{"foo.v3.0.0", "foo.v1.1.0", nil},
+			headName:        "foo.v3.0.0",
+			assertion:       require.True,
+			expIntersecting: inputBundles1,
+		},
+		{
+			name:         "Success/SubGraph1",
+			inputBundles: inputBundles1,
+			start:        bundleSpec{"foo.v0.2.0", "foo.v0.1.1", nil},
+			end:          bundleSpec{"foo.v3.0.0", "foo.v1.1.0", nil},
+			headName:     "foo.v3.0.0",
+			assertion:    require.True,
+			expIntersecting: []bundleSpec{
+				{"foo.v0.2.0", "foo.v0.1.1", nil},
+				{"foo.v0.3.0", "foo.v0.2.0", nil},
+				{"foo.v1.0.0", "foo.v0.1.0", []string{"foo.v0.1.1", "foo.v0.2.0", "foo.v0.3.0"}},
+				{"foo.v1.1.0", "foo.v1.0.0", nil},
+				{"foo.v2.0.0", "foo.v0.1.0", []string{"foo.v0.1.1", "foo.v0.2.0", "foo.v0.3.0", "foo.v1.0.0", "foo.v1.1.0"}},
+				{"foo.v2.1.0", "foo.v2.0.0", nil},
+				{"foo.v3.0.0", "foo.v1.1.0", []string{"foo.v2.0.0", "foo.v2.1.0"}},
+			},
+		},
+		{
+			name:         "Success/SubGraph2",
+			inputBundles: inputBundles1,
+			start:        bundleSpec{"foo.v0.1.1", "foo.v0.1.0", nil},
+			end:          bundleSpec{"foo.v0.3.0", "foo.v0.2.0", nil},
+			headName:     "foo.v3.0.0",
+			assertion:    require.True,
+			expIntersecting: []bundleSpec{
+				{"foo.v0.1.1", "foo.v0.1.0", nil},
+				{"foo.v0.2.0", "foo.v0.1.1", nil},
+				{"foo.v0.3.0", "foo.v0.2.0", nil},
+			},
+		},
+		{
+			// This case returns inputBundles1 minus foo.v0.1.0, which is the intersection,
+			// because foo.v2.0.0 is a leaf node (disregarding skips).
+			name:            "Success/SubGraph3",
+			inputBundles:    inputBundles1,
+			start:           bundleSpec{"foo.v0.1.1", "foo.v0.1.0", nil},
+			end:             bundleSpec{"foo.v2.0.0", "foo.v0.1.0", nil},
+			headName:        "foo.v3.0.0",
+			assertion:       require.True,
+			expIntersecting: inputBundles1[1:],
+		},
+		{
+			// Even though foo.v0.4.0 is not in the channel, it's replaces (foo.v0.1.1) is.
+			name:         "Success/ReplacesInChannel",
+			inputBundles: inputBundles1,
+			start:        bundleSpec{"foo.v0.2.0", "foo.v0.1.1", nil},
+			end:          bundleSpec{"foo.v0.4.0", "foo.v0.1.1", nil},
+			headName:     "foo.v3.0.0",
+			assertion:    require.True,
+			expIntersecting: []bundleSpec{
+				{"foo.v0.2.0", "foo.v0.1.1", nil},
+				{"foo.v0.3.0", "foo.v0.2.0", nil},
+				{"foo.v0.4.0", "foo.v0.1.1", nil},
+			},
+		},
+		{
+			name:         "Fail/ReplacesNotInChannel",
+			inputBundles: inputBundles1,
+			start:        bundleSpec{"foo.v0.2.0", "foo.v0.1.1", nil},
+			end:          bundleSpec{"foo.v0.4.0", "foo.v0.1.2", nil},
+			headName:     "foo.v3.0.0",
+			assertion:    require.False,
+		},
+	}
+
+	for _, s := range specs {
+		t.Run(s.name, func(t *testing.T) {
+			// Construct test
+			pkg := &model.Package{Name: "foo"}
+			ch := &model.Channel{Name: "stable", Bundles: make(map[string]*model.Bundle, len(s.inputBundles))}
+			ch.Package = pkg
+			for _, b := range s.inputBundles {
+				ch.Bundles[b.name] = newReplacingBundle(b.name, b.replaces, b.skips, ch, pkg)
+			}
+			expIntersecting := make([]*model.Bundle, len(s.expIntersecting))
+			for i, b := range s.expIntersecting {
+				expIntersecting[i] = newReplacingBundle(b.name, b.replaces, b.skips, ch, pkg)
+			}
+
+			// Ensure the channel is valid and has the correct head.
+			require.NoError(t, ch.Validate())
+			head, err := ch.Head()
+			require.NoError(t, err)
+			require.Equal(t, ch.Bundles[s.headName], head)
+
+			start := newReplacingBundle(s.start.name, s.start.replaces, s.start.skips, ch, pkg)
+			end := newReplacingBundle(s.end.name, s.end.replaces, s.end.skips, ch, pkg)
+			graph := makeUpgradeGraph(ch)
+			intersecting, found := findIntersectingBundles(ch, start, end, graph)
+			s.assertion(t, found)
+			// Compare bundle names only, since mismatch output is too verbose.
+			require.ElementsMatch(t, getBundleNames(expIntersecting), getBundleNames(intersecting))
+		})
+	}
+
+}
+
+func newReplacingBundle(name, replaces string, skips []string, ch *model.Channel, pkg *model.Package) *model.Bundle {
+	split := strings.SplitN(name, ".", 2)
+	nameStr, verStr := split[0], split[1]
+	b := &model.Bundle{
+		Name:     name,
+		Replaces: replaces,
+		Skips:    skips,
+		Channel:  ch,
+		Package:  pkg,
+		Image:    fmt.Sprintf("namespace/%s:%s", nameStr, verStr),
+		Properties: []property.Property{
+			property.MustBuildPackage(ch.Package.Name, verStr),
+		},
+	}
+	return b
+}
+
+func getBundleNames(bundles []*model.Bundle) (names []string) {
+	for _, b := range bundles {
+		names = append(names, b.Name)
+	}
+	sort.Strings(names)
+	return names
+}


### PR DESCRIPTION
**Description of the change:** select the latest bundle that satisfies each dependency (deduplicated).

**Motivation for the change:** currently entire dependency packages are added to `opm alpha diff`'s output. This is not optimal even when not using the resolver because multiple bundles may satisfy the same dependency when the latest bundle (version) will suffice. This implementation does not attempt to resolve dependencies, but pre-groom the set passed to the resolver.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive