### PR TITLE
Enable cgo in multiarch builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,7 @@ builds:
       - amd64
     env:
       - CC=gcc
+      - CGO_ENABLED=1
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags: &build-flags
       - -tags=json1
@@ -30,6 +31,7 @@ builds:
       - arm64
     env:
       - CC=aarch64-linux-gnu-gcc
+      - CGO_ENABLED=1
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags: *build-flags
     asmflags: *build-asmflags
@@ -44,6 +46,7 @@ builds:
       - ppc64le
     env:
       - CC=powerpc64le-linux-gnu-gcc
+      - CGO_ENABLED=1
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags: *build-flags
     asmflags: *build-asmflags
@@ -58,6 +61,7 @@ builds:
       - s390x
     env:
       - CC=s390x-linux-gnu-gcc
+      - CGO_ENABLED=1
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags: *build-flags
     asmflags: *build-asmflags
@@ -72,6 +76,7 @@ builds:
       - amd64
     env:
       - CC=x86_64-w64-mingw32-gcc-posix
+      - CGO_ENABLED=1
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags: *build-flags
     asmflags: *build-asmflags


### PR DESCRIPTION
**Description of the change:**

Enable cgo in multiarch builds

**Motivation for the change:**

Current builds are not able to read SQLite database due to the lack of CGO.

Closes #792

**Reviewer Checklist**

- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
