### PR TITLE
Makefile: Add a .PHONY target for the opm build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ all: clean test build
 $(CMDS):
 	$(GO) build $(extra_flags) $(TAGS) -o $@ ./cmd/$(notdir $@)
 
+.PHONY: $(OPM)
 $(OPM): opm_version_flags=-ldflags "-X '$(PKG)/cmd/opm/version.gitCommit=$(GIT_COMMIT)' -X '$(PKG)/cmd/opm/version.opmVersion=$(OPM_VERSION)' -X '$(PKG)/cmd/opm/version.buildDate=$(BUILD_DATE)'"
 $(OPM):
 	$(GO) build $(opm_version_flags) $(extra_flags) $(TAGS) -o $@ ./cmd/$(notdir $@)


### PR DESCRIPTION
Update the root Makefile and add a .PHONY target for the bin/opm target.
This is needed to as the bin/opm target outputs the opm executable in
the same name as the target, which is problematic in the case there's an
existing ./bin/opm file present and a re-build is necessary.

Signed-off-by: timflannagan <timflannagan@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
