### PR TITLE
render: populate related images even when CSV has none explicitly defined

### DIFF
--- a/alpha/action/render.go
+++ b/alpha/action/render.go
@@ -328,14 +328,12 @@ func getRelatedImages(b *registry.Bundle) ([]declcfg.RelatedImage, error) {
 		return nil, err
 	}
 
-	rawValue, ok := objmap["relatedImages"]
-	if !ok || rawValue == nil {
-		return nil, err
-	}
-
 	var relatedImages []declcfg.RelatedImage
-	if err = json.Unmarshal(*rawValue, &relatedImages); err != nil {
-		return nil, err
+	rawValue, ok := objmap["relatedImages"]
+	if ok && rawValue != nil {
+		if err = json.Unmarshal(*rawValue, &relatedImages); err != nil {
+			return nil, err
+		}
 	}
 
 	// Keep track of the images we've already found, so that we don't add

--- a/alpha/action/render_test.go
+++ b/alpha/action/render_test.go
@@ -473,6 +473,47 @@ func TestRender(t *testing.T) {
 			},
 			assertion: require.NoError,
 		},
+		{
+			name: "Success/BundleImageWithNoCSVRelatedImages",
+			render: action.Render{
+				Refs:     []string{"test.registry/foo-operator/foo-bundle-no-csv-related-images:v0.2.0"},
+				Registry: reg,
+			},
+			expectCfg: &declcfg.DeclarativeConfig{
+				Bundles: []declcfg.Bundle{
+					{
+						Schema:  "olm.bundle",
+						Name:    "foo.v0.2.0",
+						Package: "foo",
+						Image:   "test.registry/foo-operator/foo-bundle-no-csv-related-images:v0.2.0",
+						Properties: []property.Property{
+							property.MustBuildGVK("test.foo", "v1", "Foo"),
+							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
+							property.MustBuildPackage("foo", "0.2.0"),
+							property.MustBuildPackageRequired("bar", "<0.1.0"),
+						},
+						RelatedImages: []declcfg.RelatedImage{
+							{
+								Image: "test.registry/foo-operator/foo-2:v0.2.0",
+							},
+							{
+								Image: "test.registry/foo-operator/foo-bundle-no-csv-related-images:v0.2.0",
+							},
+							{
+								Image: "test.registry/foo-operator/foo-init-2:v0.2.0",
+							},
+							{
+								Image: "test.registry/foo-operator/foo-init:v0.2.0",
+							},
+							{
+								Image: "test.registry/foo-operator/foo:v0.2.0",
+							},
+						},
+					},
+				},
+			},
+			assertion: require.NoError,
+		},
 	}
 
 	for _, s := range specs {
@@ -687,6 +728,10 @@ var bundleImageV1 embed.FS
 //go:embed testdata/foo-bundle-v0.2.0/metadata/*
 var bundleImageV2 embed.FS
 
+//go:embed testdata/foo-bundle-v0.2.0-no-csv-related-images/manifests/*
+//go:embed testdata/foo-bundle-v0.2.0-no-csv-related-images/metadata/*
+var bundleImageV2NoCSVRelatedImages embed.FS
+
 //go:embed testdata/foo-index-v0.2.0-declcfg/foo/*
 var declcfgImage embed.FS
 
@@ -709,6 +754,10 @@ func newRegistry() (image.Registry, error) {
 		return nil, err
 	}
 	subBundleImageV2, err := fs.Sub(bundleImageV2, "testdata/foo-bundle-v0.2.0")
+	if err != nil {
+		return nil, err
+	}
+	subBundleImageV2NoCSVRelatedImages, err := fs.Sub(bundleImageV2NoCSVRelatedImages, "testdata/foo-bundle-v0.2.0-no-csv-related-images")
 	if err != nil {
 		return nil, err
 	}
@@ -737,6 +786,12 @@ func newRegistry() (image.Registry, error) {
 					bundle.PackageLabel: "foo",
 				},
 				FS: subBundleImageV2,
+			},
+			image.SimpleReference("test.registry/foo-operator/foo-bundle-no-csv-related-images:v0.2.0"): {
+				Labels: map[string]string{
+					bundle.PackageLabel: "foo",
+				},
+				FS: subBundleImageV2NoCSVRelatedImages,
 			},
 		},
 	}, nil

--- a/alpha/action/testdata/foo-bundle-v0.2.0-no-csv-related-images/bundle.Dockerfile
+++ b/alpha/action/testdata/foo-bundle-v0.2.0-no-csv-related-images/bundle.Dockerfile
@@ -1,0 +1,12 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=foo
+LABEL operators.operatorframework.io.bundle.channels.v1=beta
+
+# Copy files to locations specified by labels.
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/alpha/action/testdata/foo-bundle-v0.2.0-no-csv-related-images/manifests/foo.v0.2.0.csv.yaml
+++ b/alpha/action/testdata/foo-bundle-v0.2.0-no-csv-related-images/manifests/foo.v0.2.0.csv.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: foo.v0.2.0
+  annotations:
+    olm.skipRange: <0.2.0
+spec:
+  displayName: "Foo Operator"
+  customresourcedefinitions:
+    owned:
+      - group: test.foo
+        version: v1
+        kind: Foo
+        name: foos.test.foo
+  version: 0.2.0
+  replaces: foo.v0.1.0
+  skips:
+    - foo.v0.1.1
+    - foo.v0.1.2
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+        - name: foo-operator
+          spec:
+            template:
+              spec:
+                initContainers:
+                  - image: test.registry/foo-operator/foo-init:v0.2.0
+                containers:
+                  - image: test.registry/foo-operator/foo:v0.2.0
+        - name: foo-operator-2
+          spec:
+            template:
+              spec:
+                initContainers:
+                  - image: test.registry/foo-operator/foo-init-2:v0.2.0
+                containers:
+                  - image: test.registry/foo-operator/foo-2:v0.2.0

--- a/alpha/action/testdata/foo-bundle-v0.2.0-no-csv-related-images/manifests/foos.test.foo.crd.yaml
+++ b/alpha/action/testdata/foo-bundle-v0.2.0-no-csv-related-images/manifests/foos.test.foo.crd.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: foos.test.foo
+spec:
+  group: test.foo
+  names:
+    kind: Foo
+    plural: foos
+  versions:
+    - name: v1

--- a/alpha/action/testdata/foo-bundle-v0.2.0-no-csv-related-images/metadata/annotations.yaml
+++ b/alpha/action/testdata/foo-bundle-v0.2.0-no-csv-related-images/metadata/annotations.yaml
@@ -1,0 +1,4 @@
+annotations:
+  operators.operatorframework.io.bundle.package.v1: foo
+  operators.operatorframework.io.bundle.channels.v1: beta,stable
+  operators.operatorframework.io.bundle.channel.default.v1: beta

--- a/alpha/action/testdata/foo-bundle-v0.2.0-no-csv-related-images/metadata/dependencies.yaml
+++ b/alpha/action/testdata/foo-bundle-v0.2.0-no-csv-related-images/metadata/dependencies.yaml
@@ -1,0 +1,11 @@
+---
+dependencies:
+  - type: olm.package
+    value:
+      packageName: bar
+      version: <0.1.0
+  - type: olm.gvk
+    value:
+      group: "test.bar"
+      version: "v1alpha1"
+      kind: "Bar"


### PR DESCRIPTION


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
When `opm render` renders a bundle, it currently produces zero related images if the CSV does not have an explicit `spec.relatedImages` field.

This is update to fix an edge case not already fixed in #771.


**Motivation for the change:**
Related images can be derived from a CSV even when the CSV does not explicitly contain a `spec.relatedImages` field.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
