### PR TITLE
Update long description indentation for alpha

### DIFF
--- a/cmd/opm/alpha/bundle/build.go
+++ b/cmd/opm/alpha/bundle/build.go
@@ -23,24 +23,23 @@ func newBundleBuildCmd() *cobra.Command {
 		Use:   "build",
 		Short: "Build operator bundle image",
 		Long: `The "opm alpha bundle build" command will generate operator
-        bundle metadata if needed and build bundle image with operator manifest
-        and metadata for a specific version.
+bundle metadata if needed and build bundle image with operator manifest
+and metadata for a specific version.
 
-        For example: The command will generate annotations.yaml metadata plus
-        Dockerfile for bundle image and then build a container image from
-        provided operator bundle manifests generated metadata
-        e.g. "quay.io/example/operator:v0.0.1".
+For example: The command will generate annotations.yaml metadata plus
+Dockerfile for bundle image and then build a container image from
+provided operator bundle manifests generated metadata
+e.g. "quay.io/example/operator:v0.0.1".
 
-        After the build process is completed, a container image would be built
-        locally in docker and available to push to a container registry.
+After the build process is completed, a container image would be built
+locally in docker and available to push to a container registry.
 
-        $ opm alpha bundle build --directory /test/0.1.0/ --tag quay.io/example/operator:v0.1.0 \
-		--package test-operator --channels stable,beta --default stable --overwrite
+$ opm alpha bundle build --directory /test/0.1.0/ --tag quay.io/example/operator:v0.1.0 \
+	--package test-operator --channels stable,beta --default stable --overwrite
 
-		Note:
-		* Bundle image is not runnable.
-		* All manifests yaml must be in the same directory. 
-        `,
+Note:
+* Bundle image is not runnable.
+* All manifests yaml must be in the same directory. `,
 		RunE: buildFunc,
 	}
 

--- a/cmd/opm/alpha/bundle/generate.go
+++ b/cmd/opm/alpha/bundle/generate.go
@@ -14,14 +14,13 @@ func newBundleGenerateCmd() *cobra.Command {
 		Use:   "generate",
 		Short: "Generate operator bundle metadata and Dockerfile",
 		Long: `The "opm alpha bundle generate" command will generate operator
-        bundle metadata if needed and a Dockerfile to build Operator bundle image.
+bundle metadata if needed and a Dockerfile to build Operator bundle image.
 
-        $ opm alpha bundle generate --directory /test/0.1.0/ --package test-operator \
-		--channels stable,beta --default stable
+$ opm alpha bundle generate --directory /test/0.1.0/ --package test-operator \
+	--channels stable,beta --default stable
 
-		Note:
-		* All manifests yaml must be in the same directory.
-        `,
+Note:
+* All manifests yaml must be in the same directory.`,
 		RunE: generateFunc,
 	}
 


### PR DESCRIPTION
Signed-off-by: Tyler Slaton <tyslaton@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Adjusting the spacing of the `alpha` subcommands to have appropriate indentation.

**Motivation for the change:**
<details>
<summary>The output for the alpha bundle command, for example, looks wonky. Click to see.</summary>

```bash
$ ./bin/opm alpha bundle --help
The "opm alpha bundle build" command will generate operator
        bundle metadata if needed and build bundle image with operator manifest
        and metadata for a specific version.

        For example: The command will generate annotations.yaml metadata plus
        Dockerfile for bundle image and then build a container image from
        provided operator bundle manifests generated metadata
        e.g. "quay.io/example/operator:v0.0.1".

        After the build process is completed, a container image would be built
        locally in docker and available to push to a container registry.

        $ opm alpha bundle build --directory /test/0.1.0/ --tag quay.io/example/operator:v0.1.0 \
		--package test-operator --channels stable,beta --default stable --overwrite

		Note:
		* Bundle image is not runnable.
		* All manifests yaml must be in the same directory.
```

</details>


**Reviewer Checklist**
- [X] Implementation matches the proposed design, or proposal is updated to match implementation
- [X] Sufficient unit test coverage 
- [X] Sufficient end-to-end test coverage
- [X] Docs updated or added to `/docs` 
- [X] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
