### PR TITLE
Makefile: fix major and major-minor docker release tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,6 @@ release:
 define tagged-or-empty
 $(shell \
 	echo $(OPM_VERSION) | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$$' \
-	&& git describe --exact-match HEAD >/dev/null 2>&1 \
+	&& git describe --tags --exact-match HEAD >/dev/null 2>&1 \
 	&& echo "$(OPM_IMAGE_REPO):$(1)" || echo "" )
 endef

--- a/docs/contributors/releases.md
+++ b/docs/contributors/releases.md
@@ -2,7 +2,7 @@
 
 ## opm
 
-Releases of opm are built by Github Actions, see the [release.yml](../../.github/workflows/release.yml) for details.
+Binary releases of opm are built by Github Actions, see [release.yaml](../../.github/workflows/release.yaml) for details.
 amd64 builds are produced for linux, macos, and windows. 
 
 opm follows semantic versioning, with the latest version derived from the newest semver tag.
@@ -11,17 +11,35 @@ opm follows semantic versioning, with the latest version derived from the newest
 
 Releases are triggered via tags. Make a new release by tagging a commit with an appropriate semver tag.
 
+```console
+$ git tag -a -m "operator-registry vX.Y.Z" vX.Y.Z
+$ git push upstream vX.Y.Z
+```
+
 ## Checking the build
 
 Builds for a release can be found [on GitHub Actions](https://github.com/operator-framework/operator-registry/actions). After triggering a build, watch for logs. If the build is successful, a new [release](https://github.com/operator-framework/operator-registry/releases) should appear in GitHub. It will be a draft release, so once all the artifacts are available you need to edit the release to publish the draft.
 
 ## Docker images
 
-Builds are also triggered for the following docker images. The tags in Quay.io will match the git tag:
+The primary image produced from this repository is [quay.io/operator-framework/opm](https://quay.io/repository/operator-framework/opm). See [goreleaser.yaml](../../.github/workflows/goreleaser.yaml) for details. The following tagging system is used for this image:
+ - `:master` - tracks this repository's `master` branch.
+ - `:latest` - tracks the highest semver tag in the repository.
+ - `vX` - tracks the highest semver tag with major version `X`.
+ - `vX.Y` - tracks the highest semver tag with the major/minor version `X.Y`.
+ - `vX.Y.Z` - pushed on every non-prerelease semver tag.
+
+For each of the appropriate tags, the build configuration produces images and a manifest list for the following platforms:
+ - `linux/amd64`
+ - `linux/arm64`
+ - `linux/s390x`
+ - `linux/ppc64le`
+
+Other deprecated images are also built via Quay triggers. The tags in Quay.io will match the git tag, and for these images, `:latest` tracks the `master` branch:
 
  - [quay.io/operator-framework/operator-registry-server](https://quay.io/repository/operator-framework/operator-registry-server)
  - [quay.io/operator-framework/configmap-operator-registry](https://quay.io/repository/operator-framework/configmap-operator-registry)
  - [quay.io/operator-framework/upstream-registry-builder](https://quay.io/repository/operator-framework/upstream-registry-builder?tab=tags)
  
- Images are also built to track master with `latest` tags. It is recommended that you always pull by digest, and only use images that are tagged with a version.
- 
+It is recommended that you always pull by digest, and only use images that are tagged with a version.
+


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
- Updates release documentation to provide explicit commands to run to create appropriate tag.
- Updates the Makefile to be more resilient to non-annotated tags.

**Motivation for the change:**
When we pushed the `v1.18.1` tag, the `v1` and `v1.18` image tags were not pushed as expected. It seems like this happened because:
1. `v1.18.1` was not an annotated tag.
2. The `Makefile`'s use of a `git describe` command to check the tag of `HEAD` assumed _only_ annotated tags.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
