### PR TITLE
handle deprecating branch points

### DIFF
--- a/alpha/action/render_test.go
+++ b/alpha/action/render_test.go
@@ -792,7 +792,7 @@ func generateSqliteFile(path string, imageMap map[image.Reference]string) error 
 		return err
 	}
 
-	populator := registry.NewDirectoryPopulator(loader, graphLoader, dbQuerier, imageMap, nil, false)
+	populator := registry.NewDirectoryPopulator(loader, graphLoader, dbQuerier, imageMap, nil)
 	if err := populator.Populate(registry.ReplacesMode); err != nil {
 		return err
 	}

--- a/pkg/lib/registry/registry.go
+++ b/pkg/lib/registry/registry.go
@@ -165,7 +165,7 @@ func populate(ctx context.Context, loader registry.Load, graphLoader registry.Gr
 		return err
 
 	}
-	populator := registry.NewDirectoryPopulator(loader, graphLoader, querier, unpackedImageMap, overwrittenBundles, overwrite)
+	populator := registry.NewDirectoryPopulator(loader, graphLoader, querier, unpackedImageMap, overwrittenBundles)
 
 	if err := populator.Populate(mode); err != nil {
 
@@ -258,7 +258,7 @@ func (r RegistryUpdater) PruneFromRegistry(request PruneFromRegistryRequest) err
 	}
 	defer db.Close()
 
-	dbLoader, err := sqlite.NewSQLLiteLoader(db)
+	dbLoader, err := sqlite.NewDeprecationAwareLoader(db)
 	if err != nil {
 		return err
 	}
@@ -311,7 +311,7 @@ func (r RegistryUpdater) DeprecateFromRegistry(request DeprecateFromRegistryRequ
 	}
 	defer db.Close()
 
-	dbLoader, err := sqlite.NewSQLLiteLoader(db)
+	dbLoader, err := sqlite.NewDeprecationAwareLoader(db)
 	if err != nil {
 		return err
 	}
