### PR TITLE
(opm) Introduce deprecatetruncate for `opm registry`

### DIFF
--- a/cmd/opm/registry/cmd.go
+++ b/cmd/opm/registry/cmd.go
@@ -32,6 +32,7 @@ func NewOpmRegistryCmd() *cobra.Command {
 	rootCmd.AddCommand(newRegistryRmCmd())
 	rootCmd.AddCommand(newRegistryPruneCmd())
 	rootCmd.AddCommand(newRegistryPruneStrandedCmd())
+	rootCmd.AddCommand(newRegistryDeprecateCmd())
 
 	return rootCmd
 }

--- a/cmd/opm/registry/deprecatetruncate.go
+++ b/cmd/opm/registry/deprecatetruncate.go
@@ -1,0 +1,76 @@
+package registry
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/operator-framework/operator-registry/pkg/lib/registry"
+	"github.com/operator-framework/operator-registry/pkg/sqlite"
+)
+
+func newRegistryDeprecateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "deprecatetruncate",
+		Short:  "deprecate operator bundle from registry DB",
+		Long: `deprecate operator bundle from registry DB
+
+` + sqlite.DeprecationMessage,
+
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			if debug, _ := cmd.Flags().GetBool("debug"); debug {
+				logrus.SetLevel(logrus.DebugLevel)
+			}
+			return nil
+		},
+
+		RunE: deprecateFunc,
+		Args: cobra.NoArgs,
+	}
+
+	cmd.Flags().Bool("debug", false, "enable debug logging")
+	cmd.Flags().StringP("database", "d", "index.db", "relative path to database file")
+	cmd.Flags().StringSliceP("bundle-images", "b", []string{}, "comma separated list of links to bundle image")
+	cmd.Flags().Bool("permissive", false, "allow registry load errors")
+	cmd.Flags().Bool("allow-package-removal", false, "removes the entire package if the heads of all channels in the package are deprecated")
+
+	return cmd
+}
+
+func deprecateFunc(cmd *cobra.Command, _ []string) error {
+	permissive, err := cmd.Flags().GetBool("permissive")
+	if err != nil {
+		return err
+	}
+	fromFilename, err := cmd.Flags().GetString("database")
+	if err != nil {
+		return err
+	}
+	bundleImages, err := cmd.Flags().GetStringSlice("bundle-images")
+	if err != nil {
+		return err
+	}
+	allowPackageRemoval, err := cmd.Flags().GetBool("allow-package-removal")
+	if err != nil {
+		return err
+	}
+
+	request := registry.DeprecateFromRegistryRequest{
+		Permissive:          permissive,
+		InputDatabase:       fromFilename,
+		Bundles:             bundleImages,
+		AllowPackageRemoval: allowPackageRemoval,
+	}
+
+	logger := logrus.WithFields(logrus.Fields{"bundles": bundleImages})
+
+	logger.Info("deprecating from registry")
+
+	registryDeprecator := registry.NewRegistryDeprecator(logger)
+
+	err = registryDeprecator.DeprecateFromRegistry(request)
+	if err != nil {
+		logger.Fatal(err)
+	}
+	return nil
+}


### PR DESCRIPTION
**Description of the change:**

This PR exposes the `deprecatetruncate` functionality, previously
only included under `opm index`, under `opm registry`. In line with
all other commands that operate on a sqlite db, this sub-command is
deprecated too. In line with `opm index deprecatetruncate`, the
`deprecatetruncate` sub-command for `opm registry` is hidden too.


**Motivation for the change:**

Existing catalog building pipelines that operate on index images are about to be migrated to building plaintext files backed catalogs. Infrastructures are being built for them such that during the migration process, they can continue to use the `opm index` UX (i.e imperative workflow) on plaintext files backed catalogs. This is required to provide the pipelines with sufficient time to move over from existing imperative workflow to declarative workflow while building plaintext backed catalogs. The new infrastructures mentioned previously operates exclusively on sqlite databases (and not index images). As a result all existing functionalities for index images are also needed to be present for sqlite databases. `deprecatetruncate` is only functionality that was missing from `opm registry`.      
 
**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
