### PR TITLE
migrate: add subcommand to migrate sqlite catalogs to file-based catalogs

### DIFF
--- a/alpha/action/migrate.go
+++ b/alpha/action/migrate.go
@@ -1,0 +1,99 @@
+package action
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+	"github.com/operator-framework/operator-registry/pkg/image"
+)
+
+type Migrate struct {
+	CatalogRef string
+	OutputDir  string
+
+	WriteFunc WriteFunc
+	FileExt   string
+	Registry  image.Registry
+}
+
+type WriteFunc func(config declcfg.DeclarativeConfig, w io.Writer) error
+
+func (m Migrate) Run(ctx context.Context) error {
+	entries, err := ioutil.ReadDir(m.OutputDir)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if len(entries) > 0 {
+		return fmt.Errorf("output dir %q must be empty", m.OutputDir)
+	}
+
+	r := Render{
+		Refs: []string{m.CatalogRef},
+
+		// Only allow sqlite images and files to be migrated. Other types cannot
+		// always be migrated cleanly because they may contain file references.
+		// Rendered sqlite databases never contain file references.
+		AllowedRefMask: RefSqliteImage | RefSqliteFile,
+
+		skipSqliteDeprecationLog: true,
+	}
+	if m.Registry != nil {
+		r.Registry = m.Registry
+	}
+
+	cfg, err := r.Run(ctx)
+	if err != nil {
+		return fmt.Errorf("render catalog image: %w", err)
+	}
+
+	return writeToFS(*cfg, m.OutputDir, m.WriteFunc, m.FileExt)
+}
+
+func writeToFS(cfg declcfg.DeclarativeConfig, rootDir string, writeFunc WriteFunc, fileExt string) error {
+	channelsByPackage := map[string][]declcfg.Channel{}
+	for _, c := range cfg.Channels {
+		channelsByPackage[c.Package] = append(channelsByPackage[c.Package], c)
+	}
+	bundlesByPackage := map[string][]declcfg.Bundle{}
+	for _, b := range cfg.Bundles {
+		bundlesByPackage[b.Package] = append(bundlesByPackage[b.Package], b)
+	}
+
+	if err := os.MkdirAll(rootDir, 0777); err != nil {
+		return err
+	}
+
+	for _, p := range cfg.Packages {
+		fcfg := declcfg.DeclarativeConfig{
+			Packages: []declcfg.Package{p},
+			Channels: channelsByPackage[p.Name],
+			Bundles:  bundlesByPackage[p.Name],
+		}
+		pkgDir := filepath.Join(rootDir, p.Name)
+		if err := os.MkdirAll(pkgDir, 0777); err != nil {
+			return err
+		}
+		filename := filepath.Join(pkgDir, fmt.Sprintf("catalog%s", fileExt))
+		if err := writeFile(fcfg, filename, writeFunc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeFile(cfg declcfg.DeclarativeConfig, filename string, writeFunc WriteFunc) error {
+	buf := &bytes.Buffer{}
+	if err := writeFunc(cfg, buf); err != nil {
+		return fmt.Errorf("write to buffer for %q: %v", filename, err)
+	}
+	if err := ioutil.WriteFile(filename, buf.Bytes(), 0666); err != nil {
+		return fmt.Errorf("write file %q: %v", filename, err)
+	}
+	return nil
+}

--- a/alpha/action/migrate_test.go
+++ b/alpha/action/migrate_test.go
@@ -1,0 +1,341 @@
+package action_test
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/operator-framework/operator-registry/alpha/action"
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+	"github.com/operator-framework/operator-registry/pkg/containertools"
+	"github.com/operator-framework/operator-registry/pkg/image"
+	"github.com/operator-framework/operator-registry/pkg/lib/bundle"
+)
+
+func TestMigrate(t *testing.T) {
+	type spec struct {
+		name          string
+		migrate       action.Migrate
+		expectedFiles map[string]string
+		expectErr     error
+	}
+
+	sqliteBundles := map[image.Reference]string{
+		image.SimpleReference("test.registry/foo-operator/foo-bundle:v0.1.0"): "testdata/foo-bundle-v0.1.0",
+		image.SimpleReference("test.registry/foo-operator/foo-bundle:v0.2.0"): "testdata/foo-bundle-v0.2.0",
+		image.SimpleReference("test.registry/bar-operator/bar-bundle:v0.1.0"): "testdata/bar-bundle-v0.1.0",
+		image.SimpleReference("test.registry/bar-operator/bar-bundle:v0.2.0"): "testdata/bar-bundle-v0.2.0",
+	}
+
+	tmpDir := t.TempDir()
+	dbFile := filepath.Join(tmpDir, "index.db")
+	err := generateSqliteFile(dbFile, sqliteBundles)
+	require.NoError(t, err)
+
+	reg, err := newMigrateRegistry(sqliteBundles)
+	require.NoError(t, err)
+
+	specs := []spec{
+		{
+			name: "SqliteImage/Success",
+			migrate: action.Migrate{
+				CatalogRef: "test.registry/migrate/catalog:sqlite",
+				OutputDir:  filepath.Join(tmpDir, "sqlite-image"),
+				WriteFunc:  declcfg.WriteYAML,
+				FileExt:    ".yaml",
+				Registry:   reg,
+			},
+			expectedFiles: map[string]string{
+				"foo/catalog.yaml": migrateFooCatalog(),
+				"bar/catalog.yaml": migrateBarCatalog(),
+			},
+		},
+		{
+			name: "SqliteFile/Success",
+			migrate: action.Migrate{
+				CatalogRef: dbFile,
+				OutputDir:  filepath.Join(tmpDir, "sqlite-file"),
+				WriteFunc:  declcfg.WriteYAML,
+				FileExt:    ".yaml",
+				Registry:   reg,
+			},
+			expectedFiles: map[string]string{
+				"foo/catalog.yaml": migrateFooCatalog(),
+				"bar/catalog.yaml": migrateBarCatalog(),
+			},
+		},
+		{
+			name: "DeclcfgImage/Failure",
+			migrate: action.Migrate{
+				CatalogRef: "test.registry/foo-operator/foo-index-declcfg:v0.2.0",
+				OutputDir:  filepath.Join(tmpDir, "declcfg-image"),
+				WriteFunc:  declcfg.WriteYAML,
+				FileExt:    ".yaml",
+				Registry:   reg,
+			},
+			expectErr: action.ErrNotAllowed,
+		},
+		{
+			name: "DeclcfgDir/Failure",
+			migrate: action.Migrate{
+				CatalogRef: "testdata/foo-index-v0.2.0-declcfg",
+				OutputDir:  filepath.Join(tmpDir, "declcfg-dir"),
+				WriteFunc:  declcfg.WriteYAML,
+				FileExt:    ".yaml",
+				Registry:   reg,
+			},
+			expectErr: action.ErrNotAllowed,
+		},
+		{
+			name: "BundleImage/Failure",
+			migrate: action.Migrate{
+				CatalogRef: "test.registry/foo-operator/foo-bundle:v0.1.0",
+				OutputDir:  filepath.Join(tmpDir, "bundle-image"),
+				WriteFunc:  declcfg.WriteYAML,
+				FileExt:    ".yaml",
+				Registry:   reg,
+			},
+			expectErr: action.ErrNotAllowed,
+		},
+	}
+	for _, s := range specs {
+		t.Run(s.name, func(t *testing.T) {
+			err := s.migrate.Run(context.Background())
+			require.ErrorIs(t, err, s.expectErr)
+			for file, expectedData := range s.expectedFiles {
+				path := filepath.Join(s.migrate.OutputDir, file)
+				actualData, err := os.ReadFile(path)
+				require.NoError(t, err)
+				fmt.Println(string(actualData))
+				require.Equal(t, expectedData, string(actualData))
+			}
+		})
+	}
+}
+
+func newMigrateRegistry(imageMap map[image.Reference]string) (image.Registry, error) {
+	subSqliteImage, err := generateSqliteFS(imageMap)
+	if err != nil {
+		return nil, err
+	}
+
+	subDeclcfgImage, err := fs.Sub(declcfgImage, "testdata/foo-index-v0.2.0-declcfg")
+	if err != nil {
+		return nil, err
+	}
+
+	subBundleImageV1, err := fs.Sub(bundleImageV1, "testdata/foo-bundle-v0.1.0")
+	if err != nil {
+		return nil, err
+	}
+
+	reg := &image.MockRegistry{RemoteImages: map[image.Reference]*image.MockImage{
+		image.SimpleReference("test.registry/migrate/catalog:sqlite"): {
+			Labels: map[string]string{
+				containertools.DbLocationLabel: "/database/index.db",
+			},
+			FS: subSqliteImage,
+		},
+		image.SimpleReference("test.registry/foo-operator/foo-index-declcfg:v0.2.0"): {
+			Labels: map[string]string{
+				"operators.operatorframework.io.index.configs.v1": "/foo",
+			},
+			FS: subDeclcfgImage,
+		},
+		image.SimpleReference("test.registry/foo-operator/foo-bundle:v0.1.0"): {
+			Labels: map[string]string{
+				bundle.PackageLabel: "foo",
+			},
+			FS: subBundleImageV1,
+		},
+	}}
+
+	return reg, nil
+}
+
+func migrateFooCatalog() string {
+	return `---
+defaultChannel: beta
+name: foo
+schema: olm.package
+---
+entries:
+- name: foo.v0.1.0
+  skipRange: <0.1.0
+- name: foo.v0.2.0
+  replaces: foo.v0.1.0
+  skipRange: <0.2.0
+  skips:
+  - foo.v0.1.1
+  - foo.v0.1.2
+name: beta
+package: foo
+schema: olm.channel
+---
+entries:
+- name: foo.v0.1.0
+  skipRange: <0.1.0
+- name: foo.v0.2.0
+  replaces: foo.v0.1.0
+  skipRange: <0.2.0
+  skips:
+  - foo.v0.1.1
+  - foo.v0.1.2
+name: stable
+package: foo
+schema: olm.channel
+---
+image: test.registry/foo-operator/foo-bundle:v0.1.0
+name: foo.v0.1.0
+package: foo
+properties:
+- type: olm.gvk
+  value:
+    group: test.foo
+    kind: Foo
+    version: v1
+- type: olm.gvk.required
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: foo
+    version: 0.1.0
+- type: olm.package.required
+  value:
+    packageName: bar
+    versionRange: <0.1.0
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsib2xtLnNraXBSYW5nZSI6Ilx1MDAzYzAuMS4wIn0sIm5hbWUiOiJmb28udjAuMS4wIn0sInNwZWMiOnsiY3VzdG9tcmVzb3VyY2VkZWZpbml0aW9ucyI6eyJvd25lZCI6W3siZ3JvdXAiOiJ0ZXN0LmZvbyIsImtpbmQiOiJGb28iLCJuYW1lIjoiZm9vcy50ZXN0LmZvbyIsInZlcnNpb24iOiJ2MSJ9XX0sImRpc3BsYXlOYW1lIjoiRm9vIE9wZXJhdG9yIiwicmVsYXRlZEltYWdlcyI6W3siaW1hZ2UiOiJ0ZXN0LnJlZ2lzdHJ5L2Zvby1vcGVyYXRvci9mb286djAuMS4wIiwibmFtZSI6Im9wZXJhdG9yIn1dLCJ2ZXJzaW9uIjoiMC4xLjAifX0=
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImZvb3MudGVzdC5mb28ifSwic3BlYyI6eyJncm91cCI6InRlc3QuZm9vIiwibmFtZXMiOnsia2luZCI6IkZvbyIsInBsdXJhbCI6ImZvb3MifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MSJ9XX19
+relatedImages:
+- image: test.registry/foo-operator/foo-bundle:v0.1.0
+  name: ""
+- image: test.registry/foo-operator/foo:v0.1.0
+  name: operator
+schema: olm.bundle
+---
+image: test.registry/foo-operator/foo-bundle:v0.2.0
+name: foo.v0.2.0
+package: foo
+properties:
+- type: olm.gvk
+  value:
+    group: test.foo
+    kind: Foo
+    version: v1
+- type: olm.gvk.required
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: foo
+    version: 0.2.0
+- type: olm.package.required
+  value:
+    packageName: bar
+    versionRange: <0.1.0
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsib2xtLnNraXBSYW5nZSI6Ilx1MDAzYzAuMi4wIn0sIm5hbWUiOiJmb28udjAuMi4wIn0sInNwZWMiOnsiY3VzdG9tcmVzb3VyY2VkZWZpbml0aW9ucyI6eyJvd25lZCI6W3siZ3JvdXAiOiJ0ZXN0LmZvbyIsImtpbmQiOiJGb28iLCJuYW1lIjoiZm9vcy50ZXN0LmZvbyIsInZlcnNpb24iOiJ2MSJ9XX0sImRpc3BsYXlOYW1lIjoiRm9vIE9wZXJhdG9yIiwiaW5zdGFsbCI6eyJzcGVjIjp7ImRlcGxveW1lbnRzIjpbeyJuYW1lIjoiZm9vLW9wZXJhdG9yIiwic3BlYyI6eyJ0ZW1wbGF0ZSI6eyJzcGVjIjp7ImNvbnRhaW5lcnMiOlt7ImltYWdlIjoidGVzdC5yZWdpc3RyeS9mb28tb3BlcmF0b3IvZm9vOnYwLjIuMCJ9XSwiaW5pdENvbnRhaW5lcnMiOlt7ImltYWdlIjoidGVzdC5yZWdpc3RyeS9mb28tb3BlcmF0b3IvZm9vLWluaXQ6djAuMi4wIn1dfX19fSx7Im5hbWUiOiJmb28tb3BlcmF0b3ItMiIsInNwZWMiOnsidGVtcGxhdGUiOnsic3BlYyI6eyJjb250YWluZXJzIjpbeyJpbWFnZSI6InRlc3QucmVnaXN0cnkvZm9vLW9wZXJhdG9yL2Zvby0yOnYwLjIuMCJ9XSwiaW5pdENvbnRhaW5lcnMiOlt7ImltYWdlIjoidGVzdC5yZWdpc3RyeS9mb28tb3BlcmF0b3IvZm9vLWluaXQtMjp2MC4yLjAifV19fX19XX0sInN0cmF0ZWd5IjoiZGVwbG95bWVudCJ9LCJyZWxhdGVkSW1hZ2VzIjpbeyJpbWFnZSI6InRlc3QucmVnaXN0cnkvZm9vLW9wZXJhdG9yL2Zvbzp2MC4yLjAiLCJuYW1lIjoib3BlcmF0b3IifSx7ImltYWdlIjoidGVzdC5yZWdpc3RyeS9mb28tb3BlcmF0b3IvZm9vLW90aGVyOnYwLjIuMCIsIm5hbWUiOiJvdGhlciJ9XSwicmVwbGFjZXMiOiJmb28udjAuMS4wIiwic2tpcHMiOlsiZm9vLnYwLjEuMSIsImZvby52MC4xLjIiXSwidmVyc2lvbiI6IjAuMi4wIn19
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImZvb3MudGVzdC5mb28ifSwic3BlYyI6eyJncm91cCI6InRlc3QuZm9vIiwibmFtZXMiOnsia2luZCI6IkZvbyIsInBsdXJhbCI6ImZvb3MifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MSJ9XX19
+relatedImages:
+- image: test.registry/foo-operator/foo-2:v0.2.0
+  name: ""
+- image: test.registry/foo-operator/foo-bundle:v0.2.0
+  name: ""
+- image: test.registry/foo-operator/foo-init-2:v0.2.0
+  name: ""
+- image: test.registry/foo-operator/foo-init:v0.2.0
+  name: ""
+- image: test.registry/foo-operator/foo-other:v0.2.0
+  name: other
+- image: test.registry/foo-operator/foo:v0.2.0
+  name: operator
+schema: olm.bundle
+`
+}
+
+func migrateBarCatalog() string {
+	return `---
+defaultChannel: alpha
+name: bar
+schema: olm.package
+---
+entries:
+- name: bar.v0.1.0
+- name: bar.v0.2.0
+  skipRange: <0.2.0
+  skips:
+  - bar.v0.1.0
+name: alpha
+package: bar
+schema: olm.channel
+---
+image: test.registry/bar-operator/bar-bundle:v0.1.0
+name: bar.v0.1.0
+package: bar
+properties:
+- type: olm.gvk
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: bar
+    version: 0.1.0
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhci52MC4xLjAifSwic3BlYyI6eyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjp7Im93bmVkIjpbeyJncm91cCI6InRlc3QuYmFyIiwia2luZCI6IkJhciIsIm5hbWUiOiJiYXJzLnRlc3QuYmFyIiwidmVyc2lvbiI6InYxYWxwaGExIn1dfSwicmVsYXRlZEltYWdlcyI6W3siaW1hZ2UiOiJ0ZXN0LnJlZ2lzdHJ5L2Jhci1vcGVyYXRvci9iYXI6djAuMS4wIiwibmFtZSI6Im9wZXJhdG9yIn1dLCJ2ZXJzaW9uIjoiMC4xLjAifX0=
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhcnMudGVzdC5iYXIifSwic3BlYyI6eyJncm91cCI6InRlc3QuYmFyIiwibmFtZXMiOnsia2luZCI6IkJhciIsInBsdXJhbCI6ImJhcnMifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MWFscGhhMSJ9XX19
+relatedImages:
+- image: test.registry/bar-operator/bar-bundle:v0.1.0
+  name: ""
+- image: test.registry/bar-operator/bar:v0.1.0
+  name: operator
+schema: olm.bundle
+---
+image: test.registry/bar-operator/bar-bundle:v0.2.0
+name: bar.v0.2.0
+package: bar
+properties:
+- type: olm.gvk
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: bar
+    version: 0.2.0
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsib2xtLnNraXBSYW5nZSI6Ilx1MDAzYzAuMi4wIn0sIm5hbWUiOiJiYXIudjAuMi4wIn0sInNwZWMiOnsiY3VzdG9tcmVzb3VyY2VkZWZpbml0aW9ucyI6eyJvd25lZCI6W3siZ3JvdXAiOiJ0ZXN0LmJhciIsImtpbmQiOiJCYXIiLCJuYW1lIjoiYmFycy50ZXN0LmJhciIsInZlcnNpb24iOiJ2MWFscGhhMSJ9XX0sInJlbGF0ZWRJbWFnZXMiOlt7ImltYWdlIjoidGVzdC5yZWdpc3RyeS9iYXItb3BlcmF0b3IvYmFyOnYwLjIuMCIsIm5hbWUiOiJvcGVyYXRvciJ9XSwic2tpcHMiOlsiYmFyLnYwLjEuMCJdLCJ2ZXJzaW9uIjoiMC4yLjAifX0=
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhcnMudGVzdC5iYXIifSwic3BlYyI6eyJncm91cCI6InRlc3QuYmFyIiwibmFtZXMiOnsia2luZCI6IkJhciIsInBsdXJhbCI6ImJhcnMifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MWFscGhhMSJ9XX19
+relatedImages:
+- image: test.registry/bar-operator/bar-bundle:v0.2.0
+  name: ""
+- image: test.registry/bar-operator/bar:v0.2.0
+  name: operator
+schema: olm.bundle
+`
+}

--- a/alpha/action/render.go
+++ b/alpha/action/render.go
@@ -52,6 +52,8 @@ type Render struct {
 	Refs           []string
 	Registry       image.Registry
 	AllowedRefMask RefType
+
+	skipSqliteDeprecationLog bool
 }
 
 func nullLogger() *logrus.Entry {
@@ -61,6 +63,10 @@ func nullLogger() *logrus.Entry {
 }
 
 func (r Render) Run(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
+	if r.skipSqliteDeprecationLog {
+		// exhaust once with a no-op function.
+		logDeprecationMessage.Do(func() {})
+	}
 	if r.Registry == nil {
 		reg, err := r.createRegistry()
 		if err != nil {

--- a/alpha/action/render_test.go
+++ b/alpha/action/render_test.go
@@ -704,7 +704,7 @@ func newRegistry() (image.Registry, error) {
 	if err != nil {
 		return nil, err
 	}
-	subBundleImageV1, err := fs.Sub(bundleImageV2, "testdata/foo-bundle-v0.1.0")
+	subBundleImageV1, err := fs.Sub(bundleImageV1, "testdata/foo-bundle-v0.1.0")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/opm/migrate/cmd.go
+++ b/cmd/opm/migrate/cmd.go
@@ -1,0 +1,54 @@
+package migrate
+
+import (
+	"log"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/operator-framework/operator-registry/alpha/action"
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+	"github.com/operator-framework/operator-registry/pkg/sqlite"
+)
+
+func NewCmd() *cobra.Command {
+	var (
+		migrate action.Migrate
+		output  string
+	)
+	cmd := &cobra.Command{
+		Use:   "migrate <indexRef> <outputDir>",
+		Short: "Migrate a sqlite-based index image or database file to a file-based catalog",
+		Long: `Migrate a sqlite-based index image or database file to a file-based catalog.
+
+` + sqlite.DeprecationMessage,
+		Args: cobra.ExactArgs(2),
+		PersistentPreRun: func(_ *cobra.Command, _ []string) {
+			sqlite.LogSqliteDeprecation()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			migrate.CatalogRef = args[0]
+			migrate.OutputDir = args[1]
+
+			switch output {
+			case "yaml":
+				migrate.WriteFunc = declcfg.WriteYAML
+				migrate.FileExt = ".yaml"
+			case "json":
+				migrate.WriteFunc = declcfg.WriteJSON
+				migrate.FileExt = ".json"
+			default:
+				log.Fatalf("invalid --output value %q, expected (json|yaml)", output)
+			}
+
+			logrus.Infof("rendering index %q as file-based catalog", migrate.CatalogRef)
+			if err := migrate.Run(cmd.Context()); err != nil {
+				logrus.New().Fatal(err)
+			}
+			logrus.Infof("wrote rendered file-based catalog to %q\n", migrate.OutputDir)
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&output, "output", "o", "json", "Output format (json|yaml)")
+	return cmd
+}

--- a/cmd/opm/root/cmd.go
+++ b/cmd/opm/root/cmd.go
@@ -7,6 +7,7 @@ import (
 	"github.com/operator-framework/operator-registry/cmd/opm/alpha"
 	"github.com/operator-framework/operator-registry/cmd/opm/index"
 	initcmd "github.com/operator-framework/operator-registry/cmd/opm/init"
+	"github.com/operator-framework/operator-registry/cmd/opm/migrate"
 	"github.com/operator-framework/operator-registry/cmd/opm/registry"
 	"github.com/operator-framework/operator-registry/cmd/opm/render"
 	"github.com/operator-framework/operator-registry/cmd/opm/serve"
@@ -28,7 +29,7 @@ func NewCmd() *cobra.Command {
 		Args: cobra.NoArgs,
 	}
 
-	cmd.AddCommand(registry.NewOpmRegistryCmd(), alpha.NewCmd(), initcmd.NewCmd(), serve.NewCmd(), render.NewCmd(), validate.NewCmd())
+	cmd.AddCommand(registry.NewOpmRegistryCmd(), alpha.NewCmd(), initcmd.NewCmd(), migrate.NewCmd(), serve.NewCmd(), render.NewCmd(), validate.NewCmd())
 	index.AddCommand(cmd)
 	version.AddCommand(cmd)
 


### PR DESCRIPTION
**Description of the change:**
Add `opm migrate` which will convert an sqlite-based catalog (image or db file) into a file-based catalog.

This command is different from the general `render` command in two important ways:
1. It works only on sqlite-based catalogs (this is necessary because it is unsafe to "migrate" file-based catalogs to file-based catalogs. `migrate` writes files in an opinionated location, which could break any relative file references that exist in the input file-based catalog.
2. It writes a full package-based directory structure in the output directory, such that each package in the catalog gets its own file (`render` concatenates everything together into one output stream) 

Note that this command is immediately deprecated because it works with sqlite catalogs, which are deprecated.

**Motivation for the change:**
To help users migrate their existing indexes to a file-based catalog.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
