### PR TITLE
opm serve: pre-compute and store api.Bundles to disk; requests read from disk 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ static: build
 
 .PHONY: unit
 unit:
-	$(GO) test -coverprofile=coverage.out $(SPECIFIC_UNIT_TEST) $(TAGS) $(TEST_RACE) -count=1 -v ./pkg/... ./alpha/...
+	$(GO) test -coverprofile=coverage.out $(SPECIFIC_UNIT_TEST) $(TAGS) $(TEST_RACE) -count=1 ./pkg/... ./alpha/...
 
 .PHONY: sanity-check
 sanity-check:

--- a/cmd/opm/serve/serve.go
+++ b/cmd/opm/serve/serve.go
@@ -87,7 +87,11 @@ func (s *serve) run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("could not build index model from declarative config: %v", err)
 	}
-	store := registry.NewQuerier(m)
+	store, err := registry.NewQuerier(m)
+	defer store.Close()
+	if err != nil {
+		return err
+	}
 
 	lis, err := net.Listen("tcp", ":"+s.port)
 	if err != nil {

--- a/pkg/registry/parse.go
+++ b/pkg/registry/parse.go
@@ -6,10 +6,9 @@ import (
 	"io/fs"
 	"strings"
 
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 )
 
 type bundleParser struct {

--- a/pkg/registry/query.go
+++ b/pkg/registry/query.go
@@ -70,6 +70,7 @@ func NewQuerier(packages model.Model) (*Querier, error) {
 					Channel:  ch,
 					Name:     b.Name,
 					Replaces: b.Replaces,
+					Skips:    b.Skips,
 				}
 			}
 		}

--- a/pkg/registry/query_test.go
+++ b/pkg/registry/query_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 )
 
-var testModelQuerier = genTestModelQuerier()
-
 func TestQuerier_GetBundle(t *testing.T) {
+	testModelQuerier := genTestModelQuerier(t)
+	defer testModelQuerier.Close()
 	b, err := testModelQuerier.GetBundle(context.TODO(), "etcd", "singlenamespace-alpha", "etcdoperator.v0.9.4")
 	require.NoError(t, err)
 	require.Equal(t, b.PackageName, "etcd")
@@ -21,6 +21,8 @@ func TestQuerier_GetBundle(t *testing.T) {
 }
 
 func TestQuerier_GetBundleForChannel(t *testing.T) {
+	testModelQuerier := genTestModelQuerier(t)
+	defer testModelQuerier.Close()
 	b, err := testModelQuerier.GetBundleForChannel(context.TODO(), "etcd", "singlenamespace-alpha")
 	require.NoError(t, err)
 	require.NotNil(t, b)
@@ -30,6 +32,8 @@ func TestQuerier_GetBundleForChannel(t *testing.T) {
 }
 
 func TestQuerier_GetBundleThatProvides(t *testing.T) {
+	testModelQuerier := genTestModelQuerier(t)
+	defer testModelQuerier.Close()
 	b, err := testModelQuerier.GetBundleThatProvides(context.TODO(), "etcd.database.coreos.com", "v1beta2", "EtcdBackup")
 	require.NoError(t, err)
 	require.NotNil(t, b)
@@ -39,6 +43,8 @@ func TestQuerier_GetBundleThatProvides(t *testing.T) {
 }
 
 func TestQuerier_GetBundleThatReplaces(t *testing.T) {
+	testModelQuerier := genTestModelQuerier(t)
+	defer testModelQuerier.Close()
 	b, err := testModelQuerier.GetBundleThatReplaces(context.TODO(), "etcdoperator.v0.9.0", "etcd", "singlenamespace-alpha")
 	require.NoError(t, err)
 	require.NotNil(t, b)
@@ -48,6 +54,8 @@ func TestQuerier_GetBundleThatReplaces(t *testing.T) {
 }
 
 func TestQuerier_GetChannelEntriesThatProvide(t *testing.T) {
+	testModelQuerier := genTestModelQuerier(t)
+	defer testModelQuerier.Close()
 	entries, err := testModelQuerier.GetChannelEntriesThatProvide(context.TODO(), "etcd.database.coreos.com", "v1beta2", "EtcdBackup")
 	require.NoError(t, err)
 	require.NotNil(t, entries)
@@ -92,6 +100,8 @@ func TestQuerier_GetChannelEntriesThatProvide(t *testing.T) {
 }
 
 func TestQuerier_GetChannelEntriesThatReplace(t *testing.T) {
+	testModelQuerier := genTestModelQuerier(t)
+	defer testModelQuerier.Close()
 	entries, err := testModelQuerier.GetChannelEntriesThatReplace(context.TODO(), "etcdoperator.v0.9.0")
 	require.NoError(t, err)
 	require.NotNil(t, entries)
@@ -112,6 +122,8 @@ func TestQuerier_GetChannelEntriesThatReplace(t *testing.T) {
 }
 
 func TestQuerier_GetLatestChannelEntriesThatProvide(t *testing.T) {
+	testModelQuerier := genTestModelQuerier(t)
+	defer testModelQuerier.Close()
 	entries, err := testModelQuerier.GetLatestChannelEntriesThatProvide(context.TODO(), "etcd.database.coreos.com", "v1beta2", "EtcdBackup")
 	require.NoError(t, err)
 	require.NotNil(t, entries)
@@ -132,6 +144,8 @@ func TestQuerier_GetLatestChannelEntriesThatProvide(t *testing.T) {
 }
 
 func TestQuerier_GetPackage(t *testing.T) {
+	testModelQuerier := genTestModelQuerier(t)
+	defer testModelQuerier.Close()
 	p, err := testModelQuerier.GetPackage(context.TODO(), "etcd")
 	require.NoError(t, err)
 	require.NotNil(t, p)
@@ -161,6 +175,8 @@ func TestQuerier_GetPackage(t *testing.T) {
 }
 
 func TestQuerier_ListBundles(t *testing.T) {
+	testModelQuerier := genTestModelQuerier(t)
+	defer testModelQuerier.Close()
 	bundles, err := testModelQuerier.ListBundles(context.TODO())
 	require.NoError(t, err)
 	require.NotNil(t, bundles)
@@ -172,22 +188,27 @@ func TestQuerier_ListBundles(t *testing.T) {
 }
 
 func TestQuerier_ListPackages(t *testing.T) {
+	testModelQuerier := genTestModelQuerier(t)
+	defer testModelQuerier.Close()
 	packages, err := testModelQuerier.ListPackages(context.TODO())
 	require.NoError(t, err)
 	require.NotNil(t, packages)
 	require.Equal(t, 2, len(packages))
 }
 
-func genTestModelQuerier() *Querier {
+func genTestModelQuerier(t *testing.T) *Querier {
+	t.Helper()
+
 	cfg, err := declcfg.LoadFS(validFS)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
+
 	m, err := declcfg.ConvertToModel(*cfg)
-	if err != nil {
-		panic(err)
-	}
-	return NewQuerier(m)
+	require.NoError(t, err)
+
+	reg, err := NewQuerier(m)
+	require.NoError(t, err)
+
+	return reg
 }
 
 var validFS = fstest.MapFS{


### PR DESCRIPTION
Signed-off-by: Joe Lanford <joe.lanford@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
When serving the registry from the model, pre-compute the `api.Bundle` blobs, save them to disk, and reduce the size of the in-memory model to contain only enough to answer requests by looking up and reading bundles from disk.

**Motivation for the change:**
This change provides a major memory optimization. Using a real-world file-based catalog (created by migrating a production sqlite-based catalog), the steady state RSS is reduced from 373Mb to 55Mb, an 85% decrease.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
