### PR TITLE
(.gitignore): Do not ignore debug/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,7 +179,6 @@ tags
 *.userprefs
 
 # Build results
-[Dd]ebug/
 [Dd]ebugPublic/
 x64/
 x86/


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

In PR #888, there's vendoring of the cel-go package, one of which
    is named "debug" (github.com/google/cel-go/common/debug). Due to
    the .gitignore file ignoring all [Dd]bug folders, the vendored
    package isn't being checked in by git, causing the build to fail.
    This PR removes the instruction to ignore [Dd]bug/ folders.
**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
Open question to consider: Do we see foresee any drastic consequence of not ignoring all [Dd]ebug folders, apart from unwanted `debug` folders showing up in PRs if `git add .` is invoked? If we do, is an explicit `!github.com/google/cel-go/common/debug` better? Although that is hard-coding the package, and potentially confusing future vendoring efforts.   