### PR TITLE
fix(release): upgrade goreleaser so script requests correct checksum file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ export LATEST_IMAGE_OR_EMPTY ?= $(shell \
 	&& echo "$(OPM_IMAGE_REPO):latest" || echo "")
 release: RELEASE_ARGS ?= release --rm-dist --snapshot
 release:
-	./scripts/fetch goreleaser 0.173.2 && ./bin/goreleaser $(RELEASE_ARGS)
+	./scripts/fetch goreleaser 0.177.0 && ./bin/goreleaser $(RELEASE_ARGS)
 
 # tagged-or-empty returns $(OPM_IMAGE_REPO):$(1) when HEAD is assigned a non-prerelease semver tag,
 # otherwise the empty string. An empty string causes goreleaser to skip building


### PR DESCRIPTION
**Description of the change:** upgrade goreleaser to 0.177

**Motivation for the change:** checksum file name changed so the most recent install script is broken. Not sure how to pin the install script url to a version so this fix will work until their script breaks again :frowning_face:.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
