### PR TITLE
updated dockerfile generator to build index images from scratch

### DIFF
--- a/pkg/containertools/dockerfilegenerator.go
+++ b/pkg/containertools/dockerfilegenerator.go
@@ -43,13 +43,16 @@ func (g *IndexDockerfileGenerator) GenerateIndexDockerfile(binarySourceImage, da
 	g.Logger.Info("Generating dockerfile")
 
 	// From
-	dockerfile += fmt.Sprintf("FROM %s\n", binarySourceImage)
+	dockerfile += fmt.Sprintf("FROM %s AS builder\n\n", binarySourceImage)
+	dockerfile += fmt.Sprintf("FROM scratch\n")
 
 	// Labels
 	dockerfile += fmt.Sprintf("LABEL %s=%s\n", DbLocationLabel, DefaultDbLocation)
 
 	// Content
-	dockerfile += fmt.Sprintf("ADD %s %s\n", databasePath, DefaultDbLocation)
+	dockerfile += fmt.Sprintf("COPY %s %s\n", databasePath, DefaultDbLocation)
+	dockerfile += fmt.Sprintf("COPY --from=builder /bin/opm /bin/opm\n")
+	dockerfile += fmt.Sprintf("COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe\n")
 	dockerfile += fmt.Sprintf("EXPOSE 50051\n")
 	dockerfile += fmt.Sprintf("ENTRYPOINT [\"/bin/opm\"]\n")
 	dockerfile += fmt.Sprintf("CMD [\"registry\", \"serve\", \"--database\", \"%s\"]\n", DefaultDbLocation)


### PR DESCRIPTION
Signed-off-by: Sid Kattoju <skattoju@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Fix for #765 

**Motivation for the change:**
Index image is being built from an alpine base instead of from scratch. This became an issue because some vulnerabilities were found in the base alpine image and resulted in things not passing the certification pipeline.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
