### PR TITLE
Clean indexfile for opm alpha generate dockerfile

### DIFF
--- a/cmd/opm/alpha/generate/cmd.go
+++ b/cmd/opm/alpha/generate/cmd.go
@@ -44,7 +44,7 @@ When specifying extra labels, note that if duplicate keys exist, only the last
 value of each duplicate key will be added to the generated Dockerfile.
 `,
 		RunE: func(_ *cobra.Command, args []string) error {
-			fromDir := args[0]
+			fromDir := filepath.Clean(args[0])
 
 			extraLabels, err := parseLabels(extraLabelStrs)
 			if err != nil {


### PR DESCRIPTION
drop trailing slash for catalog directory on `opm alpha generate dockerfile` to avoid / in the generated Dockerfile name

Closes #830