### PR TITLE
alpha/declcfg: re-encode olm.bundle.object data to JSON when loading

### DIFF
--- a/alpha/declcfg/load.go
+++ b/alpha/declcfg/load.go
@@ -87,14 +87,23 @@ func readBundleObjects(bundles []Bundle, root fs.FS, path string) error {
 	for bi, b := range bundles {
 		props, err := property.Parse(b.Properties)
 		if err != nil {
-			return fmt.Errorf("parse properties for bundle %q: %v", b.Name, err)
+			return fmt.Errorf("package %q, bundle %q: parse properties: %v", b.Package, b.Name, err)
 		}
 		for oi, obj := range props.BundleObjects {
+			objID := fmt.Sprintf(" %q", obj.GetRef())
+			if !obj.IsRef() {
+				objID = fmt.Sprintf("[%d]", oi)
+			}
+
 			d, err := obj.GetData(root, filepath.Dir(path))
 			if err != nil {
-				return fmt.Errorf("get data for bundle object[%d]: %v", oi, err)
+				return fmt.Errorf("package %q, bundle %q: get data for bundle object%s: %v", b.Package, b.Name, objID, err)
 			}
-			bundles[bi].Objects = append(bundles[bi].Objects, string(d))
+			objJson, err := yaml.ToJSON(d)
+			if err != nil {
+				return fmt.Errorf("package %q, bundle %q: convert object%s to JSON: %v", b.Package, b.Name, objID, err)
+			}
+			bundles[bi].Objects = append(bundles[bi].Objects, string(objJson))
 		}
 		bundles[bi].CsvJSON = extractCSV(bundles[bi].Objects)
 	}

--- a/alpha/declcfg/load_test.go
+++ b/alpha/declcfg/load_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/operator-framework/operator-registry/alpha/property"
 )
@@ -188,8 +189,8 @@ func TestLoadFS(t *testing.T) {
 							{Type: "olm.bundle.object", Value: json.RawMessage(`{"ref":"etcdoperator.v0.6.1.clusterserviceversion.yaml"}`)},
 						},
 						RelatedImages: []RelatedImage{{Name: "etcdv0.6.1", Image: "quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943"}},
-						Objects:       []string{string(etcdCSV.Data)},
-						CsvJSON:       string(etcdCSV.Data),
+						Objects:       []string{toJSON(t, etcdCSV.Data)},
+						CsvJSON:       toJSON(t, etcdCSV.Data),
 					},
 					{
 						Schema:  "olm.bundle",
@@ -278,6 +279,15 @@ func TestLoadFS(t *testing.T) {
 			}
 		})
 	}
+}
+
+func toJSON(t *testing.T, in []byte) string {
+	t.Helper()
+	out, err := yaml.ToJSON(in)
+	if err != nil {
+		t.Fatalf("failed converting testdata to JSON: %v", err)
+	}
+	return string(out)
 }
 
 var (


### PR DESCRIPTION
**Description of the change:**
This commit updates the FBC loading code such that data for all
olm.bundle.object properties are converted to JSON.

**Motivation for the change:**
Maintainers of file-based catalogs often have YAML manifests for their
bundle objects. However the GRPC API expects the CSV and bundle objects
to be presented with a JSON encoding.

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>

Closes #873 

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
