### PR TITLE
Fix case-related typo in ConsoleYAMLSample entry in supported_resources

### DIFF
--- a/pkg/lib/bundle/supported_resources.go
+++ b/pkg/lib/bundle/supported_resources.go
@@ -16,7 +16,7 @@ const (
 	PodDisruptionBudgetKind   = "PodDisruptionBudget"
 	PriorityClassKind         = "PriorityClass"
 	VerticalPodAutoscalerKind = "VerticalPodAutoscaler"
-	ConsoleYamlSampleKind     = "ConsoleYamlSample"
+	ConsoleYAMLSampleKind     = "ConsoleYAMLSample"
 )
 
 // Namespaced indicates whether the resource is namespace scoped (true) or cluster-scoped (false).
@@ -40,7 +40,7 @@ var supportedResources = map[string]Namespaced{
 	PodDisruptionBudgetKind:   true,
 	PriorityClassKind:         false,
 	VerticalPodAutoscalerKind: false,
-	ConsoleYamlSampleKind:     false,
+	ConsoleYAMLSampleKind:     false,
 }
 
 // IsSupported checks if the object kind is OLM-supported and if it is namespaced


### PR DESCRIPTION
**Description of the change:**
Fix a typo in the `ConsoleYAMLSample` kind in supported_resources. Running `operator-sdk bundle validate` with `ConsoleYAMLSample` resources in the bundle's `manifests` directory gives `ERRO[0000] Error: Value console.openshift.io/v1, Kind=ConsoleYAMLSample: unsupported media type registry+v1 for bundle object`, whereas the current `supported_resources.go` list of allowed `kinds` contains `ConsoleYamlSample`, so this validation is case-sensitive.

**Motivation for the change:**
Allow the inclusion of `ConsoleYAMLSample` objects in a operator bundles.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

