### PR TITLE
Makefile: use /bin/bash as SHELL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL = /bin/bash
 GO := GOFLAGS="-mod=vendor" go
 CMDS := $(addprefix bin/, $(shell ls ./cmd | grep -v opm))
 OPM := $(addprefix bin/, opm)


### PR DESCRIPTION
Signed-off-by: Joe Lanford <joe.lanford@gmail.com>

**Description of the change:**
Set `Makefile` shell to /bin/bash

**Motivation for the change:**
The portion of the Makefile responsible for determining whether a tag is the latest tag in the repo assumes that bash shell built-ins are available.

Here's the hint that there's an error with the shell from a previous run:
https://github.com/operator-framework/operator-registry/runs/3767789661?check_suite_focus=true#step:11:10

Here's the suspected line in the Makefile that is the source of the issue:
https://github.com/operator-framework/operator-registry/blob/5ac5c52145f04f1c0f881780878b226ce7b487da/Makefile#L135

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
