### PR TITLE
take image domain name from env in e2e test

### DIFF
--- a/test/e2e/bundle_image_test.go
+++ b/test/e2e/bundle_image_test.go
@@ -85,12 +85,12 @@ func buildContainer(tag, dockerfilePath, dockerContext string, w io.Writer) {
 
 var _ = Describe("Launch bundle", func() {
 	namespace := "default"
-	initImage := dockerHost + "/olmtest/init-operator-manifest:test"
 
 	Context("Deploy bundle job", func() {
 		table.DescribeTable("should populate specified configmap", func(bundleName, bundleDirectory string, gzip bool) {
 			// these permissions are only necessary for the e2e (and not OLM using the feature)
 			By("configuring configmap service account")
+			initImage := imageRegistry + "/init-operator-manifest:test"
 			kubeclient, err := kubernetes.NewForConfig(ctx.Ctx().RESTConfig())
 			Expect(err).NotTo(HaveOccurred())
 
@@ -134,7 +134,7 @@ var _ = Describe("Launch bundle", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("building required images")
-			bundleImage := dockerHost + "/olmtest/" + bundleName + ":test"
+			bundleImage := imageRegistry + "/" + bundleName + ":test"
 			buildContainer(initImage, imageDirectory+"serve.Dockerfile", "../../bin", GinkgoWriter)
 			buildContainer(bundleImage, imageDirectory+"bundle.Dockerfile", bundleDirectory, GinkgoWriter)
 

--- a/test/e2e/opm_bundle_test.go
+++ b/test/e2e/opm_bundle_test.go
@@ -53,7 +53,7 @@ var _ = Describe("opm alpha bundle", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Create a bundle ref using the local registry host name and the namespace/name of a bundle we already know the content of
-			bundleRef = host + "/olmtest/kiali@sha256:a1bec450c104ceddbb25b252275eb59f1f1e6ca68e0ced76462042f72f7057d8"
+			bundleRef = host + "/" + imageDomain + "/kiali@sha256:a1bec450c104ceddbb25b252275eb59f1f1e6ca68e0ced76462042f72f7057d8"
 
 			// Generate a checksum of the expected content for the bundle under test
 			bundleChecksum, err = dirhash.HashDir(filepath.Join(goldenFiles, "bundles/kiali"), "", dirhash.DefaultHash)

--- a/test/e2e/opm_test.go
+++ b/test/e2e/opm_test.go
@@ -43,11 +43,11 @@ var (
 	indexTag2  = rand.String(6)
 	indexTag3  = rand.String(6)
 
-	bundleImage = dockerHost + "/olmtest/e2e-bundle"
-	indexImage  = dockerHost + "/olmtest/e2e-index"
-	indexImage1 = dockerHost + "/olmtest/e2e-index:" + indexTag1
-	indexImage2 = dockerHost + "/olmtest/e2e-index:" + indexTag2
-	indexImage3 = dockerHost + "/olmtest/e2e-index:" + indexTag3
+	bundleImage string
+	indexImage  string
+	indexImage1 string
+	indexImage2 string
+	indexImage3 string
 
 	// publishedIndex is an index used to check for regressions in opm's behavior.
 	publishedIndex = os.Getenv("PUBLISHED_INDEX")
@@ -215,6 +215,15 @@ func initialize() error {
 	loader := sqlite.NewSQLLoaderForDirectory(dbLoader, "downloaded")
 	return loader.Populate()
 }
+
+var _ = BeforeEach(func() {
+	bundleImage = imageRegistry + "/e2e-bundle"
+	indexImage = imageRegistry + "/e2e-index"
+	indexImage1 = imageRegistry + "/e2e-index:" + indexTag1
+	indexImage2 = imageRegistry + "/e2e-index:" + indexTag2
+	indexImage3 = imageRegistry + "/e2e-index:" + indexTag3
+
+})
 
 var _ = Describe("opm", func() {
 	IncludeSharedSpecs := func(containerTool string) {


### PR DESCRIPTION
Signed-off-by: akihikokuroda <akihikokuroda2020@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
e2e tests take `IMAGE_DOMAIN` env variable for the domain name of the image.  The default is `olmtest`.  It allows to use the `docker.io` as the registry for the e2e tests like
```
KUBECONFIG="$HOME/.kube/config" DOCKER_REGISTRY_HOST=docker.io IMAGE_DOMAIN="your docker id"  make build e2e
```

**Motivation for the change:**
Closes #764
**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:


-->
