### PR TITLE
Update opm commands to specifcy if they don't take args

### DIFF
--- a/cmd/opm/alpha/bundle/build.go
+++ b/cmd/opm/alpha/bundle/build.go
@@ -42,6 +42,7 @@ func newBundleBuildCmd() *cobra.Command {
 		* All manifests yaml must be in the same directory. 
         `,
 		RunE: buildFunc,
+		Args: cobra.NoArgs,
 	}
 
 	bundleBuildCmd.Flags().StringVarP(&buildDir, "directory", "d", "",
@@ -79,7 +80,7 @@ func newBundleBuildCmd() *cobra.Command {
 	return bundleBuildCmd
 }
 
-func buildFunc(cmd *cobra.Command, args []string) error {
+func buildFunc(cmd *cobra.Command, _ []string) error {
 	return bundle.BuildFunc(
 		buildDir,
 		outputDir,

--- a/cmd/opm/alpha/bundle/cmd.go
+++ b/cmd/opm/alpha/bundle/cmd.go
@@ -9,6 +9,7 @@ func NewCmd() *cobra.Command {
 		Use:   "bundle",
 		Short: "Operator bundle commands",
 		Long:  `Generate operator bundle metadata and build bundle image.`,
+		Args:  cobra.NoArgs,
 	}
 
 	runCmd.AddCommand(newBundleGenerateCmd())

--- a/cmd/opm/alpha/bundle/extract.go
+++ b/cmd/opm/alpha/bundle/extract.go
@@ -14,7 +14,7 @@ var extractCmd = &cobra.Command{
 	Short: "Extracts the data in a bundle directory via ConfigMap",
 	Long:  "Extract takes as input a directory containing manifests and writes the per file contents to a ConfipMap",
 
-	PreRunE: func(cmd *cobra.Command, args []string) error {
+	PreRunE: func(cmd *cobra.Command, _ []string) error {
 		if debug, _ := cmd.Flags().GetBool("debug"); debug {
 			logrus.SetLevel(logrus.DebugLevel)
 		}
@@ -22,6 +22,7 @@ var extractCmd = &cobra.Command{
 	},
 
 	RunE: runExtractCmd,
+	Args: cobra.NoArgs,
 }
 
 func init() {
@@ -35,7 +36,7 @@ func init() {
 	extractCmd.MarkPersistentFlagRequired("configmapname")
 }
 
-func runExtractCmd(cmd *cobra.Command, args []string) error {
+func runExtractCmd(cmd *cobra.Command, _ []string) error {
 	manifestsDir, err := cmd.Flags().GetString("manifestsdir")
 	if err != nil {
 		return err

--- a/cmd/opm/alpha/bundle/generate.go
+++ b/cmd/opm/alpha/bundle/generate.go
@@ -23,6 +23,7 @@ func newBundleGenerateCmd() *cobra.Command {
 		* All manifests yaml must be in the same directory.
         `,
 		RunE: generateFunc,
+		Args: cobra.NoArgs,
 	}
 
 	bundleGenerateCmd.Flags().StringVarP(&buildDir, "directory", "d", "",
@@ -48,7 +49,7 @@ func newBundleGenerateCmd() *cobra.Command {
 	return bundleGenerateCmd
 }
 
-func generateFunc(cmd *cobra.Command, args []string) error {
+func generateFunc(cmd *cobra.Command, _ []string) error {
 	return bundle.GenerateFunc(
 		buildDir,
 		outputDir,

--- a/cmd/opm/alpha/bundle/validate.go
+++ b/cmd/opm/alpha/bundle/validate.go
@@ -38,6 +38,7 @@ Optional validators. These validators are disabled by default and can be enabled
 See https://olm.operatorframework.io/docs/tasks/validate-package/#validation for more info.`,
 		Example: `$ opm alpha bundle validate --tag quay.io/test/test-operator:latest --image-builder docker`,
 		RunE:    validateFunc,
+		Args:    cobra.NoArgs,
 	}
 
 	bundleValidateCmd.Flags().StringVarP(&tag, "tag", "t", "",
@@ -52,7 +53,7 @@ See https://olm.operatorframework.io/docs/tasks/validate-package/#validation for
 	return bundleValidateCmd
 }
 
-func validateFunc(cmd *cobra.Command, args []string) error {
+func validateFunc(cmd *cobra.Command, _ []string) error {
 	logger := log.WithFields(log.Fields{"container-tool": containerTool})
 	log.SetLevel(log.DebugLevel)
 

--- a/cmd/opm/alpha/cmd.go
+++ b/cmd/opm/alpha/cmd.go
@@ -14,6 +14,7 @@ func NewCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "alpha",
 		Short:  "Run an alpha subcommand",
+		Args:   cobra.NoArgs,
 	}
 
 	runCmd.AddCommand(

--- a/cmd/opm/index/add.go
+++ b/cmd/opm/index/add.go
@@ -45,13 +45,14 @@ func addIndexAddCmd(parent *cobra.Command) {
 		Use:   "add",
 		Short: "Add operator bundles to an index.",
 		Long:  addLong,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if debug, _ := cmd.Flags().GetBool("debug"); debug {
 				logrus.SetLevel(logrus.DebugLevel)
 			}
 			return nil
 		},
 		RunE: runIndexAddCmdFunc,
+		Args: cobra.NoArgs,
 	}
 
 	indexCmd.Flags().Bool("debug", false, "enable debug logging")
@@ -89,7 +90,7 @@ func addIndexAddCmd(parent *cobra.Command) {
 
 }
 
-func runIndexAddCmdFunc(cmd *cobra.Command, args []string) error {
+func runIndexAddCmdFunc(cmd *cobra.Command, _ []string) error {
 	generate, err := cmd.Flags().GetBool("generate")
 	if err != nil {
 		return err

--- a/cmd/opm/index/cmd.go
+++ b/cmd/opm/index/cmd.go
@@ -16,18 +16,19 @@ func AddCommand(parent *cobra.Command) {
 
 ` + sqlite.DeprecationMessage,
 
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if debug, _ := cmd.Flags().GetBool("debug"); debug {
 				logrus.SetLevel(logrus.DebugLevel)
 			}
 			return nil
 		},
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 			sqlite.LogSqliteDeprecation()
 			if skipTLS, err := cmd.Flags().GetBool("skip-tls"); err == nil && skipTLS {
 				logrus.Warn("--skip-tls flag is set: this mode is insecure and meant for development purposes only.")
 			}
 		},
+		Args: cobra.NoArgs,
 	}
 
 	parent.AddCommand(cmd)

--- a/cmd/opm/index/delete.go
+++ b/cmd/opm/index/delete.go
@@ -17,7 +17,7 @@ func newIndexDeleteCmd() *cobra.Command {
 
 ` + sqlite.DeprecationMessage,
 
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if debug, _ := cmd.Flags().GetBool("debug"); debug {
 				logrus.SetLevel(logrus.DebugLevel)
 			}
@@ -25,6 +25,7 @@ func newIndexDeleteCmd() *cobra.Command {
 		},
 
 		RunE: runIndexDeleteCmdFunc,
+		Args: cobra.NoArgs,
 	}
 
 	indexCmd.Flags().Bool("debug", false, "enable debug logging")
@@ -53,7 +54,7 @@ func newIndexDeleteCmd() *cobra.Command {
 
 }
 
-func runIndexDeleteCmdFunc(cmd *cobra.Command, args []string) error {
+func runIndexDeleteCmdFunc(cmd *cobra.Command, _ []string) error {
 	generate, err := cmd.Flags().GetBool("generate")
 	if err != nil {
 		return err

--- a/cmd/opm/index/deprecatetruncate.go
+++ b/cmd/opm/index/deprecatetruncate.go
@@ -37,13 +37,14 @@ func newIndexDeprecateTruncateCmd() *cobra.Command {
 		Use:    "deprecatetruncate",
 		Short:  "Deprecate and truncate operator bundles from an index.",
 		Long:   deprecateLong,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if debug, _ := cmd.Flags().GetBool("debug"); debug {
 				logrus.SetLevel(logrus.DebugLevel)
 			}
 			return nil
 		},
 		RunE: runIndexDeprecateTruncateCmdFunc,
+		Args: cobra.NoArgs,
 	}
 
 	indexCmd.Flags().Bool("debug", false, "enable debug logging")
@@ -68,7 +69,7 @@ func newIndexDeprecateTruncateCmd() *cobra.Command {
 	return indexCmd
 }
 
-func runIndexDeprecateTruncateCmdFunc(cmd *cobra.Command, args []string) error {
+func runIndexDeprecateTruncateCmdFunc(cmd *cobra.Command, _ []string) error {
 	generate, err := cmd.Flags().GetBool("generate")
 	if err != nil {
 		return err

--- a/cmd/opm/index/export.go
+++ b/cmd/opm/index/export.go
@@ -27,7 +27,7 @@ func newIndexExportCmd() *cobra.Command {
 		Short: "Export an operator from an index into the appregistry format",
 		Long:  exportLong,
 
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if debug, _ := cmd.Flags().GetBool("debug"); debug {
 				logrus.SetLevel(logrus.DebugLevel)
 			}
@@ -35,6 +35,7 @@ func newIndexExportCmd() *cobra.Command {
 		},
 
 		RunE: runIndexExportCmdFunc,
+		Args: cobra.NoArgs,
 	}
 	indexCmd.Flags().Bool("debug", false, "enable debug logging")
 	indexCmd.Flags().StringP("index", "i", "", "index to get package from")
@@ -58,7 +59,7 @@ func newIndexExportCmd() *cobra.Command {
 
 }
 
-func runIndexExportCmdFunc(cmd *cobra.Command, args []string) error {
+func runIndexExportCmdFunc(cmd *cobra.Command, _ []string) error {
 	index, err := cmd.Flags().GetString("index")
 	if err != nil {
 		return err

--- a/cmd/opm/index/prune.go
+++ b/cmd/opm/index/prune.go
@@ -19,7 +19,7 @@ func newIndexPruneCmd() *cobra.Command {
 
 ` + sqlite.DeprecationMessage,
 
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if debug, _ := cmd.Flags().GetBool("debug"); debug {
 				logrus.SetLevel(logrus.DebugLevel)
 			}
@@ -27,6 +27,7 @@ func newIndexPruneCmd() *cobra.Command {
 		},
 
 		RunE: runIndexPruneCmdFunc,
+		Args: cobra.NoArgs,
 	}
 
 	indexCmd.Flags().Bool("debug", false, "enable debug logging")
@@ -53,7 +54,7 @@ func newIndexPruneCmd() *cobra.Command {
 
 }
 
-func runIndexPruneCmdFunc(cmd *cobra.Command, args []string) error {
+func runIndexPruneCmdFunc(cmd *cobra.Command, _ []string) error {
 	generate, err := cmd.Flags().GetBool("generate")
 	if err != nil {
 		return err

--- a/cmd/opm/index/prunestranded.go
+++ b/cmd/opm/index/prunestranded.go
@@ -19,7 +19,7 @@ func newIndexPruneStrandedCmd() *cobra.Command {
 
 ` + sqlite.DeprecationMessage,
 
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if debug, _ := cmd.Flags().GetBool("debug"); debug {
 				logrus.SetLevel(logrus.DebugLevel)
 			}
@@ -27,6 +27,7 @@ func newIndexPruneStrandedCmd() *cobra.Command {
 		},
 
 		RunE: runIndexPruneStrandedCmdFunc,
+		Args: cobra.NoArgs,
 	}
 
 	indexCmd.Flags().Bool("debug", false, "enable debug logging")
@@ -48,7 +49,7 @@ func newIndexPruneStrandedCmd() *cobra.Command {
 
 }
 
-func runIndexPruneStrandedCmdFunc(cmd *cobra.Command, args []string) error {
+func runIndexPruneStrandedCmdFunc(cmd *cobra.Command, _ []string) error {
 	generate, err := cmd.Flags().GetBool("generate")
 	if err != nil {
 		return err

--- a/cmd/opm/registry/add.go
+++ b/cmd/opm/registry/add.go
@@ -21,7 +21,7 @@ func newRegistryAddCmd() *cobra.Command {
 
 ` + sqlite.DeprecationMessage,
 
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if debug, _ := cmd.Flags().GetBool("debug"); debug {
 				logrus.SetLevel(logrus.DebugLevel)
 			}
@@ -29,6 +29,7 @@ func newRegistryAddCmd() *cobra.Command {
 		},
 
 		RunE: addFunc,
+		Args: cobra.NoArgs,
 	}
 
 	rootCmd.Flags().Bool("debug", false, "enable debug logging")
@@ -43,7 +44,7 @@ func newRegistryAddCmd() *cobra.Command {
 	return rootCmd
 }
 
-func addFunc(cmd *cobra.Command, args []string) error {
+func addFunc(cmd *cobra.Command, _ []string) error {
 	permissive, err := cmd.Flags().GetBool("permissive")
 	if err != nil {
 		return err

--- a/cmd/opm/registry/cmd.go
+++ b/cmd/opm/registry/cmd.go
@@ -18,12 +18,13 @@ func NewOpmRegistryCmd() *cobra.Command {
 		PersistentPreRun: func(_ *cobra.Command, _ []string) {
 			sqlite.LogSqliteDeprecation()
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if debug, _ := cmd.Flags().GetBool("debug"); debug {
 				logrus.SetLevel(logrus.DebugLevel)
 			}
 			return nil
 		},
+		Args: cobra.NoArgs,
 	}
 
 	rootCmd.AddCommand(newRegistryServeCmd())

--- a/cmd/opm/registry/mirror.go
+++ b/cmd/opm/registry/mirror.go
@@ -40,6 +40,7 @@ func MirrorCmd() *cobra.Command {
 			}
 			return nil
 		},
+		Args: cobra.ExactArgs(2),
 	}
 	flags := cmd.Flags()
 

--- a/cmd/opm/registry/prune.go
+++ b/cmd/opm/registry/prune.go
@@ -16,7 +16,7 @@ func newRegistryPruneCmd() *cobra.Command {
 
 ` + sqlite.DeprecationMessage,
 
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if debug, _ := cmd.Flags().GetBool("debug"); debug {
 				logrus.SetLevel(logrus.DebugLevel)
 			}
@@ -24,6 +24,7 @@ func newRegistryPruneCmd() *cobra.Command {
 		},
 
 		RunE: runRegistryPruneCmdFunc,
+		Args: cobra.NoArgs,
 	}
 
 	rootCmd.Flags().Bool("debug", false, "enable debug logging")
@@ -37,7 +38,7 @@ func newRegistryPruneCmd() *cobra.Command {
 	return rootCmd
 }
 
-func runRegistryPruneCmdFunc(cmd *cobra.Command, args []string) error {
+func runRegistryPruneCmdFunc(cmd *cobra.Command, _ []string) error {
 	fromFilename, err := cmd.Flags().GetString("database")
 	if err != nil {
 		return err

--- a/cmd/opm/registry/prunestranded.go
+++ b/cmd/opm/registry/prunestranded.go
@@ -16,7 +16,7 @@ func newRegistryPruneStrandedCmd() *cobra.Command {
 
 ` + sqlite.DeprecationMessage,
 
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if debug, _ := cmd.Flags().GetBool("debug"); debug {
 				logrus.SetLevel(logrus.DebugLevel)
 			}
@@ -24,6 +24,7 @@ func newRegistryPruneStrandedCmd() *cobra.Command {
 		},
 
 		RunE: runRegistryPruneStrandedCmdFunc,
+		Args: cobra.NoArgs,
 	}
 
 	rootCmd.Flags().Bool("debug", false, "enable debug logging")
@@ -32,7 +33,7 @@ func newRegistryPruneStrandedCmd() *cobra.Command {
 	return rootCmd
 }
 
-func runRegistryPruneStrandedCmdFunc(cmd *cobra.Command, args []string) error {
+func runRegistryPruneStrandedCmdFunc(cmd *cobra.Command, _ []string) error {
 	fromFilename, err := cmd.Flags().GetString("database")
 	if err != nil {
 		return err

--- a/cmd/opm/registry/rm.go
+++ b/cmd/opm/registry/rm.go
@@ -16,7 +16,7 @@ func newRegistryRmCmd() *cobra.Command {
 
 ` + sqlite.DeprecationMessage,
 
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if debug, _ := cmd.Flags().GetBool("debug"); debug {
 				logrus.SetLevel(logrus.DebugLevel)
 			}
@@ -24,6 +24,7 @@ func newRegistryRmCmd() *cobra.Command {
 		},
 
 		RunE: rmFunc,
+		Args: cobra.NoArgs,
 	}
 
 	rootCmd.Flags().Bool("debug", false, "enable debug logging")
@@ -37,7 +38,7 @@ func newRegistryRmCmd() *cobra.Command {
 	return rootCmd
 }
 
-func rmFunc(cmd *cobra.Command, args []string) error {
+func rmFunc(cmd *cobra.Command, _ []string) error {
 	fromFilename, err := cmd.Flags().GetString("database")
 	if err != nil {
 		return err

--- a/cmd/opm/registry/serve.go
+++ b/cmd/opm/registry/serve.go
@@ -32,7 +32,7 @@ func newRegistryServeCmd() *cobra.Command {
 
 ` + sqlite.DeprecationMessage,
 
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if debug, _ := cmd.Flags().GetBool("debug"); debug {
 				logrus.SetLevel(logrus.DebugLevel)
 			}
@@ -40,6 +40,7 @@ func newRegistryServeCmd() *cobra.Command {
 		},
 
 		RunE: serveFunc,
+		Args: cobra.NoArgs,
 	}
 
 	rootCmd.Flags().Bool("debug", false, "enable debug logging")
@@ -52,7 +53,7 @@ func newRegistryServeCmd() *cobra.Command {
 	return rootCmd
 }
 
-func serveFunc(cmd *cobra.Command, args []string) error {
+func serveFunc(cmd *cobra.Command, _ []string) error {
 	// Immediately set up termination log
 	terminationLogPath, err := cmd.Flags().GetString("termination-log")
 	if err != nil {

--- a/cmd/opm/root/cmd.go
+++ b/cmd/opm/root/cmd.go
@@ -19,12 +19,13 @@ func NewCmd() *cobra.Command {
 		Use:   "opm",
 		Short: "operator package manager",
 		Long:  "CLI to interact with operator-registry and build indexes of operator content",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if debug, _ := cmd.Flags().GetBool("debug"); debug {
 				logrus.SetLevel(logrus.DebugLevel)
 			}
 			return nil
 		},
+		Args: cobra.NoArgs,
 	}
 
 	cmd.AddCommand(registry.NewOpmRegistryCmd(), alpha.NewCmd(), initcmd.NewCmd(), serve.NewCmd(), render.NewCmd(), validate.NewCmd())


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Updating the `opm` binary to specify when a command takes arguments or not. This will prevent typos from successfully running should a user accidentally type args into a command that does not accept them.

**Motivation for the change:**
[Issue 703](https://github.com/operator-framework/operator-registry/issues/703)

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage 
- [x] Sufficient end-to-end test coverage
- [x] Docs updated or added to `/docs` 
- [x] Commit messages sensible and descriptive

Closes 703
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
