### PR TITLE
test/e2e: Ignore stdout output when checking if podman/docker are present

### DIFF
--- a/test/e2e/opm_test.go
+++ b/test/e2e/opm_test.go
@@ -487,7 +487,7 @@ var _ = Describe("opm", func() {
 	}
 
 	Context("using docker", func() {
-		cmd := exec.Command("docker")
+		cmd := exec.Command("docker", "--version")
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
 			GinkgoT().Logf("container tool docker not found - skipping docker-based opm e2e tests: %v", err)
@@ -497,7 +497,7 @@ var _ = Describe("opm", func() {
 	})
 
 	Context("using podman", func() {
-		cmd := exec.Command("podman", "info")
+		cmd := exec.Command("podman", "--version")
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
 			GinkgoT().Logf("container tool podman not found - skipping podman-based opm e2e tests: %v", err)


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Ignore any stdout output that's returned when attempting to check
whether podman/docker are present when running the e2e suite.

**Motivation for the change:**
There's little need for printing out the `docker --help` or `podman info` stdout output. That command was previously updated to capture stderr to help identify any issues when running the e2e suite locally:

```log
GOFLAGS="-mod=vendor" go run github.com/onsi/ginkgo/ginkgo --v --randomizeAllSpecs --randomizeSuites --race  -tags=json1,kind ./test/e2e -- 
INFO: Using builder at '/usr/bin/docker'


Usage:  docker [OPTIONS] COMMAND

A self-sufficient runtime for containers

Options:
      --config string      Location of client config files (default
                           "/home/runner/.docker")
  -c, --context string     Name of the context to use to connect to the
                           daemon (overrides DOCKER_HOST env var and
                           default context set with "docker context use")
  -D, --debug              Enable debug mode
  -H, --host list          Daemon socket(s) to connect to
  -l, --log-level string   Set the logging level
                           ("debug"|"info"|"warn"|"error"|"fatal")
                           (default "info")
      --tls                Use TLS; implied by --tlsverify
      --tlscacert string   Trust certs signed only by this CA (default
                           "/home/runner/.docker/ca.pem")
      --tlscert string     Path to TLS certificate file (default
                           "/home/runner/.docker/cert.pem")
      --tlskey string      Path to TLS key file (default
                           "/home/runner/.docker/key.pem")
      --tlsverify          Use TLS and verify the remote
  -v, --version            Print version information and quit
...
```

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage 
- [x] Sufficient end-to-end test coverage
- [x] Docs updated or added to `/docs` 
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
