### PR TITLE
update default scaffolded opm base image

### DIFF
--- a/opm-example.Dockerfile
+++ b/opm-example.Dockerfile
@@ -1,11 +1,14 @@
-FROM quay.io/operator-framework/upstream-opm-builder AS builder
+# The base image is expected to contain
+# /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
+FROM quay.io/operator-framework/opm:latest
 
-FROM scratch
-LABEL operators.operatorframework.io.index.database.v1=./index.db
-COPY ["nsswitch.conf", "/etc/nsswitch.conf"]
-COPY database ./
-COPY --from=builder /bin/opm /opm
-COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
-EXPOSE 50051
-ENTRYPOINT ["/opm"]
-CMD ["registry", "serve", "--database", "index.db"]
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs"]
+
+# Copy declarative config root into image at /configs
+ADD index /configs
+
+# Set DC-specific label for the location of the DC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs

--- a/pkg/containertools/dockerfilegenerator.go
+++ b/pkg/containertools/dockerfilegenerator.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	DefaultBinarySourceImage = "quay.io/operator-framework/upstream-opm-builder"
+	DefaultBinarySourceImage = "quay.io/operator-framework/opm:latest"
 	DefaultDbLocation        = "/database/index.db"
 	DbLocationLabel          = "operators.operatorframework.io.index.database.v1"
 	ConfigsLocationLabel     = "operators.operatorframework.io.index.configs.v1"

--- a/pkg/containertools/dockerfilegenerator_test.go
+++ b/pkg/containertools/dockerfilegenerator_test.go
@@ -3,11 +3,11 @@ package containertools_test
 import (
 	"testing"
 
-	"github.com/operator-framework/operator-registry/pkg/containertools"
-
 	"github.com/golang/mock/gomock"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+
+	"github.com/operator-framework/operator-registry/pkg/containertools"
 )
 
 func TestGenerateDockerfile(t *testing.T) {
@@ -39,7 +39,7 @@ func TestGenerateDockerfile_EmptyBaseImage(t *testing.T) {
 	defer controller.Finish()
 
 	databasePath := "database/index.db"
-	expectedDockerfile := `FROM quay.io/operator-framework/upstream-opm-builder
+	expectedDockerfile := `FROM quay.io/operator-framework/opm:latest
 LABEL operators.operatorframework.io.index.database.v1=/database/index.db
 ADD database/index.db /database/index.db
 EXPOSE 50051


### PR DESCRIPTION
Signed-off-by: Joe Lanford <joe.lanford@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
- Change default base image scaffolded during `opm index` and `opm alpha
  generate dockerfile` to `quay.io/operator-framework/opm:latest`
- update opm-example.Dockerfile to reflect this change (and to focus on
  file-based configs rather than sqlite databases)

**Motivation for the change:**
The new upstream base image for `opm` is multi-arch, `:latest` points to a tagged release (instead of master), and the image build is tested on every PR from github actions, making image build failures during tag pushes less likely.

See also: https://github.com/operator-framework/operator-sdk/pull/5171

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
