### PR TITLE
The `--skip-tls` flag shouldn't use the http protocol

### DIFF
--- a/pkg/image/containerdregistry/resolver.go
+++ b/pkg/image/containerdregistry/resolver.go
@@ -27,16 +27,11 @@ func NewResolver(configDir string, insecure bool, roots *x509.CertPool) (remotes
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 5 * time.Second,
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: false,
+			InsecureSkipVerify: insecure,
 			RootCAs:            roots,
 		},
 	}
 
-	if insecure {
-		transport.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: insecure,
-		}
-	}
 	headers := http.Header{}
 	headers.Set("User-Agent", "opm/alpha")
 
@@ -54,9 +49,6 @@ func NewResolver(configDir string, insecure bool, roots *x509.CertPool) (remotes
 			docker.WithAuthCreds(credential(cfg)),
 		)),
 		docker.WithClient(client),
-	}
-	if insecure {
-		regopts = append(regopts, docker.WithPlainHTTP(docker.MatchAllHosts))
 	}
 
 	opts := docker.ResolverOptions{


### PR DESCRIPTION
**Description of the change:**
This commit makes it so that the `https` scheme is still used even when
the `--skip-tls` flag is specified

**Motivation for the change:**
When using the `operator-sdk run bundle`'s `--skip-tls` flag which is
described as:

> skip authentication of image registry TLS certificate when pulling a bundle image in-cluster

It tries to access the image registry (given in the <bundle_image>
positional argument) using HTTP rather than HTTPS.

This behavior is unexpected and fails when the image registry only
speaks the HTTPS protocol.

The commit (a16399f05c380ba432691d2e1d99a69aa5a269e2) which seems to have introduced
this behavior doesn't mention this behavior anywhere, so I'm assuming
it's unintentional and therefore a bug that needs fixing - Let me know
if you think otherwise.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
