### PR TITLE
alpha/declcfg: Include bundle name in version parsing failure message

### DIFF
--- a/alpha/declcfg/declcfg_to_model.go
+++ b/alpha/declcfg/declcfg_to_model.go
@@ -98,9 +98,10 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 		}
 
 		// Parse version from the package property.
-		ver, err := semver.Parse(props.Packages[0].Version)
+		rawVersion := props.Packages[0].Version
+		ver, err := semver.Parse(rawVersion)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing bundle version: %v", err)
+			return nil, fmt.Errorf("error parsing bundle %q version %q: %v", b.Name, rawVersion, err)
 		}
 
 		channelDefinedEntries[b.Package] = channelDefinedEntries[b.Package].Delete(b.Name)

--- a/alpha/declcfg/declcfg_to_model_test.go
+++ b/alpha/declcfg/declcfg_to_model_test.go
@@ -77,7 +77,7 @@ func TestConvertToModel(t *testing.T) {
 		},
 		{
 			name:      "Error/BundleInvalidVersion",
-			assertion: hasError(`error parsing bundle version: Invalid character(s) found in patch number "0.1"`),
+			assertion: hasError(`error parsing bundle "foo.v0.1.0" version "0.1.0.1": Invalid character(s) found in patch number "0.1"`),
 			cfg: DeclarativeConfig{
 				Packages: []Package{newTestPackage("foo", "alpha", svgSmallCircle)},
 				Bundles: []Bundle{newTestBundle("foo", "0.1.0", func(b *Bundle) {
@@ -85,6 +85,14 @@ func TestConvertToModel(t *testing.T) {
 						property.MustBuildPackage("foo", "0.1.0.1"),
 					}
 				})},
+			},
+		},
+		{
+			name:      "Error/BundleMissingVersion",
+			assertion: hasError(`error parsing bundle "foo.v" version "": Version string empty`),
+			cfg: DeclarativeConfig{
+				Packages: []Package{newTestPackage("foo", "alpha", svgSmallCircle)},
+				Bundles:  []Bundle{newTestBundle("foo", "", func(b *Bundle) {})},
 			},
 		},
 		{


### PR DESCRIPTION
Update the alpha/declcfg/declfg_to_model.go package and add the bundle's
name while attempting to validate file-based indices that contain an
empty or invalid bundle version.

Before:

```bash
$ ./bin/opm validate index
FATA[0000] error parsing bundle version: Version string empty
```

After:

```bash
$ ./bin/opm validate index
FATA[0000] error parsing bundle "operator-1.v0.1.0 version": Version string empty
```

Index image used:

```yaml
---
schema: olm.package
name: operator-1
defaultChannel: beta
---
entries:
- name: operator-1.v0.1.0
name: alpha
package: operator-1
schema: olm.channel
---
image: <...>
name: operator-1.v0.1.0
package: operator-1
properties:
- type: olm.gvk
  value:
    group: example.my.domain
    kind: Operator
    version: v1alpha1
- type: olm.package
  value:
    packageName: operator-1
- type: olm.maxOpenShiftVersion
  value: 4.9
schema: olm.bundle
```
