### PR TITLE
Use the proper grpc_health_probe command per architectures.

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -65,6 +65,8 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
           registry: quay.io
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
 
       - name: "Run GoReleaser"
         run: make release

--- a/release/goreleaser.opm.Dockerfile
+++ b/release/goreleaser.opm.Dockerfile
@@ -2,7 +2,13 @@
 #   build opm images. See the configurations in .goreleaser.yaml
 #   and .github/workflows/release.yaml.
 
-FROM --platform=$BUILDPLATFORM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.4 as grpc_health_probe
+FROM alpine as grpc_health_probe
+ARG TARGETARCH
+RUN apk update && \
+	apk add curl && \
+	curl --silent --show-error --location --output /grpc_health_probe \
+	https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.5/grpc_health_probe-linux-$TARGETARCH && \
+	chmod 755 /grpc_health_probe
 FROM gcr.io/distroless/static:debug
 COPY --from=grpc_health_probe /grpc_health_probe /bin/grpc_health_probe
 COPY ["nsswitch.conf", "/etc/nsswitch.conf"]


### PR DESCRIPTION
**Description of the change:**

Downloads the proper grpc_health_probe binary for the build
architectures during the release process.
 
**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


Closes #795 
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