@@ -460,7 +460,7 @@ func isDeprecated(ctx context.Context, q *sqlite.SQLQuerier, bundle registry.Bun
 * eg:  [1.0.2 (alpha, stable)] <- 1.0.1 (alpha)
 * When 1.0.2 in alpha and stable channels is added replacing 1.0.1, 1.0.1's presence will only be marked as expected on
 * the alpha channel, not on the inherited stable channel.
-*/
+ */
 // expectedGraphBundles returns a set of package-channel-bundle tuples that MUST be present following an add.
 func expectedGraphBundles(imagesToAdd []*registry.Bundle, graphLoader registry.GraphLoader, overwrite bool) (map[string]*registry.Package, error) {
 	expectedBundles := map[string]*registry.Package{}

--- a/pkg/lib/registry/registry.go
+++ b/pkg/lib/registry/registry.go
@@ -155,9 +155,6 @@ func populate(ctx context.Context, loader registry.Load, graphLoader registry.Gr
 			if overwritten == "" {
 				return fmt.Errorf("index add --overwrite-latest is only supported when using bundle images")
 			}
-			if len(overwrittenBundles[img.Bundle.Package]) == 0 {
-				overwrittenBundles[img.Bundle.Package] = []string{}
-			}
 			overwrittenBundles[img.Bundle.Package] = append(overwrittenBundles[img.Bundle.Package], img.Bundle.Name)
 		}
 	}

--- a/pkg/lib/registry/registry.go
+++ b/pkg/lib/registry/registry.go
@@ -446,6 +446,7 @@ func isDeprecated(ctx context.Context, q *sqlite.SQLQuerier, bundle registry.Bun
 	return false, nil
 }
 
+// expectedGraphBundles returns a set of package-channel-bundle tuples that MUST be present following an add.
 /* opm index add drops bundles that replace a channel head, and since channel head selection heuristics
 * choose the bundle with the greatest semver as the channel head, any bundle that replaces such a bundle
 * will be dropped from the graph following an add.
@@ -457,11 +458,10 @@ func isDeprecated(ctx context.Context, q *sqlite.SQLQuerier, bundle registry.Bun
 *
 * Overwritten bundles will only be verified on the channels of the newly added version.
 * Any inherited channels due to addition of a new bundle on its tail bundles may not be verified
-* eg:  [1.0.2 (alpha, stable)] <- 1.0.1 (alpha)
+* eg:  1.0.1 (alpha) <-[1.0.2 (alpha, stable)]
 * When 1.0.2 in alpha and stable channels is added replacing 1.0.1, 1.0.1's presence will only be marked as expected on
 * the alpha channel, not on the inherited stable channel.
  */
-// expectedGraphBundles returns a set of package-channel-bundle tuples that MUST be present following an add.
 func expectedGraphBundles(imagesToAdd []*registry.Bundle, graphLoader registry.GraphLoader, overwrite bool) (map[string]*registry.Package, error) {
 	expectedBundles := map[string]*registry.Package{}
 	for _, bundle := range imagesToAdd {

--- a/pkg/lib/registry/registry_test.go
+++ b/pkg/lib/registry/registry_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/operator-framework/operator-registry/pkg/registry/registryfakes"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -26,6 +25,7 @@ import (
 	"github.com/operator-framework/operator-registry/pkg/image"
 	"github.com/operator-framework/operator-registry/pkg/lib/bundle"
 	"github.com/operator-framework/operator-registry/pkg/registry"
+	"github.com/operator-framework/operator-registry/pkg/registry/registryfakes"
 	"github.com/operator-framework/operator-registry/pkg/sqlite"
 	"github.com/operator-framework/operator-registry/pkg/sqlite/sqlitefakes"
 )
@@ -526,9 +526,6 @@ func TestCheckForBundles(t *testing.T) {
 						if step.action == actionOverwrite {
 							img, err := registry.NewImageInput(image.SimpleReference(name), dir)
 							require.NoError(t, err)
-							if _, ok := overwriteRefs[img.Bundle.Package]; ok {
-								overwriteRefs[img.Bundle.Package] = make([]string, 0)
-							}
 							overwriteRefs[img.Bundle.Package] = append(overwriteRefs[img.Bundle.Package], name)
 						}
 					}
@@ -646,7 +643,7 @@ func TestExpectedGraphBundles(t *testing.T) {
 			wantErr:     fmt.Errorf("graphLoader error"),
 		},
 		{
-			description: "newBundle",
+			description: "NewPackage",
 			graphLoader: &registryfakes.FakeGraphLoader{GenerateStub: func(string) (*registry.Package, error) { return nil, registry.ErrPackageNotInDatabase }},
 			bundles:     []*registry.Bundle{testBundle},
 			wantGraphBundles: map[string]*registry.Package{

--- a/pkg/lib/registry/registry_test.go
+++ b/pkg/lib/registry/registry_test.go
@@ -351,8 +351,8 @@ type bundleDir struct {
 
 func TestCheckForBundles(t *testing.T) {
 	type step struct {
-		bundles map[string]bundleDir
-		action  int
+		bundles  map[string]bundleDir
+		action   int
 		expected map[string]*registry.Package
 	}
 	const (
@@ -404,8 +404,8 @@ func TestCheckForBundles(t *testing.T) {
 					action: actionAdd,
 					expected: map[string]*registry.Package{
 						"testpkg": {
-							Name:           "testpkg",
-							Channels:       map[string]registry.Channel{
+							Name: "testpkg",
+							Channels: map[string]registry.Channel{
 								"alpha": {
 									Nodes: map[registry.BundleKey]map[registry.BundleKey]struct{}{
 										registry.BundleKey{
@@ -479,8 +479,8 @@ func TestCheckForBundles(t *testing.T) {
 					action: actionAdd,
 					expected: map[string]*registry.Package{
 						"testpkg": {
-							Name:           "testpkg",
-							Channels:       map[string]registry.Channel{
+							Name: "testpkg",
+							Channels: map[string]registry.Channel{
 								"stable": {
 									Nodes: map[registry.BundleKey]map[registry.BundleKey]struct{}{
 										registry.BundleKey{
@@ -511,8 +511,8 @@ func TestCheckForBundles(t *testing.T) {
 					action: actionDeprecate,
 					expected: map[string]*registry.Package{
 						"testpkg": {
-							Name:           "testpkg",
-							Channels:       map[string]registry.Channel{
+							Name: "testpkg",
+							Channels: map[string]registry.Channel{
 								"stable": {
 									Nodes: map[registry.BundleKey]map[registry.BundleKey]struct{}{
 										registry.BundleKey{
@@ -536,8 +536,8 @@ func TestCheckForBundles(t *testing.T) {
 						"ignoreDeprecated-1.2.0": {
 							csvSpec: json.RawMessage(`{"version":"1.2.0","replaces":""}`),
 							annotations: registry.Annotations{
-								PackageName: "testpkg",
-								Channels:    "alpha",
+								PackageName:        "testpkg",
+								Channels:           "alpha",
 								DefaultChannelName: "alpha",
 							},
 							version: "1.2.0",
@@ -546,8 +546,8 @@ func TestCheckForBundles(t *testing.T) {
 					action: actionOverwrite,
 					expected: map[string]*registry.Package{
 						"testpkg": {
-							Name:           "testpkg",
-							Channels:       map[string]registry.Channel{
+							Name: "testpkg",
+							Channels: map[string]registry.Channel{
 								"stable": {
 									Nodes: map[registry.BundleKey]map[registry.BundleKey]struct{}{
 										registry.BundleKey{
@@ -618,8 +618,7 @@ func TestCheckForBundles(t *testing.T) {
 						graphLoader,
 						query,
 						refs,
-						overwriteRefs,
-						true).Populate(registry.ReplacesMode))
+						overwriteRefs).Populate(registry.ReplacesMode))
 
 				}
 				err = checkForBundles(context.TODO(), query, graphLoader, step.expected)

--- a/pkg/lib/registry/registry_test.go
+++ b/pkg/lib/registry/registry_test.go
@@ -683,34 +683,27 @@ func TestExpectedGraphBundles(t *testing.T) {
 	testBundle, err := registry.NewBundleFromStrings("testBundle", "0.0.1", "testPkg", "default", "default", "")
 	require.NoError(t, err)
 	testBundle.BundleImage = "testImage"
-	testBundlePkg := &registry.Package{
-		Name: "testPkg",
-		Channels: map[string]registry.Channel{
-			"default": {
-				Nodes: map[registry.BundleKey]map[registry.BundleKey]struct{}{
-					registry.BundleKey{
-						BundlePath: "testImage",
-						Version:    "0.0.1",
-						CsvName:    "testBundle",
-					}: nil,
-				},
-			},
-		},
+	testBundleKey := registry.BundleKey{
+		BundlePath: testBundle.BundleImage,
+		Version:    "0.0.1",
+		CsvName:    testBundle.Name,
 	}
-	testBundleDifferentChannelPkg := &registry.Package{
-		Name: "testPkg",
-		Channels: map[string]registry.Channel{
-			"alpha": {
-				Nodes: map[registry.BundleKey]map[registry.BundleKey]struct{}{
-					registry.BundleKey{
-						BundlePath: "testImage",
-						Version:    "0.0.1",
-						CsvName:    "testBundle",
-					}: nil,
-				},
-			},
-		},
+	newTestPackage := func(name string, channelEntries map[string]registry.BundleKey) *registry.Package {
+		channels := map[string]registry.Channel{}
+		for channelName, node := range channelEntries {
+			if _, ok := channels[channelName]; !ok {
+				channels[channelName] = registry.Channel{
+					Nodes: map[registry.BundleKey]map[registry.BundleKey]struct{}{},
+				}
+			}
+			channels[channelName].Nodes[node] = nil
+		}
+		return &registry.Package{
+			Name:     name,
+			Channels: channels,
+		}
 	}
+
 	tests := []struct {
 		description      string
 		graphLoader      registry.GraphLoader
@@ -730,22 +723,26 @@ func TestExpectedGraphBundles(t *testing.T) {
 			graphLoader: &registryfakes.FakeGraphLoader{GenerateStub: func(string) (*registry.Package, error) { return nil, registry.ErrPackageNotInDatabase }},
 			bundles:     []*registry.Bundle{testBundle},
 			wantGraphBundles: map[string]*registry.Package{
-				"testPkg": testBundlePkg,
+				"testPkg": newTestPackage("testPkg", map[string]registry.BundleKey{"default": testBundleKey}),
 			},
 		},
 		{
 			description: "OverwriteWithoutFlag",
-			graphLoader: &registryfakes.FakeGraphLoader{GenerateStub: func(string) (*registry.Package, error) { return testBundleDifferentChannelPkg, nil }},
-			bundles:     []*registry.Bundle{testBundle},
-			wantErr:     registry.BundleImageAlreadyAddedErr{ErrorString: fmt.Sprintf("Bundle %s already exists", testBundle.BundleImage)},
+			graphLoader: &registryfakes.FakeGraphLoader{GenerateStub: func(string) (*registry.Package, error) {
+				return newTestPackage("testPkg", map[string]registry.BundleKey{"alpha": testBundleKey}), nil
+			}},
+			bundles: []*registry.Bundle{testBundle},
+			wantErr: registry.BundleImageAlreadyAddedErr{ErrorString: fmt.Sprintf("Bundle %s already exists", testBundle.BundleImage)},
 		},
 		{
 			description: "OverwriteWithFlag",
-			graphLoader: &registryfakes.FakeGraphLoader{GenerateStub: func(string) (*registry.Package, error) { return testBundleDifferentChannelPkg, nil }},
-			bundles:     []*registry.Bundle{testBundle},
-			overwrite:   true,
+			graphLoader: &registryfakes.FakeGraphLoader{GenerateStub: func(string) (*registry.Package, error) {
+				return newTestPackage("testPkg", map[string]registry.BundleKey{"alpha": testBundleKey}), nil
+			}},
+			bundles:   []*registry.Bundle{testBundle},
+			overwrite: true,
 			wantGraphBundles: map[string]*registry.Package{
-				"testPkg": testBundlePkg,
+				"testPkg": newTestPackage("testPkg", map[string]registry.BundleKey{"default": testBundleKey}),
 			},
 		},
 	}

--- a/pkg/registry/interface.go
+++ b/pkg/registry/interface.go
@@ -15,6 +15,7 @@ type Load interface {
 	RemoveStrandedBundles() error
 	DeprecateBundle(path string) error
 	ClearNonHeadBundles() error
+	RemoveOverwrittenChannelHead(pkg, bundle string) error
 }
 
 type BundleSender interface {

--- a/pkg/registry/interface.go
+++ b/pkg/registry/interface.go
@@ -15,7 +15,6 @@ type Load interface {
 	RemoveStrandedBundles() error
 	DeprecateBundle(path string) error
 	ClearNonHeadBundles() error
-	RemoveOverwrittenChannelHead(pkg, bundle string) error
 }
 
 type BundleSender interface {
@@ -104,4 +103,8 @@ type GraphLoader interface {
 // RegistryPopulator populates a registry.
 type RegistryPopulator interface {
 	Populate() error
+}
+
+type HeadOverwriter interface {
+	RemoveOverwrittenChannelHead(pkg, bundle string) error
 }

--- a/pkg/registry/populator.go
+++ b/pkg/registry/populator.go
@@ -153,9 +153,7 @@ func (i *DirectoryPopulator) loadManifests(imagesToAdd []*ImageInput, mode Mode)
 				}
 				// delete old head bundle and swap it with the previous real bundle in its replaces chain
 				if err := i.loader.RemoveOverwrittenChannelHead(pkg, imgToDelete[0]); err != nil {
-
 					return err
-
 				}
 			}
 		}

--- a/pkg/registry/populator.go
+++ b/pkg/registry/populator.go
@@ -146,13 +146,19 @@ func (i *DirectoryPopulator) loadManifests(imagesToAdd []*ImageInput, mode Mode)
 
 		// globalSanityCheck should have verified this to be a head without anything replacing it
 		// and that we have a single overwrite per package
-		for pkg, imgToDelete := range i.overwrittenImages {
-			if len(imgToDelete) == 0 {
-				continue
-			}
-			// delete old head bundle and swap it with the previous real bundle in its replaces chain
-			if err := i.loader.RemoveOverwrittenChannelHead(pkg, imgToDelete[0]); err != nil {
-				return err
+
+		if len(i.overwrittenImages) > 0 {
+			if overwriter, ok := i.loader.(HeadOverwriter); ok {
+				// Assume loader has some way to handle overwritten heads if HeadOverwriter isn't implemented explicitly
+				for pkg, imgToDelete := range i.overwrittenImages {
+					if len(imgToDelete) == 0 {
+						continue
+					}
+					// delete old head bundle and swap it with the previous real bundle in its replaces chain
+					if err := overwriter.RemoveOverwrittenChannelHead(pkg, imgToDelete[0]); err != nil {
+						return err
+					}
+				}
 			}
 		}
 

--- a/pkg/registry/populator.go
+++ b/pkg/registry/populator.go
@@ -20,22 +20,22 @@ type Dependencies struct {
 
 // DirectoryPopulator loads an unpacked operator bundle from a directory into the database.
 type DirectoryPopulator struct {
-	loader          Load
-	graphLoader     GraphLoader
-	querier         Query
-	imageDirMap     map[image.Reference]string
-	overwriteDirMap map[string]map[image.Reference]string
-	overwrite       bool
+	loader            Load
+	graphLoader       GraphLoader
+	querier           Query
+	imageDirMap       map[image.Reference]string
+	overwrittenImages map[string][]string
+	overwrite         bool
 }
 
-func NewDirectoryPopulator(loader Load, graphLoader GraphLoader, querier Query, imageDirMap map[image.Reference]string, overwriteDirMap map[string]map[image.Reference]string, overwrite bool) *DirectoryPopulator {
+func NewDirectoryPopulator(loader Load, graphLoader GraphLoader, querier Query, imageDirMap map[image.Reference]string, overwrittenImages map[string][]string, overwrite bool) *DirectoryPopulator {
 	return &DirectoryPopulator{
-		loader:          loader,
-		graphLoader:     graphLoader,
-		querier:         querier,
-		imageDirMap:     imageDirMap,
-		overwriteDirMap: overwriteDirMap,
-		overwrite:       overwrite,
+		loader:            loader,
+		graphLoader:       graphLoader,
+		querier:           querier,
+		imageDirMap:       imageDirMap,
+		overwrittenImages: overwrittenImages,
+		overwrite:         overwrite,
 	}
 }
 
@@ -52,24 +52,11 @@ func (i *DirectoryPopulator) Populate(mode Mode) error {
 		imagesToAdd = append(imagesToAdd, imageInput)
 	}
 
-	imagesToReAdd := make([]*ImageInput, 0)
-	for pkg := range i.overwriteDirMap {
-		for to, from := range i.overwriteDirMap[pkg] {
-			imageInput, err := NewImageInput(to, from)
-			if err != nil {
-				errs = append(errs, err)
-				continue
-			}
-
-			imagesToReAdd = append(imagesToReAdd, imageInput)
-		}
-	}
-
 	if len(errs) > 0 {
 		return utilerrors.NewAggregate(errs)
 	}
 
-	err := i.loadManifests(imagesToAdd, imagesToReAdd, mode)
+	err := i.loadManifests(imagesToAdd, mode)
 	if err != nil {
 		return err
 	}
@@ -145,7 +132,7 @@ func (i *DirectoryPopulator) globalSanityCheck(imagesToAdd []*ImageInput) error 
 	return utilerrors.NewAggregate(errs)
 }
 
-func (i *DirectoryPopulator) loadManifests(imagesToAdd []*ImageInput, imagesToReAdd []*ImageInput, mode Mode) error {
+func (i *DirectoryPopulator) loadManifests(imagesToAdd []*ImageInput, mode Mode) error {
 	// global sanity checks before insertion
 	if err := i.globalSanityCheck(imagesToAdd); err != nil {
 		return err
@@ -153,17 +140,26 @@ func (i *DirectoryPopulator) loadManifests(imagesToAdd []*ImageInput, imagesToRe
 
 	switch mode {
 	case ReplacesMode:
-		for pkg := range i.overwriteDirMap {
-			// TODO: If this succeeds but the add fails there will be a disconnect between
-			// the registry and the index. Loading the bundles in a single transactions as
-			// described above would allow us to do the removable in that same transaction
-			// and ensure that rollback is possible.
-			if err := i.loader.RemovePackage(pkg); err != nil {
-				return err
+		// TODO: If this succeeds but the add fails there will be a disconnect between
+		// the registry and the index. Loading the bundles in a single transactions as
+		// described above would allow us to do the removable in that same transaction
+		// and ensure that rollback is possible.
+		if i.overwrite {
+			// globalSanityCheck should have verified this to be a head without anything replacing it
+			// and that we have a single overwrite per package
+			for pkg, imgToDelete := range i.overwrittenImages {
+				if len(imgToDelete) == 0 {
+					continue
+				}
+				// delete old head bundle and swap it with the previous real bundle in its replaces chain
+				if err := i.loader.RemoveOverwrittenChannelHead(pkg, imgToDelete[0]); err != nil {
+
+					return err
+
+				}
 			}
 		}
-
-		return i.loadManifestsReplaces(append(imagesToAdd, imagesToReAdd...))
+		return i.loadManifestsReplaces(imagesToAdd)
 	case SemVerMode:
 		for _, image := range imagesToAdd {
 			if err := i.loadManifestsSemver(image.Bundle, false); err != nil {

--- a/pkg/registry/populator_test.go
+++ b/pkg/registry/populator_test.go
@@ -77,7 +77,7 @@ func createAndPopulateDB(db *sql.DB) (*sqlite.SQLQuerier, error) {
 			graphLoader,
 			query,
 			refMap,
-			map[string][]string{}, false).Populate(registry.ReplacesMode)
+			nil).Populate(registry.ReplacesMode)
 	}
 	names := []string{"etcd.0.9.0", "etcd.0.9.2", "prometheus.0.22.2", "prometheus.0.14.0", "prometheus.0.15.0"}
 	if err := populate(names); err != nil {
@@ -503,7 +503,7 @@ func TestImageLoading(t *testing.T) {
 					graphLoader,
 					query,
 					map[image.Reference]string{i.ref: i.dir},
-					map[string][]string{}, false)
+					nil)
 				require.NoError(t, p.Populate(registry.ReplacesMode))
 			}
 			add := registry.NewDirectoryPopulator(
@@ -511,7 +511,7 @@ func TestImageLoading(t *testing.T) {
 				graphLoader,
 				query,
 				map[image.Reference]string{tt.addImage.ref: tt.addImage.dir},
-				map[string][]string{}, false)
+				nil)
 			err = add.Populate(registry.ReplacesMode)
 			if tt.wantErr {
 				require.True(t, checkAggErr(err, tt.err))
@@ -720,8 +720,7 @@ func TestDirectoryPopulator(t *testing.T) {
 			graphLoader,
 			query,
 			bundles,
-			map[string][]string{},
-			false).Populate(registry.ReplacesMode)
+			nil).Populate(registry.ReplacesMode)
 	}
 	add := map[image.Reference]string{
 		image.SimpleReference("quay.io/test/etcd.0.9.2"):        "../../bundles/etcd.0.9.2",
@@ -1637,9 +1636,7 @@ func TestAddAfterDeprecate(t *testing.T) {
 					graphLoader,
 					query,
 					addRefs,
-					overwrite,
-					len(overwrite) > 0,
-				).Populate(registry.ReplacesMode)
+					overwrite).Populate(registry.ReplacesMode)
 
 			}
 			// Initialize index with some bundles
@@ -2055,8 +2052,7 @@ func TestOverwrite(t *testing.T) {
 					graphLoader,
 					query,
 					bundles,
-					overwrites,
-					true).Populate(registry.ReplacesMode)
+					overwrites).Populate(registry.ReplacesMode)
 			}
 			require.NoError(t, populate(tt.args.firstAdd, nil))
 
@@ -2886,7 +2882,7 @@ func TestSubstitutesFor(t *testing.T) {
 					graphLoader,
 					query,
 					refMap,
-					map[string][]string{}, false).Populate(registry.ReplacesMode)
+					nil).Populate(registry.ReplacesMode)
 			}
 			// Initialize index with some bundles
 			require.NoError(t, populate(tt.args.bundles))
@@ -3010,7 +3006,7 @@ func TestEnableAlpha(t *testing.T) {
 					graphLoader,
 					query,
 					refMap,
-					map[string][]string{}, false).Populate(registry.ReplacesMode)
+					nil).Populate(registry.ReplacesMode)
 			}
 			require.Equal(t, tt.expected.err, populate(tt.args.bundles))
 		})

--- a/pkg/sqlite/load.go
+++ b/pkg/sqlite/load.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"github.com/operator-framework/operator-registry/alpha/property"
 	"strings"
 
 	"github.com/blang/semver"
@@ -1614,7 +1613,7 @@ func (s *sqlLoader) rmStrandedDeprecated(tx *sql.Tx) error {
 	}
 
 	packagePropertiesQuery := `select distinct operatorbundle_name, value from properties where type = ?`
-	rows, err = s.db.Query(packagePropertiesQuery, property.TypePackage)
+	rows, err = s.db.Query(packagePropertiesQuery, registry.PackageType)
 	if err != nil {
 		return err
 	}
@@ -1633,7 +1632,7 @@ func (s *sqlLoader) rmStrandedDeprecated(tx *sql.Tx) error {
 			return fmt.Errorf("invalid package property on %v: %v", bundle, value)
 		}
 
-		var prop property.Package
+		var prop registry.PackageProperty
 		if err := json.Unmarshal([]byte(value.String), &prop); err != nil {
 			return err
 		}

--- a/pkg/sqlite/load.go
+++ b/pkg/sqlite/load.go
@@ -644,6 +644,16 @@ func (s *sqlLoader) addPackageChannels(tx *sql.Tx, manifest registry.PackageMani
 				break
 			}
 
+			deprecated, err := s.deprecated(tx, channelEntryCSVName)
+			if err != nil {
+				errs = append(errs, err)
+				break
+			}
+			if deprecated {
+				// The package is truncated below this point, we're done!
+				break
+			}
+
 			for _, skip := range skips {
 				// add dummy channel entry for the skipped version
 				skippedChannelEntry, err := addChannelEntry.Exec(c.Name, manifest.PackageName, skip, depth)
@@ -705,15 +715,6 @@ func (s *sqlLoader) addPackageChannels(tx *sql.Tx, manifest registry.PackageMani
 			}
 			if _, err = addReplaces.Exec(replacedID, currentID); err != nil {
 				errs = append(errs, err)
-				break
-			}
-			deprecated, err := s.deprecated(tx, channelEntryCSVName)
-			if err != nil {
-				errs = append(errs, err)
-				break
-			}
-			if deprecated {
-				// The package is truncated below this point, we're done!
 				break
 			}
 			if _, _, _, err := s.getBundleSkipsReplacesVersion(tx, replaces); err != nil {

--- a/pkg/sqlite/load_test.go
+++ b/pkg/sqlite/load_test.go
@@ -424,6 +424,42 @@ func TestDeprecationAwareLoader(t *testing.T) {
 				},
 			},
 		},
+		{
+			description: "DeprecateTruncateRemoveDeprecatedChannelHeadOnPackageRemoval",
+			fields: fields{
+				bundles: []*registry.Bundle{
+					withBundleImage("quay.io/my/bundle-a", newBundle(t, "csv-a", "pkg-0", []string{"a"}, newUnstructuredCSV(t, "csv-a", ""))),
+					withBundleImage("quay.io/my/bundle-aa", newBundle(t, "csv-aa", "pkg-0", []string{"a"}, newUnstructuredCSV(t, "csv-aa", "csv-a"))),
+					withBundleImage("quay.io/my/bundle-aaa", newBundle(t, "csv-b", "pkg-0", []string{"b"}, newUnstructuredCSV(t, "csv-b", "csv-a"))),
+				},
+				pkgs: []registry.PackageManifest{
+					{
+						PackageName: "pkg-0",
+						Channels: []registry.PackageChannel{
+							{
+								Name:           "a",
+								CurrentCSVName: "csv-aa",
+							},
+							{
+								Name:           "b",
+								CurrentCSVName: "csv-b",
+							},
+						},
+						DefaultChannelName: "b",
+					},
+				},
+				deprecatedPaths: []string{
+					"quay.io/my/bundle-aa",
+				},
+			},
+			args: args{
+				pkg: "pkg0",
+			},
+			expected: expected{
+				err: nil,
+				deprecated: map[string]struct{}{},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/sqlite/load_test.go
+++ b/pkg/sqlite/load_test.go
@@ -1112,7 +1112,7 @@ func TestRemoveOverwrittenChannelHead(t *testing.T) {
 				// Throw away any errors loading packages (not testing this)
 				store.AddPackageChannels(pkg)
 			}
-			err = store.RemoveOverwrittenChannelHead(tt.args.pkg, tt.args.bundle)
+			err = store.(registry.HeadOverwriter).RemoveOverwrittenChannelHead(tt.args.pkg, tt.args.bundle)
 			if tt.expected.err != nil {
 				require.EqualError(t, err, tt.expected.err.Error())
 			} else {

--- a/pkg/sqlite/load_test.go
+++ b/pkg/sqlite/load_test.go
@@ -798,13 +798,11 @@ func TestGetTailFromBundle(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, bundle := range tt.fields.bundles {
-				// Throw away any errors loading bundles (not testing this)
-				store.AddOperatorBundle(bundle)
+				require.NoError(t, store.AddOperatorBundle(bundle))
 			}
 
 			for _, pkg := range tt.fields.pkgs {
-				// Throw away any errors loading packages (not testing this)
-				store.AddPackageChannels(pkg)
+				require.NoError(t, store.AddPackageChannels(pkg))
 			}
 			tx, err := db.Begin()
 			require.NoError(t, err)

--- a/pkg/sqlite/migrations/013_rm_truncated_deprecations.go
+++ b/pkg/sqlite/migrations/013_rm_truncated_deprecations.go
@@ -16,11 +16,11 @@ var rmTruncatedDeprecationsMigration = &Migration{
 	Id: RmTruncatedDeprecationsMigrationKey,
 	Up: func(ctx context.Context, tx *sql.Tx) error {
 
-		// Delete deprecation history for all bundles that no longer exist in the channel_entries table
+		// Delete deprecation history for all bundles that no longer exist in the operatorbundle table
 		// These bundles have been truncated by more recent deprecations and would only confuse future operations on an index;
 		// e.g. adding a previously truncated bundle to a package removed via `opm index|registry rm` would lead to that bundle
 		// being deprecated
-		_, err := tx.ExecContext(ctx, `DELETE FROM deprecated WHERE deprecated.operatorbundle_name NOT IN (SELECT DISTINCT deprecated.operatorbundle_name FROM (deprecated INNER JOIN channel_entry ON deprecated.operatorbundle_name = channel_entry.operatorbundle_name))`)
+		_, err := tx.ExecContext(ctx, `DELETE FROM deprecated WHERE deprecated.operatorbundle_name NOT IN (SELECT DISTINCT deprecated.operatorbundle_name FROM (deprecated INNER JOIN operatorbundle ON deprecated.operatorbundle_name = operatorbundle.name))`)
 
 		return err
 	},

--- a/pkg/sqlite/remove_test.go
+++ b/pkg/sqlite/remove_test.go
@@ -34,7 +34,7 @@ func TestRemover(t *testing.T) {
 			map[image.Reference]string{
 				image.SimpleReference("quay.io/test/" + name): "../../bundles/" + name,
 			},
-			make(map[string]map[image.Reference]string, 0), false).Populate(registry.ReplacesMode)
+			map[string][]string{}, false).Populate(registry.ReplacesMode)
 	}
 	for _, name := range []string{"etcd.0.9.0", "etcd.0.9.2", "prometheus.0.14.0", "prometheus.0.15.0", "prometheus.0.22.2"} {
 		require.NoError(t, populate(name))

--- a/pkg/sqlite/remove_test.go
+++ b/pkg/sqlite/remove_test.go
@@ -34,7 +34,7 @@ func TestRemover(t *testing.T) {
 			map[image.Reference]string{
 				image.SimpleReference("quay.io/test/" + name): "../../bundles/" + name,
 			},
-			map[string][]string{}, false).Populate(registry.ReplacesMode)
+			nil).Populate(registry.ReplacesMode)
 	}
 	for _, name := range []string{"etcd.0.9.0", "etcd.0.9.2", "prometheus.0.14.0", "prometheus.0.15.0", "prometheus.0.22.2"} {
 		require.NoError(t, populate(name))

--- a/pkg/sqlite/stranded_test.go
+++ b/pkg/sqlite/stranded_test.go
@@ -33,7 +33,7 @@ func TestStrandedBundleRemover(t *testing.T) {
 			map[image.Reference]string{
 				image.SimpleReference("quay.io/test/" + name): "./testdata/strandedbundles/" + name,
 			},
-			map[string][]string{}, false).Populate(registry.ReplacesMode)
+			nil).Populate(registry.ReplacesMode)
 	}
 	for _, name := range []string{"prometheus.0.14.0", "prometheus.0.15.0", "prometheus.0.22.2"} {
 		require.NoError(t, populate(name))

--- a/pkg/sqlite/stranded_test.go
+++ b/pkg/sqlite/stranded_test.go
@@ -33,7 +33,7 @@ func TestStrandedBundleRemover(t *testing.T) {
 			map[image.Reference]string{
 				image.SimpleReference("quay.io/test/" + name): "./testdata/strandedbundles/" + name,
 			},
-			make(map[string]map[image.Reference]string, 0), false).Populate(registry.ReplacesMode)
+			map[string][]string{}, false).Populate(registry.ReplacesMode)
 	}
 	for _, name := range []string{"prometheus.0.14.0", "prometheus.0.15.0", "prometheus.0.22.2"} {
 		require.NoError(t, populate(name))


### PR DESCRIPTION
Signed-off-by: Ankita Thomas <ankithom@redhat.com>

`deprecatetruncate` deprecates a bundle path and truncates all bundles that have an upgrade path to the deprecated bundle, either via a skips or replaces entry. 
[![](https://mermaid.ink/img/eyJjb2RlIjoiZ3JhcGggTFJcbkFbQTogc3RhYmxlXVxuQidbQzogMS4wLnhdXG5CJydbQjogMS4wLnhdXG5CW0Q6IHN0YWJsZSwxLjAueF1cbkNbRTogc3RhYmxlLDEuMC5dXG5cbkEgLS0-IEIgLS0-IENcbkInJyAtLT4gQicgLS4tPiBCIFxuXG5jbGFzcyBCJycgZGVwcmVjYXRlZFxuY2xhc3MgQicsQyxCIHRydW5jYXRlZFxuXG5jbGFzc0RlZiBkZXByZWNhdGVkIGZpbGw6I2Y5ZixzdHJva2U6IzMzMyxzdHJva2Utd2lkdGg6NHB4O1xuY2xhc3NEZWYgdHJ1bmNhdGVkIGZpbGw6I2JiZixzdHJva2U6I2Y2NixzdHJva2Utd2lkdGg6MnB4LGNvbG9yOiNmZmYsc3Ryb2tlLWRhc2hhcnJheTogNSA1O1xuIiwibWVybWFpZCI6eyJ0aGVtZSI6ImRlZmF1bHQifSwidXBkYXRlRWRpdG9yIjpmYWxzZSwiYXV0b1N5bmMiOnRydWUsInVwZGF0ZURpYWdyYW0iOmZhbHNlfQ)](https://mermaid-js.github.io/mermaid-live-editor/edit/##eyJjb2RlIjoiZ3JhcGggTFJcbkFbQTogc3RhYmxlXVxuQidbQzogMS4wLnhdXG5CJydbQjogMS4wLnhdXG5CW0Q6IHN0YWJsZSwxLjAueF1cbkNbOiBzdGFibGUsMS4wLl1cblxuQSAtLT4gQiAtLT4gQ1xuQicnIC0tPiBCJyAtLi0-IEIgXG5cbmNsYXNzIEInJyBkZXByZWNhdGVkXG5jbGFzcyBCJyxDLEIgdHJ1bmNhdGVkXG5cbmNsYXNzRGVmIGRlcHJlY2F0ZWQgZmlsbDojZjlmLHN0cm9rZTojMzMzLHN0cm9rZS13aWR0aDo0cHg7XG5jbGFzc0RlZiB0cnVuY2F0ZWQgZmlsbDojYmJmLHN0cm9rZTojZjY2LHN0cm9rZS13aWR0aDoycHgsY29sb3I6I2ZmZixzdHJva2UtZGFzaGFycmF5OiA1IDU7XG4iLCJtZXJtYWlkIjoie1xuICBcInRoZW1lXCI6IFwiZGVmYXVsdFwiXG59IiwidXBkYXRlRWRpdG9yIjpmYWxzZSwiYXV0b1N5bmMiOnRydWUsInVwZGF0ZURpYWdyYW0iOmZhbHNlfQ)

This causes the index to become invalid when one or more truncated tail bundles are branch points, i.e they have paths to other non-deprecated bundles  
e.g, v1.1.0 replaces v1.0.1 which gets truncated on deprecating v1.0.3

This PR now removes tail bundles only from the channels the deprecated bundle belongs to. Bundles are truncated only if they no longer belong to any channel.
[![](https://mermaid.ink/img/eyJjb2RlIjoiZ3JhcGggTFJcbkFbQTogc3RhYmxlXVxuQidbQzogMS4wLnhdXG5CJydbQjogMS4wLnhdXG5CW0Q6IHN0YWJsZV1cbkNbRTogc3RhYmxlXVxuXG5BIC0tPiBCIC0tPiBDXG5CJycgLS0-IEInIC0uLT4gQiBcblxuY2xhc3MgQicnIGRlcHJlY2F0ZWRcbmNsYXNzIEInLCB0cnVuY2F0ZWRcblxuY2xhc3NEZWYgZGVwcmVjYXRlZCBmaWxsOiNmOWYsc3Ryb2tlOiMzMzMsc3Ryb2tlLXdpZHRoOjRweDtcbmNsYXNzRGVmIHRydW5jYXRlZCBmaWxsOiNiYmYsc3Ryb2tlOiNmNjYsc3Ryb2tlLXdpZHRoOjJweCxjb2xvcjojZmZmLHN0cm9rZS1kYXNoYXJyYXk6IDUgNTtcbiIsIm1lcm1haWQiOnsidGhlbWUiOiJkZWZhdWx0In0sInVwZGF0ZUVkaXRvciI6ZmFsc2UsImF1dG9TeW5jIjp0cnVlLCJ1cGRhdGVEaWFncmFtIjpmYWxzZX0)](https://mermaid-js.github.io/mermaid-live-editor/edit/##eyJjb2RlIjoiZ3JhcGggTFJcbkFbQTogc3RhYmxlXVxuQidbQzE6IDEuMC54XVxuQicnW0I6IDEuMC54XVxuQltEOiBzdGFibGVdXG5DW0U6IHN0YWJsZV1cblxuQSAtLT4gQiAtLT4gQ1xuQicnIC0tPiBCJyAtLi0-IEIgXG5cbmNsYXNzIEInJyBkZXByZWNhdGVkXG5jbGFzcyBCJywgdHJ1bmNhdGVkXG5cbmNsYXNzRGVmIGRlcHJlY2F0ZWQgZmlsbDojZjlmLHN0cm9rZTojMzMzLHN0cm9rZS13aWR0aDo0cHg7XG5jbGFzc0RlZiB0cnVuY2F0ZWQgZmlsbDojYmJmLHN0cm9rZTojZjY2LHN0cm9rZS13aWR0aDoycHgsY29sb3I6I2ZmZixzdHJva2UtZGFzaGFycmF5OiA1IDU7XG4iLCJtZXJtYWlkIjoie1xuICBcInRoZW1lXCI6IFwiZGVmYXVsdFwiXG59IiwidXBkYXRlRWRpdG9yIjpmYWxzZSwiYXV0b1N5bmMiOnRydWUsInVwZGF0ZURpYWdyYW0iOmZhbHNlfQ)

It also switches to using the `operatorbundle` table to remove truncated bundles from the `deprecated` table to handle deprecating channel heads (which get removed from the `channel_entry` table to avoid removing deprecated channels showing up in console).

To avoid the multiple channel head problem that comes from regenerating such a graph in `--overwrite-latest`, the PR also modifies `--overwrite-latest` to only readd the bundle that is overwritten - the remaining graph is preserved.

This also stops opm add's graph generation from traversing down a replaces chain past the first deprecated entry.