### PR TITLE
OPM: Check if image exists locally before pulling

### DIFF
--- a/pkg/containertools/runner.go
+++ b/pkg/containertools/runner.go
@@ -81,6 +81,11 @@ func (r *ContainerCommandRunner) GetToolName() string {
 // Pull takes a container image path hosted on a container registry and runs the
 // pull command to download it onto the local environment
 func (r *ContainerCommandRunner) Pull(image string) error {
+	if r.imagePresentLocally(image) {
+		// Image present locally, dont pull.
+		return nil
+	}
+
 	args := r.argsForCmd("pull", image)
 
 	command := exec.Command(r.containerTool.String(), args...)
@@ -181,4 +186,18 @@ func (r *ContainerCommandRunner) Inspect(image string) ([]byte, error) {
 	}
 
 	return out, err
+}
+
+// Checks if the passed image is present locally. Returns false
+// if a non-zero exit code (or any other error) is returned when
+// docker image inspect <image> is run.
+func (r *ContainerCommandRunner) imagePresentLocally(image string) bool {
+	args := r.argsForCmd("inspect", image)
+	command := exec.Command(r.containerTool.String(), args...)
+
+	_, err := command.CombinedOutput()
+	if err != nil {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION

**Description of the change:**
Fixes: https://github.com/operator-framework/operator-registry/issues/885.
The the opm package always assumes that the image is present in a remote registry, this PR allows opm to work off of locally present images by checking if an image is present locally before trying to pull it.

**Motivation for the change:**
 Make opm work with locally build index images.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
