### PR TITLE
feat(opm): Create multiple files during migration

### DIFF
--- a/alpha/action/migrate_test.go
+++ b/alpha/action/migrate_test.go
@@ -17,149 +17,7 @@ import (
 	"github.com/operator-framework/operator-registry/pkg/lib/bundle"
 )
 
-func TestMigrate(t *testing.T) {
-	type spec struct {
-		name          string
-		migrate       action.Migrate
-		expectedFiles map[string]string
-		expectErr     error
-	}
-
-	sqliteBundles := map[image.Reference]string{
-		image.SimpleReference("test.registry/foo-operator/foo-bundle:v0.1.0"): "testdata/foo-bundle-v0.1.0",
-		image.SimpleReference("test.registry/foo-operator/foo-bundle:v0.2.0"): "testdata/foo-bundle-v0.2.0",
-		image.SimpleReference("test.registry/bar-operator/bar-bundle:v0.1.0"): "testdata/bar-bundle-v0.1.0",
-		image.SimpleReference("test.registry/bar-operator/bar-bundle:v0.2.0"): "testdata/bar-bundle-v0.2.0",
-	}
-
-	tmpDir := t.TempDir()
-	dbFile := filepath.Join(tmpDir, "index.db")
-	err := generateSqliteFile(dbFile, sqliteBundles)
-	require.NoError(t, err)
-
-	reg, err := newMigrateRegistry(sqliteBundles)
-	require.NoError(t, err)
-
-	specs := []spec{
-		{
-			name: "SqliteImage/Success",
-			migrate: action.Migrate{
-				CatalogRef: "test.registry/migrate/catalog:sqlite",
-				OutputDir:  filepath.Join(tmpDir, "sqlite-image"),
-				WriteFunc:  declcfg.WriteYAML,
-				FileExt:    ".yaml",
-				Registry:   reg,
-			},
-			expectedFiles: map[string]string{
-				"foo/catalog.yaml": migrateFooCatalog(),
-				"bar/catalog.yaml": migrateBarCatalog(),
-			},
-		},
-		{
-			name: "SqliteFile/Success",
-			migrate: action.Migrate{
-				CatalogRef: dbFile,
-				OutputDir:  filepath.Join(tmpDir, "sqlite-file"),
-				WriteFunc:  declcfg.WriteYAML,
-				FileExt:    ".yaml",
-				Registry:   reg,
-			},
-			expectedFiles: map[string]string{
-				"foo/catalog.yaml": migrateFooCatalog(),
-				"bar/catalog.yaml": migrateBarCatalog(),
-			},
-		},
-		{
-			name: "DeclcfgImage/Failure",
-			migrate: action.Migrate{
-				CatalogRef: "test.registry/foo-operator/foo-index-declcfg:v0.2.0",
-				OutputDir:  filepath.Join(tmpDir, "declcfg-image"),
-				WriteFunc:  declcfg.WriteYAML,
-				FileExt:    ".yaml",
-				Registry:   reg,
-			},
-			expectErr: action.ErrNotAllowed,
-		},
-		{
-			name: "DeclcfgDir/Failure",
-			migrate: action.Migrate{
-				CatalogRef: "testdata/foo-index-v0.2.0-declcfg",
-				OutputDir:  filepath.Join(tmpDir, "declcfg-dir"),
-				WriteFunc:  declcfg.WriteYAML,
-				FileExt:    ".yaml",
-				Registry:   reg,
-			},
-			expectErr: action.ErrNotAllowed,
-		},
-		{
-			name: "BundleImage/Failure",
-			migrate: action.Migrate{
-				CatalogRef: "test.registry/foo-operator/foo-bundle:v0.1.0",
-				OutputDir:  filepath.Join(tmpDir, "bundle-image"),
-				WriteFunc:  declcfg.WriteYAML,
-				FileExt:    ".yaml",
-				Registry:   reg,
-			},
-			expectErr: action.ErrNotAllowed,
-		},
-	}
-	for _, s := range specs {
-		t.Run(s.name, func(t *testing.T) {
-			err := s.migrate.Run(context.Background())
-			require.ErrorIs(t, err, s.expectErr)
-			for file, expectedData := range s.expectedFiles {
-				path := filepath.Join(s.migrate.OutputDir, file)
-				actualData, err := os.ReadFile(path)
-				require.NoError(t, err)
-				fmt.Println(string(actualData))
-				require.Equal(t, expectedData, string(actualData))
-			}
-		})
-	}
-}
-
-func newMigrateRegistry(imageMap map[image.Reference]string) (image.Registry, error) {
-	subSqliteImage, err := generateSqliteFS(imageMap)
-	if err != nil {
-		return nil, err
-	}
-
-	subDeclcfgImage, err := fs.Sub(declcfgImage, "testdata/foo-index-v0.2.0-declcfg")
-	if err != nil {
-		return nil, err
-	}
-
-	subBundleImageV1, err := fs.Sub(bundleImageV1, "testdata/foo-bundle-v0.1.0")
-	if err != nil {
-		return nil, err
-	}
-
-	reg := &image.MockRegistry{RemoteImages: map[image.Reference]*image.MockImage{
-		image.SimpleReference("test.registry/migrate/catalog:sqlite"): {
-			Labels: map[string]string{
-				containertools.DbLocationLabel: "/database/index.db",
-			},
-			FS: subSqliteImage,
-		},
-		image.SimpleReference("test.registry/foo-operator/foo-index-declcfg:v0.2.0"): {
-			Labels: map[string]string{
-				"operators.operatorframework.io.index.configs.v1": "/foo",
-			},
-			FS: subDeclcfgImage,
-		},
-		image.SimpleReference("test.registry/foo-operator/foo-bundle:v0.1.0"): {
-			Labels: map[string]string{
-				bundle.PackageLabel: "foo",
-			},
-			FS: subBundleImageV1,
-		},
-	}}
-
-	return reg, nil
-}
-
-func migrateFooCatalog() string {
-	return `---
+var fooCatalogSingleFile = `---
 defaultChannel: beta
 name: foo
 schema: olm.package
@@ -268,10 +126,124 @@ relatedImages:
   name: operator
 schema: olm.bundle
 `
+
+var fooCatalogMultipleFiles = map[string]string{
+	"package.yaml": `---
+defaultChannel: beta
+name: foo
+schema: olm.package
+`,
+	"channels/beta.yaml": `---
+entries:
+- name: foo.v0.1.0
+  skipRange: <0.1.0
+- name: foo.v0.2.0
+  replaces: foo.v0.1.0
+  skipRange: <0.2.0
+  skips:
+  - foo.v0.1.1
+  - foo.v0.1.2
+name: beta
+package: foo
+schema: olm.channel
+`,
+	"channels/stable.yaml": `---
+entries:
+- name: foo.v0.1.0
+  skipRange: <0.1.0
+- name: foo.v0.2.0
+  replaces: foo.v0.1.0
+  skipRange: <0.2.0
+  skips:
+  - foo.v0.1.1
+  - foo.v0.1.2
+name: stable
+package: foo
+schema: olm.channel
+`,
+	"bundles/foo.v0.1.0.yaml": `---
+image: test.registry/foo-operator/foo-bundle:v0.1.0
+name: foo.v0.1.0
+package: foo
+properties:
+- type: olm.gvk
+  value:
+    group: test.foo
+    kind: Foo
+    version: v1
+- type: olm.gvk.required
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: foo
+    version: 0.1.0
+- type: olm.package.required
+  value:
+    packageName: bar
+    versionRange: <0.1.0
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsib2xtLnNraXBSYW5nZSI6Ilx1MDAzYzAuMS4wIn0sIm5hbWUiOiJmb28udjAuMS4wIn0sInNwZWMiOnsiY3VzdG9tcmVzb3VyY2VkZWZpbml0aW9ucyI6eyJvd25lZCI6W3siZ3JvdXAiOiJ0ZXN0LmZvbyIsImtpbmQiOiJGb28iLCJuYW1lIjoiZm9vcy50ZXN0LmZvbyIsInZlcnNpb24iOiJ2MSJ9XX0sImRpc3BsYXlOYW1lIjoiRm9vIE9wZXJhdG9yIiwicmVsYXRlZEltYWdlcyI6W3siaW1hZ2UiOiJ0ZXN0LnJlZ2lzdHJ5L2Zvby1vcGVyYXRvci9mb286djAuMS4wIiwibmFtZSI6Im9wZXJhdG9yIn1dLCJ2ZXJzaW9uIjoiMC4xLjAifX0=
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImZvb3MudGVzdC5mb28ifSwic3BlYyI6eyJncm91cCI6InRlc3QuZm9vIiwibmFtZXMiOnsia2luZCI6IkZvbyIsInBsdXJhbCI6ImZvb3MifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MSJ9XX19
+relatedImages:
+- image: test.registry/foo-operator/foo-bundle:v0.1.0
+  name: ""
+- image: test.registry/foo-operator/foo:v0.1.0
+  name: operator
+schema: olm.bundle
+`,
+	"bundles/foo.v0.2.0.yaml": `---
+image: test.registry/foo-operator/foo-bundle:v0.2.0
+name: foo.v0.2.0
+package: foo
+properties:
+- type: olm.gvk
+  value:
+    group: test.foo
+    kind: Foo
+    version: v1
+- type: olm.gvk.required
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: foo
+    version: 0.2.0
+- type: olm.package.required
+  value:
+    packageName: bar
+    versionRange: <0.1.0
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsib2xtLnNraXBSYW5nZSI6Ilx1MDAzYzAuMi4wIn0sIm5hbWUiOiJmb28udjAuMi4wIn0sInNwZWMiOnsiY3VzdG9tcmVzb3VyY2VkZWZpbml0aW9ucyI6eyJvd25lZCI6W3siZ3JvdXAiOiJ0ZXN0LmZvbyIsImtpbmQiOiJGb28iLCJuYW1lIjoiZm9vcy50ZXN0LmZvbyIsInZlcnNpb24iOiJ2MSJ9XX0sImRpc3BsYXlOYW1lIjoiRm9vIE9wZXJhdG9yIiwiaW5zdGFsbCI6eyJzcGVjIjp7ImRlcGxveW1lbnRzIjpbeyJuYW1lIjoiZm9vLW9wZXJhdG9yIiwic3BlYyI6eyJ0ZW1wbGF0ZSI6eyJzcGVjIjp7ImNvbnRhaW5lcnMiOlt7ImltYWdlIjoidGVzdC5yZWdpc3RyeS9mb28tb3BlcmF0b3IvZm9vOnYwLjIuMCJ9XSwiaW5pdENvbnRhaW5lcnMiOlt7ImltYWdlIjoidGVzdC5yZWdpc3RyeS9mb28tb3BlcmF0b3IvZm9vLWluaXQ6djAuMi4wIn1dfX19fSx7Im5hbWUiOiJmb28tb3BlcmF0b3ItMiIsInNwZWMiOnsidGVtcGxhdGUiOnsic3BlYyI6eyJjb250YWluZXJzIjpbeyJpbWFnZSI6InRlc3QucmVnaXN0cnkvZm9vLW9wZXJhdG9yL2Zvby0yOnYwLjIuMCJ9XSwiaW5pdENvbnRhaW5lcnMiOlt7ImltYWdlIjoidGVzdC5yZWdpc3RyeS9mb28tb3BlcmF0b3IvZm9vLWluaXQtMjp2MC4yLjAifV19fX19XX0sInN0cmF0ZWd5IjoiZGVwbG95bWVudCJ9LCJyZWxhdGVkSW1hZ2VzIjpbeyJpbWFnZSI6InRlc3QucmVnaXN0cnkvZm9vLW9wZXJhdG9yL2Zvbzp2MC4yLjAiLCJuYW1lIjoib3BlcmF0b3IifSx7ImltYWdlIjoidGVzdC5yZWdpc3RyeS9mb28tb3BlcmF0b3IvZm9vLW90aGVyOnYwLjIuMCIsIm5hbWUiOiJvdGhlciJ9XSwicmVwbGFjZXMiOiJmb28udjAuMS4wIiwic2tpcHMiOlsiZm9vLnYwLjEuMSIsImZvby52MC4xLjIiXSwidmVyc2lvbiI6IjAuMi4wIn19
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImZvb3MudGVzdC5mb28ifSwic3BlYyI6eyJncm91cCI6InRlc3QuZm9vIiwibmFtZXMiOnsia2luZCI6IkZvbyIsInBsdXJhbCI6ImZvb3MifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MSJ9XX19
+relatedImages:
+- image: test.registry/foo-operator/foo-2:v0.2.0
+  name: ""
+- image: test.registry/foo-operator/foo-bundle:v0.2.0
+  name: ""
+- image: test.registry/foo-operator/foo-init-2:v0.2.0
+  name: ""
+- image: test.registry/foo-operator/foo-init:v0.2.0
+  name: ""
+- image: test.registry/foo-operator/foo-other:v0.2.0
+  name: other
+- image: test.registry/foo-operator/foo:v0.2.0
+  name: operator
+schema: olm.bundle
+`,
 }
 
-func migrateBarCatalog() string {
-	return `---
+var barCatalogSingleFile = `---
 defaultChannel: alpha
 name: bar
 schema: olm.package
@@ -338,4 +310,241 @@ relatedImages:
   name: operator
 schema: olm.bundle
 `
+
+var barCatalogMultipleFiles = map[string]string{
+	"package.yaml": `---
+defaultChannel: alpha
+name: bar
+schema: olm.package
+`,
+	"channels/alpha.yaml": `---
+entries:
+- name: bar.v0.1.0
+- name: bar.v0.2.0
+  skipRange: <0.2.0
+  skips:
+  - bar.v0.1.0
+name: alpha
+package: bar
+schema: olm.channel
+`,
+	"bundles/bar.v0.1.0.yaml": `---
+image: test.registry/bar-operator/bar-bundle:v0.1.0
+name: bar.v0.1.0
+package: bar
+properties:
+- type: olm.gvk
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: bar
+    version: 0.1.0
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhci52MC4xLjAifSwic3BlYyI6eyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjp7Im93bmVkIjpbeyJncm91cCI6InRlc3QuYmFyIiwia2luZCI6IkJhciIsIm5hbWUiOiJiYXJzLnRlc3QuYmFyIiwidmVyc2lvbiI6InYxYWxwaGExIn1dfSwicmVsYXRlZEltYWdlcyI6W3siaW1hZ2UiOiJ0ZXN0LnJlZ2lzdHJ5L2Jhci1vcGVyYXRvci9iYXI6djAuMS4wIiwibmFtZSI6Im9wZXJhdG9yIn1dLCJ2ZXJzaW9uIjoiMC4xLjAifX0=
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhcnMudGVzdC5iYXIifSwic3BlYyI6eyJncm91cCI6InRlc3QuYmFyIiwibmFtZXMiOnsia2luZCI6IkJhciIsInBsdXJhbCI6ImJhcnMifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MWFscGhhMSJ9XX19
+relatedImages:
+- image: test.registry/bar-operator/bar-bundle:v0.1.0
+  name: ""
+- image: test.registry/bar-operator/bar:v0.1.0
+  name: operator
+schema: olm.bundle
+`,
+	"bundles/bar.v0.2.0.yaml": `---
+image: test.registry/bar-operator/bar-bundle:v0.2.0
+name: bar.v0.2.0
+package: bar
+properties:
+- type: olm.gvk
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: bar
+    version: 0.2.0
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsib2xtLnNraXBSYW5nZSI6Ilx1MDAzYzAuMi4wIn0sIm5hbWUiOiJiYXIudjAuMi4wIn0sInNwZWMiOnsiY3VzdG9tcmVzb3VyY2VkZWZpbml0aW9ucyI6eyJvd25lZCI6W3siZ3JvdXAiOiJ0ZXN0LmJhciIsImtpbmQiOiJCYXIiLCJuYW1lIjoiYmFycy50ZXN0LmJhciIsInZlcnNpb24iOiJ2MWFscGhhMSJ9XX0sInJlbGF0ZWRJbWFnZXMiOlt7ImltYWdlIjoidGVzdC5yZWdpc3RyeS9iYXItb3BlcmF0b3IvYmFyOnYwLjIuMCIsIm5hbWUiOiJvcGVyYXRvciJ9XSwic2tpcHMiOlsiYmFyLnYwLjEuMCJdLCJ2ZXJzaW9uIjoiMC4yLjAifX0=
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhcnMudGVzdC5iYXIifSwic3BlYyI6eyJncm91cCI6InRlc3QuYmFyIiwibmFtZXMiOnsia2luZCI6IkJhciIsInBsdXJhbCI6ImJhcnMifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MWFscGhhMSJ9XX19
+relatedImages:
+- image: test.registry/bar-operator/bar-bundle:v0.2.0
+  name: ""
+- image: test.registry/bar-operator/bar:v0.2.0
+  name: operator
+schema: olm.bundle
+`,
+}
+
+func TestMigrate(t *testing.T) {
+	type spec struct {
+		name          string
+		migrate       action.Migrate
+		expectedFiles map[string]string
+		expectErr     error
+	}
+
+	sqliteBundles := map[image.Reference]string{
+		image.SimpleReference("test.registry/foo-operator/foo-bundle:v0.1.0"): "testdata/foo-bundle-v0.1.0",
+		image.SimpleReference("test.registry/foo-operator/foo-bundle:v0.2.0"): "testdata/foo-bundle-v0.2.0",
+		image.SimpleReference("test.registry/bar-operator/bar-bundle:v0.1.0"): "testdata/bar-bundle-v0.1.0",
+		image.SimpleReference("test.registry/bar-operator/bar-bundle:v0.2.0"): "testdata/bar-bundle-v0.2.0",
+	}
+
+	tmpDir := t.TempDir()
+	dbFile := filepath.Join(tmpDir, "index.db")
+	err := generateSqliteFile(dbFile, sqliteBundles)
+	require.NoError(t, err)
+
+	reg, err := newMigrateRegistry(sqliteBundles)
+	require.NoError(t, err)
+
+	specs := []spec{
+		{
+			name: "SqliteImage/Success",
+			migrate: action.Migrate{
+				CatalogRef: "test.registry/migrate/catalog:sqlite",
+				OutputDir:  filepath.Join(tmpDir, "sqlite-image"),
+				WriteFunc:  declcfg.WriteYAML,
+				SingleFile: true,
+				FileExt:    ".yaml",
+				Registry:   reg,
+			},
+			expectedFiles: map[string]string{
+				"foo/catalog.yaml": fooCatalogSingleFile,
+				"bar/catalog.yaml": barCatalogSingleFile,
+			},
+		},
+		{
+			name: "SqliteFile/Success",
+			migrate: action.Migrate{
+				CatalogRef: dbFile,
+				OutputDir:  filepath.Join(tmpDir, "sqlite-file"),
+				WriteFunc:  declcfg.WriteYAML,
+				FileExt:    ".yaml",
+				SingleFile: true,
+				Registry:   reg,
+			},
+			expectedFiles: map[string]string{
+				"foo/catalog.yaml": fooCatalogSingleFile,
+				"bar/catalog.yaml": barCatalogSingleFile,
+			},
+		},
+		{
+			name: "SqliteFile/Success/MultipleFiles",
+			migrate: action.Migrate{
+				CatalogRef: dbFile,
+				OutputDir:  filepath.Join(tmpDir, "sqlite-file-multiple"),
+				WriteFunc:  declcfg.WriteYAML,
+				FileExt:    ".yaml",
+				SingleFile: false,
+				Registry:   reg,
+			},
+			expectedFiles: map[string]string{
+				"foo/package.yaml":            fooCatalogMultipleFiles["package.yaml"],
+				"foo/channels/beta.yaml":      fooCatalogMultipleFiles["channels/beta.yaml"],
+				"foo/channels/stable.yaml":    fooCatalogMultipleFiles["channels/stable.yaml"],
+				"foo/bundles/foo.v0.1.0.yaml": fooCatalogMultipleFiles["bundles/foo.v0.1.0.yaml"],
+				"foo/bundles/foo.v0.2.0.yaml": fooCatalogMultipleFiles["bundles/foo.v0.2.0.yaml"],
+				"bar/package.yaml":            barCatalogMultipleFiles["package.yaml"],
+				"bar/channels/alpha.yaml":     barCatalogMultipleFiles["channels/alpha.yaml"],
+				"bar/bundles/bar.v0.1.0.yaml": barCatalogMultipleFiles["bundles/bar.v0.1.0.yaml"],
+				"bar/bundles/bar.v0.2.0.yaml": barCatalogMultipleFiles["bundles/bar.v0.2.0.yaml"],
+			},
+		},
+		{
+			name: "DeclcfgImage/Failure",
+			migrate: action.Migrate{
+				CatalogRef: "test.registry/foo-operator/foo-index-declcfg:v0.2.0",
+				OutputDir:  filepath.Join(tmpDir, "declcfg-image"),
+				WriteFunc:  declcfg.WriteYAML,
+				FileExt:    ".yaml",
+				Registry:   reg,
+			},
+			expectErr: action.ErrNotAllowed,
+		},
+		{
+			name: "DeclcfgDir/Failure",
+			migrate: action.Migrate{
+				CatalogRef: "testdata/foo-index-v0.2.0-declcfg",
+				OutputDir:  filepath.Join(tmpDir, "declcfg-dir"),
+				WriteFunc:  declcfg.WriteYAML,
+				FileExt:    ".yaml",
+				Registry:   reg,
+			},
+			expectErr: action.ErrNotAllowed,
+		},
+		{
+			name: "BundleImage/Failure",
+			migrate: action.Migrate{
+				CatalogRef: "test.registry/foo-operator/foo-bundle:v0.1.0",
+				OutputDir:  filepath.Join(tmpDir, "bundle-image"),
+				WriteFunc:  declcfg.WriteYAML,
+				FileExt:    ".yaml",
+				Registry:   reg,
+			},
+			expectErr: action.ErrNotAllowed,
+		},
+	}
+	for _, s := range specs {
+		t.Run(s.name, func(t *testing.T) {
+			err := s.migrate.Run(context.Background())
+			require.ErrorIs(t, err, s.expectErr)
+			for file, expectedData := range s.expectedFiles {
+				path := filepath.Join(s.migrate.OutputDir, file)
+				actualData, err := os.ReadFile(path)
+				require.NoError(t, err)
+				fmt.Println(string(actualData))
+				require.Equal(t, expectedData, string(actualData))
+			}
+		})
+	}
+}
+
+func newMigrateRegistry(imageMap map[image.Reference]string) (image.Registry, error) {
+	subSqliteImage, err := generateSqliteFS(imageMap)
+	if err != nil {
+		return nil, err
+	}
+
+	subDeclcfgImage, err := fs.Sub(declcfgImage, "testdata/foo-index-v0.2.0-declcfg")
+	if err != nil {
+		return nil, err
+	}
+
+	subBundleImageV1, err := fs.Sub(bundleImageV1, "testdata/foo-bundle-v0.1.0")
+	if err != nil {
+		return nil, err
+	}
+
+	reg := &image.MockRegistry{RemoteImages: map[image.Reference]*image.MockImage{
+		image.SimpleReference("test.registry/migrate/catalog:sqlite"): {
+			Labels: map[string]string{
+				containertools.DbLocationLabel: "/database/index.db",
+			},
+			FS: subSqliteImage,
+		},
+		image.SimpleReference("test.registry/foo-operator/foo-index-declcfg:v0.2.0"): {
+			Labels: map[string]string{
+				"operators.operatorframework.io.index.configs.v1": "/foo",
+			},
+			FS: subDeclcfgImage,
+		},
+		image.SimpleReference("test.registry/foo-operator/foo-bundle:v0.1.0"): {
+			Labels: map[string]string{
+				bundle.PackageLabel: "foo",
+			},
+			FS: subBundleImageV1,
+		},
+	}}
+
+	return reg, nil
 }

--- a/cmd/opm/migrate/cmd.go
+++ b/cmd/opm/migrate/cmd.go
@@ -13,8 +13,9 @@ import (
 
 func NewCmd() *cobra.Command {
 	var (
-		migrate action.Migrate
-		output  string
+		migrate    action.Migrate
+		output     string
+		singleFile bool
 	)
 	cmd := &cobra.Command{
 		Use:   "migrate <indexRef> <outputDir>",
@@ -40,7 +41,7 @@ func NewCmd() *cobra.Command {
 			default:
 				log.Fatalf("invalid --output value %q, expected (json|yaml)", output)
 			}
-
+			migrate.SingleFile = singleFile
 			logrus.Infof("rendering index %q as file-based catalog", migrate.CatalogRef)
 			if err := migrate.Run(cmd.Context()); err != nil {
 				logrus.New().Fatal(err)
@@ -50,5 +51,6 @@ func NewCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&output, "output", "o", "json", "Output format (json|yaml)")
+	cmd.Flags().BoolVarP(&singleFile, "singleFile", "s", false, "Output is written to a single file, rather than multiple files split into bundles/channels")
 	return cmd
 }


### PR DESCRIPTION



<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

In this PR, the `opm migrate` command is enhanced to create multiple
plaintext files, one each for each package, bundles and channels
intead of a single file for each package.

**Motivation for the change:**

When plaintext files are [loaded onto memory](https://github.com/operator-framework/operator-registry/blob/master/alpha/declcfg/load.go#L69), they are able to be loaded
even if the metadata is spread across multiple files (instead of just
one file). Splitting the metadata logically in a way this PR does
makes the files more human consumable.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
