### PR TITLE
registry: vacuum db on commands that remove data

### DIFF
--- a/pkg/lib/registry/registry.go
+++ b/pkg/lib/registry/registry.go
@@ -209,6 +209,9 @@ func (r RegistryUpdater) DeleteFromRegistry(request DeleteFromRegistryRequest) e
 		return fmt.Errorf("error removing stranded packages from database: %s", err)
 	}
 
+	if _, err := db.Exec("VACUUM"); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -236,6 +239,9 @@ func (r RegistryUpdater) PruneStrandedFromRegistry(request PruneStrandedFromRegi
 		return fmt.Errorf("error removing stranded packages from database: %s", err)
 	}
 
+	if _, err := db.Exec("VACUUM"); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -288,6 +294,9 @@ func (r RegistryUpdater) PruneFromRegistry(request PruneFromRegistryRequest) err
 		}
 	}
 
+	if _, err := db.Exec("VACUUM"); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -354,6 +363,9 @@ func (r RegistryUpdater) DeprecateFromRegistry(request DeprecateFromRegistryRequ
 		r.Logger.WithError(err).Warn("permissive mode enabled")
 	}
 
+	if _, err := db.Exec("VACUUM"); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Add [`VACUUM`](https://www.sqlite.org/lang_vacuum.html) call to the following commands:
- `deprecatetruncate`
- `prune`
- `prune-stranded`
- `rm`

**Motivation for the change:**
Users would likely be surprised that the size of the database file is not reduced after a command the removes data from the database completes successfully.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
