### PR TITLE
Mark GetBundleForChannel as deprecated and trim its response.

### DIFF
--- a/pkg/api/registry.proto
+++ b/pkg/api/registry.proto
@@ -8,7 +8,9 @@ service Registry {
 	rpc ListPackages(ListPackageRequest) returns (stream PackageName) {}
 	rpc GetPackage(GetPackageRequest) returns (Package) {}
 	rpc GetBundle(GetBundleRequest) returns (Bundle) {}
-	rpc GetBundleForChannel(GetBundleInChannelRequest) returns (Bundle) {}
+	rpc GetBundleForChannel(GetBundleInChannelRequest) returns (Bundle) {
+		option deprecated = true;
+	}
 	rpc GetChannelEntriesThatReplace(GetAllReplacementsRequest) returns (stream ChannelEntry) {}
 	rpc GetBundleThatReplaces(GetReplacementRequest) returns (Bundle) {}
 	rpc GetChannelEntriesThatProvide(GetAllProvidersRequest) returns (stream ChannelEntry) {}

--- a/pkg/registry/interface.go
+++ b/pkg/registry/interface.go
@@ -37,7 +37,10 @@ type GRPCQuery interface {
 	// Get a bundle by its package name, channel name and csv name from the index
 	GetBundle(ctx context.Context, pkgName, channelName, csvName string) (*api.Bundle, error)
 
-	// Get the bundle in the specified package at the head of the specified channel
+	// Get the bundle in the specified package at the head of the
+	// specified channel. DEPRECATED. Returned bundles may have
+	// only the "name" and "csvJson" fields populated in order to
+	// support legacy usage.
 	GetBundleForChannel(ctx context.Context, pkgName string, channelName string) (*api.Bundle, error)
 
 	// Get all channel entries that say they replace this one

--- a/pkg/registry/populator_test.go
+++ b/pkg/registry/populator_test.go
@@ -171,7 +171,11 @@ func TestQuerierForImage(t *testing.T) {
 			{Group: "testapi.coreos.com", Version: "v1", Kind: "testapi"},
 		},
 	}
-	EqualBundles(t, *expectedBundle, *etcdBundleByChannel)
+	bareGetBundleForChannelResult := &api.Bundle{
+		CsvName: expectedBundle.CsvName,
+		CsvJson: expectedBundle.CsvJson + "\n",
+	}
+	EqualBundles(t, *bareGetBundleForChannelResult, *etcdBundleByChannel)
 
 	etcdBundle, err := store.GetBundle(context.TODO(), "etcd", "alpha", "etcdoperator.v0.9.2")
 	require.NoError(t, err)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -216,7 +216,13 @@ func testGetBundle(addr string, expected *api.Bundle) func(*testing.T) {
 }
 
 func TestGetBundleForChannel(t *testing.T) {
-	t.Run("Sqlite", testGetBundleForChannel(dbAddress, etcdoperator_v0_9_2("alpha", false, false)))
+	{
+		b := etcdoperator_v0_9_2("alpha", false, false)
+		t.Run("Sqlite", testGetBundleForChannel(dbAddress, &api.Bundle{
+			CsvName: b.CsvName,
+			CsvJson: b.CsvJson + "\n",
+		}))
+	}
 	t.Run("DeclarativeConfig", testGetBundleForChannel(cfgAddress, etcdoperator_v0_9_2("alpha", false, true)))
 }
 

--- a/pkg/sqlite/configmap_test.go
+++ b/pkg/sqlite/configmap_test.go
@@ -175,7 +175,11 @@ func TestQuerierForConfigmap(t *testing.T) {
 			"{\"apiVersion\":\"apiextensions.k8s.io/v1beta1\",\"kind\":\"CustomResourceDefinition\",\"metadata\":{\"creationTimestamp\":null,\"name\":\"etcdbackups.etcd.database.coreos.com\"},\"spec\":{\"group\":\"etcd.database.coreos.com\",\"names\":{\"kind\":\"EtcdBackup\",\"listKind\":\"EtcdBackupList\",\"plural\":\"etcdbackups\",\"singular\":\"etcdbackup\"},\"scope\":\"Namespaced\",\"version\":\"v1beta2\",\"versions\":[{\"name\":\"v1beta2\",\"served\":true,\"storage\":true}]},\"status\":{\"acceptedNames\":{\"kind\":\"\",\"plural\":\"\"},\"conditions\":null,\"storedVersions\":null}}",
 			"{\"apiVersion\":\"apiextensions.k8s.io/v1beta1\",\"kind\":\"CustomResourceDefinition\",\"metadata\":{\"creationTimestamp\":null,\"name\":\"etcdrestores.etcd.database.coreos.com\"},\"spec\":{\"group\":\"etcd.database.coreos.com\",\"names\":{\"kind\":\"EtcdRestore\",\"listKind\":\"EtcdRestoreList\",\"plural\":\"etcdrestores\",\"singular\":\"etcdrestore\"},\"scope\":\"Namespaced\",\"version\":\"v1beta2\",\"versions\":[{\"name\":\"v1beta2\",\"served\":true,\"storage\":true}]},\"status\":{\"acceptedNames\":{\"kind\":\"\",\"plural\":\"\"},\"conditions\":null,\"storedVersions\":null}}"},
 	}
