### PR TITLE
add warning log entry for removing non-exist package

### DIFF
--- a/pkg/sqlite/load.go
+++ b/pkg/sqlite/load.go
@@ -942,6 +942,9 @@ func (s *sqlLoader) RemovePackage(packageName string) error {
 		if err != nil {
 			return err
 		}
+		if len(csvNames) == 0 {
+			return fmt.Errorf("no package found for packagename %s", packageName)
+		}
 		for _, csvName := range csvNames {
 			if err := s.rmBundle(tx, csvName); err != nil {
 				return err

--- a/pkg/sqlite/remove_test.go
+++ b/pkg/sqlite/remove_test.go
@@ -76,6 +76,10 @@ func TestRemover(t *testing.T) {
 	_, err = query.GetPackage(context.TODO(), "prometheus")
 	require.EqualError(t, err, "package prometheus not found")
 
+	// delete prometheus again
+	err = store.RemovePackage("prometheus")
+	require.EqualError(t, err, "no package found for packagename prometheus")
+
 	// no apis after all packages are removed
 	rows, err = db.QueryContext(context.TODO(), "select * from api")
 	require.NoError(t, err)


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Adding a warning log entry when `opm index rm` is issued for a non-existing package

**Motivation for the change:**
Closes #675 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
