### PR TITLE
goreleaser: use netgo and osusergo to ensure completely static binary builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,7 +11,7 @@ builds:
       - CGO_ENABLED=1
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags: &build-flags
-      - -tags=json1
+      - -tags=json1,netgo,osusergo
     asmflags: &build-asmflags
       - all=-trimpath={{ .Env.PWD }}
     gcflags: &build-gcflags


### PR DESCRIPTION
**Description of the change:**
Use `netgo` and `osusergo` when building binaries for `opm` image to ensure completely static binary builds.

**Motivation for the change:**
The current goreleaser build results in an image with a binary that panics when the network is used (e.g. `opm render` with a remote image) 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
