### PR TITLE
opm validate: fail on duplicate packages, channels, and bundles

### DIFF
--- a/alpha/declcfg/declcfg_to_model.go
+++ b/alpha/declcfg/declcfg_to_model.go
@@ -18,6 +18,10 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 			return nil, fmt.Errorf("config contains package with no name")
 		}
 
+		if _, ok := mpkgs[p.Name]; ok {
+			return nil, fmt.Errorf("duplicate package %q", p.Name)
+		}
+
 		mpkg := &model.Package{
 			Name:        p.Name,
 			Description: p.Description,
@@ -42,6 +46,10 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 
 		if c.Name == "" {
 			return nil, fmt.Errorf("package %q contains channel with no name", c.Package)
+		}
+
+		if _, ok := mpkg.Channels[c.Name]; ok {
+			return nil, fmt.Errorf("package %q has duplicate channel %q", c.Package, c.Name)
 		}
 
 		mch := &model.Channel{
@@ -75,6 +83,10 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 		}
 	}
 
+	// packageBundles tracks the set of bundle names for each package
+	// and is used to detect duplicate bundles.
+	packageBundles := map[string]sets.String{}
+
 	for _, b := range cfg.Bundles {
 		if b.Package == "" {
 			return nil, fmt.Errorf("package name must be set for bundle %q", b.Name)
@@ -83,6 +95,16 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 		if !ok {
 			return nil, fmt.Errorf("unknown package %q for bundle %q", b.Package, b.Name)
 		}
+
+		bundles, ok := packageBundles[b.Package]
+		if !ok {
+			bundles = sets.NewString()
+		}
+		if bundles.Has(b.Name) {
+			return nil, fmt.Errorf("package %q has duplicate bundle %q", b.Package, b.Name)
+		}
+		bundles.Insert(b.Name)
+		packageBundles[b.Package] = bundles
 
 		props, err := property.Parse(b.Properties)
 		if err != nil {

--- a/alpha/declcfg/declcfg_to_model_test.go
+++ b/alpha/declcfg/declcfg_to_model_test.go
@@ -204,6 +204,42 @@ func TestConvertToModel(t *testing.T) {
 			},
 		},
 		{
+			name:      "Error/DuplicatePackage",
+			assertion: hasError(`duplicate package "foo"`),
+			cfg: DeclarativeConfig{
+				Packages: []Package{
+					newTestPackage("foo", "alpha", svgSmallCircle),
+					newTestPackage("foo", "alpha", svgSmallCircle),
+				},
+				Channels: []Channel{newTestChannel("foo", "alpha", ChannelEntry{Name: "foo.v0.1.0"})},
+				Bundles:  []Bundle{newTestBundle("foo", "0.1.0")},
+			},
+		},
+		{
+			name:      "Error/DuplicateChannel",
+			assertion: hasError(`package "foo" has duplicate channel "alpha"`),
+			cfg: DeclarativeConfig{
+				Packages: []Package{newTestPackage("foo", "alpha", svgSmallCircle)},
+				Channels: []Channel{
+					newTestChannel("foo", "alpha", ChannelEntry{Name: "foo.v0.1.0"}),
+					newTestChannel("foo", "alpha", ChannelEntry{Name: "foo.v0.1.0"}),
+				},
+				Bundles: []Bundle{newTestBundle("foo", "0.1.0")},
+			},
+		},
+		{
+			name:      "Error/DuplicateBundle",
+			assertion: hasError(`package "foo" has duplicate bundle "foo.v0.1.0"`),
+			cfg: DeclarativeConfig{
+				Packages: []Package{newTestPackage("foo", "alpha", svgSmallCircle)},
+				Channels: []Channel{newTestChannel("foo", "alpha", ChannelEntry{Name: "foo.v0.1.0"})},
+				Bundles: []Bundle{
+					newTestBundle("foo", "0.1.0"),
+					newTestBundle("foo", "0.1.0"),
+				},
+			},
+		},
+		{
 			name:      "Success/ValidModel",
 			assertion: require.NoError,
 			cfg: DeclarativeConfig{
@@ -242,7 +278,7 @@ func hasError(expectedError string) require.ErrorAssertionFunc {
 		if stdt, ok := t.(*testing.T); ok {
 			stdt.Helper()
 		}
-		if actualError.Error() == expectedError {
+		if actualError != nil && actualError.Error() == expectedError {
 			return
 		}
 		t.Errorf("expected error to be `%s`, got `%s`", expectedError, actualError)


### PR DESCRIPTION
Signed-off-by: Joe Lanford <joe.lanford@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
When `opm validate` (or any code that requires a file-based catalog to be converted to the registry's internal model) encounters a duplicate blob `olm.package`, `olm.channel`, or `olm.bundle` blob, emit an error.

**Motivation for the change:**
To prevent ambiguity in the way a file-based catalog is presented to consumers when there are duplicates. FBC is declarative, so it doesn't make sense to attempt to declare the same thing twice.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
