### PR TITLE
retain single bundle default channel for overwrite

### DIFF
--- a/pkg/sqlite/load.go
+++ b/pkg/sqlite/load.go
@@ -1820,9 +1820,6 @@ func (s sqlLoader) RemoveOverwrittenChannelHead(pkg, bundle string) error {
 			if _, err := tx.Exec(`UPDATE channel SET head_operatorbundle_name = NULL WHERE name = ? AND package_name = ? AND name IN (SELECT default_channel FROM package WHERE name = ?)`, channel, pkg, pkg); err != nil {
 				return err
 			}
-			if _, err := tx.Exec(`DELETE FROM channel WHERE name = ? AND package_name = ? AND head_operatorbundle_name = ?`, channel, pkg, bundle); err != nil {
-				return err
-			}
 		}
 	}
 

--- a/pkg/sqlite/load_test.go
+++ b/pkg/sqlite/load_test.go
@@ -1137,7 +1137,7 @@ func TestRemoveOverwrittenChannelHead(t *testing.T) {
 			defer cleanup()
 			store, err := NewSQLLiteLoader(db)
 			require.NoError(t, err)
-			err = store.Migrate(context.TODO())
+			err = store.Migrate(context.Background())
 			require.NoError(t, err)
 
 			for _, bundle := range tt.fields.bundles {
@@ -1152,7 +1152,7 @@ func TestRemoveOverwrittenChannelHead(t *testing.T) {
 
 			getDefaultChannel := func(pkg string) sql.NullString {
 				// get defaultChannel before delete
-				rows, err := db.QueryContext(context.TODO(), `SELECT default_channel FROM package WHERE name = ?`, pkg)
+				rows, err := db.QueryContext(context.Background(), `SELECT default_channel FROM package WHERE name = ?`, pkg)
 				require.NoError(t, err)
 				defer rows.Close()
 				var defaultChannel sql.NullString
@@ -1173,7 +1173,7 @@ func TestRemoveOverwrittenChannelHead(t *testing.T) {
 
 			querier := NewSQLLiteQuerierFromDb(db)
 
-			bundles, err := querier.ListBundles(context.TODO())
+			bundles, err := querier.ListBundles(context.Background())
 			require.NoError(t, err)
 
 			var extra []string


### PR DESCRIPTION
`--overwrite-latest` removes the head bundle being overwritten, setting channel head to either the previous bundle in replaces chain or dropping the channel entirely. However, when a single bundle default channel head is overwritten, this causes the package to lose its default channel, causing the package manifest to be unable to determine the default channel unless the overwritten bundle is both the highest semver in the package and either has one channel or has a default channel annotation.

This PR retains a stub default channel entry to help determine a default channel after the overwrite