### PR TITLE
Fix upstream-opm-builder build error due to rate limiting

### DIFF
--- a/upstream-opm-builder.Dockerfile
+++ b/upstream-opm-builder.Dockerfile
@@ -3,7 +3,7 @@
 ##             GoReleaser to build and push multi-arch images for opm
 ##
 
-FROM golang:1.16-alpine AS builder
+FROM quay.io/operator-framework/golang:1.16-alpine AS builder
 
 RUN apk update && apk add sqlite build-base git mercurial bash
 WORKDIR /build
@@ -14,7 +14,7 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-$(go env GOARCH) && \
     chmod +x /bin/grpc_health_probe
 
-FROM alpine
+FROM quay.io/operator-framework/alpine
 RUN apk update && apk add ca-certificates
 COPY ["nsswitch.conf", "/etc/nsswitch.conf"]
 COPY --from=builder /build/bin/opm /bin/opm


### PR DESCRIPTION
Dockerhub has some pretty severe rate limiting now, so most of our builds that rely on docker.io are failing now. To temporarily get around this, I have mirrored the base images to quay.io until we can find a more permanent base image replacement.