-	EqualBundles(t, *expectedBundle, *etcdBundleByChannel)
+	bareGetBundleForChannelResult := &api.Bundle{
+		CsvName: expectedBundle.CsvName,
+		CsvJson: expectedBundle.CsvJson + "\n",
+	}
+	EqualBundles(t, *bareGetBundleForChannelResult, *etcdBundleByChannel)
 
 	etcdBundle, err := store.GetBundle(context.TODO(), "etcd", "alpha", "etcdoperator.v0.9.2")
 	require.NoError(t, err)

--- a/pkg/sqlite/directory_test.go
+++ b/pkg/sqlite/directory_test.go
@@ -180,7 +180,11 @@ func TestQuerierForDirectory(t *testing.T) {
 			{Group: "etcd.database.coreos.com", Version: "v1beta2", Kind: "EtcdCluster", Plural: "etcdclusters"},
 		},
 	}
-	EqualBundles(t, *expectedBundle, *etcdBundleByChannel)
+	bareGetBundleForChannelResult := &api.Bundle{
+		CsvName: expectedBundle.CsvName,
+		CsvJson: expectedBundle.CsvJson + "\n",
+	}
+	EqualBundles(t, *bareGetBundleForChannelResult, *etcdBundleByChannel)
 
 	etcdBundle, err := store.GetBundle(context.TODO(), "etcd", "alpha", "etcdoperator.v0.9.2")
 	require.NoError(t, err)


### PR DESCRIPTION
The RPC api.Registry/GetBundleForChannel is consumed only by
package-server and by declarative index conversion. Neither reads any
field other than CsvName and CsvJson. The package-server generates one
call to this RPC per channel per package per catalog and is
responsible for needlessly large CPU utilization and resident set
sizes on registry pods. Removing the additional per-request processing
and database queries that populate unused fields makes the registry
server better able to absorb the bursty load from package-server.

Before:

```
$ ghz -d '{"pkgName":"mongodb-enterprise","channelName":"stable"}' --insecure --concurrency=50 --duration=10s --call=api.Registry/GetBundleForChannel localhost:50051; top -b -n1 | grep opm

Summary:
  Count:	14677
  Total:	10.00 s
  Slowest:	164.41 ms
  Fastest:	2.81 ms
  Average:	34.00 ms
  Requests/sec:	1467.34

Response time histogram:
  2.808   [1]    |
  18.968  [3046] |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  35.128  [5288] |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  51.289  [3780] |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  67.449  [1771] |∎∎∎∎∎∎∎∎∎∎∎∎∎
  83.609  [553]  |∎∎∎∎
  99.769  [143]  |∎
  115.929 [38]   |
  132.089 [5]    |
  148.249 [1]    |
  164.409 [2]    |

Latency distribution:
  10 % in 9.80 ms 
  25 % in 21.44 ms 
  50 % in 31.29 ms 
  75 % in 45.75 ms 
  90 % in 59.09 ms 
  95 % in 67.55 ms 
  99 % in 86.49 ms 

Status code distribution:
  [OK]            14628 responses   
  [Unavailable]   49 responses      

Error distribution:
  [49]   rpc error: code = Unavailable desc = transport is closing   

 518843 user  20   0 6576700 128252  30376 S  12.5   0.4   2:56.35 opm
```

After:

```
$ ghz -d '{"pkgName":"mongodb-enterprise","channelName":"stable"}' --insecure --concurrency=50 --duration=10s --call=api.Registry/GetBundleForChannel localhost:50051; top -b -n1 | grep opm

Summary:
  Count:	80470
  Total:	10.01 s
  Slowest:	47.58 ms
  Fastest:	0.18 ms
  Average:	6.16 ms
  Requests/sec:	8040.87

Response time histogram:
  0.185  [1]     |
  4.924  [54268] |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  9.663  [3217]  |∎∎
  14.402 [4495]  |∎∎∎
  19.141 [10180] |∎∎∎∎∎∎∎∎
  23.880 [6790]  |∎∎∎∎∎
  28.619 [1223]  |∎
  33.358 [198]   |
  38.097 [37]    |
  42.836 [11]    |
  47.575 [1]     |

Latency distribution:
  10 % in 0.33 ms 
  25 % in 0.49 ms 
  50 % in 1.31 ms 
  75 % in 13.15 ms 
  90 % in 19.23 ms 
  95 % in 21.35 ms 
  99 % in 25.41 ms 

Status code distribution:
  [OK]            80421 responses   
  [Unavailable]   49 responses      

Error distribution:
  [49]   rpc error: code = Unavailable desc = transport is closing   

 518256 user  20   0 5986076  82300  30704 S   6.2   0.3   2:52.65 opm
```