### PR TITLE
opm: build fully static opm binaries/images

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,6 +17,7 @@ builds:
       - all=-trimpath={{ .Env.PWD }}
     ldflags: &build-ldflags
       - -s -w
+      - -extldflags=-static
       - -X {{ .Env.PKG }}/cmd/opm/version.gitCommit={{ .Env.GIT_COMMIT }}
       - -X {{ .Env.PKG }}/cmd/opm/version.opmVersion={{ .Env.OPM_VERSION }}
       - -X {{ .Env.PKG }}/cmd/opm/version.buildDate={{ .Env.BUILD_DATE }}

--- a/release/goreleaser.opm.Dockerfile
+++ b/release/goreleaser.opm.Dockerfile
@@ -3,7 +3,7 @@
 #   and .github/workflows/release.yaml.
 
 FROM --platform=$BUILDPLATFORM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.4 as grpc_health_probe
-FROM gcr.io/distroless/base:debug
+FROM gcr.io/distroless/static:debug
 COPY --from=grpc_health_probe /grpc_health_probe /bin/grpc_health_probe
 COPY ["nsswitch.conf", "/etc/nsswitch.conf"]
 COPY opm /bin/opm


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
We typically compile `opm` with --ldflags=`-extldflags=-static`, but that was missed when transposing the Makefile into the opm image's goreleaser configuration.

This PR adds that flag to goreleaser builds and updates the base image of `quay.io/operator-framework/opm` from `gcr.io/distroless/base:debug` to `gcr.io/distroless/static:debug`

**Motivation for the change:**
Fix an issue with `opm` binary builds, decrease the size of the `opm` image, and decrease the surface area for vulnerabilities.

Closes #777 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
