### PR TITLE
fix(render/diff): Support olm.constraint in opm render/diff cmd

### DIFF
--- a/bundles/etcd.0.9.2/metadata/dependencies.yaml
+++ b/bundles/etcd.0.9.2/metadata/dependencies.yaml
@@ -4,3 +4,8 @@ dependencies:
     group: testapi.coreos.com
     kind: testapi
     version: v1
+- type: olm.constraint
+  value:
+    failureMessage: 'require to have "certified"'
+    cel:
+        rule: 'properties.exists(p, p.type == "certified")'

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/onsi/gomega v1.15.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6
-	github.com/operator-framework/api v0.11.0
+	github.com/operator-framework/api v0.11.1
 	github.com/otiai10/copy v1.2.0
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -649,8 +649,8 @@ github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700 h1:e
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
-github.com/operator-framework/api v0.11.0 h1:W9V1NNwl3LWPQL9S1pDaFONCarJLl8Xu6gdF9w54hTE=
-github.com/operator-framework/api v0.11.0/go.mod h1:FTiYGm11fZQ3cSX+EQHc/UWoGZAwkGfyeHU+wMJ8jmA=
+github.com/operator-framework/api v0.11.1 h1:5eNUMplyL/GZrnBgG4SS2csO3+Fl4F79OqXN6POHQyA=
+github.com/operator-framework/api v0.11.1/go.mod h1:FTiYGm11fZQ3cSX+EQHc/UWoGZAwkGfyeHU+wMJ8jmA=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=

--- a/pkg/registry/populator_test.go
+++ b/pkg/registry/populator_test.go
@@ -151,6 +151,10 @@ func TestQuerierForImage(t *testing.T) {
 				Type:  "olm.gvk",
 				Value: `{"group":"etcd.database.coreos.com","kind":"EtcdCluster","version":"v1beta2"}`,
 			},
+			{
+				Type:  "olm.constraint",
+				Value: `{"cel":{"rule":"properties.exists(p, p.type == \"certified\")"},"failureMessage":"require to have \"certified\""}`,
+			},
 		},
 		Properties: []*api.Property{
 			{
@@ -572,6 +576,10 @@ func TestQuerierForDependencies(t *testing.T) {
 			Type:  "olm.gvk",
 			Value: `{"group":"testprometheus.coreos.com","kind":"testtestprometheus","version":"v1"}`,
 		},
+		{
+			Type:  "olm.constraint",
+			Value: `{"cel":{"rule":"properties.exists(p, p.type == \"certified\")"},"failureMessage":"require to have \"certified\""}`,
+		},
 	}
 
 	type operatorbundle struct {
@@ -634,6 +642,14 @@ func TestListBundles(t *testing.T) {
 		{
 			Type:  "olm.gvk",
 			Value: `{"group":"etcd.database.coreos.com","kind":"EtcdCluster","version":"v1beta2"}`,
+		},
+		{
+			Type:  "olm.constraint",
+			Value: `{"cel":{"rule":"properties.exists(p, p.type == \"certified\")"},"failureMessage":"require to have \"certified\""}`,
+		},
+		{
+			Type:  "olm.constraint",
+			Value: `{"cel":{"rule":"properties.exists(p, p.type == \"certified\")"},"failureMessage":"require to have \"certified\""}`,
 		},
 	}
 

--- a/pkg/registry/registry_to_model.go
+++ b/pkg/registry/registry_to_model.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/operator-framework/api/pkg/constraints"
 	"github.com/operator-framework/operator-registry/alpha/property"
 )
 
@@ -56,11 +55,7 @@ func ObjectsAndPropertiesFromBundle(b *Bundle) ([]string, []property.Property, e
 				return nil, nil, property.ParseError{Idx: i, Typ: p.Type, Err: err}
 			}
 			packageRequiredProps = append(packageRequiredProps, property.MustBuildPackageRequired(v.PackageName, v.Version))
-		case constraints.OLMConstraintType:
-			var v constraints.Constraint
-			if err := json.Unmarshal(p.Value, &v); err != nil {
-				return nil, nil, property.ParseError{Idx: i, Typ: p.Type, Err: err}
-			}
+		default:
 			otherProps = append(otherProps, property.Property{
 				Type:  p.Type,
 				Value: p.Value,

--- a/pkg/registry/registry_to_model.go
+++ b/pkg/registry/registry_to_model.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/operator-framework/api/pkg/constraints"
 	"github.com/operator-framework/operator-registry/alpha/property"
 )
 
@@ -55,6 +56,15 @@ func ObjectsAndPropertiesFromBundle(b *Bundle) ([]string, []property.Property, e
 				return nil, nil, property.ParseError{Idx: i, Typ: p.Type, Err: err}
 			}
 			packageRequiredProps = append(packageRequiredProps, property.MustBuildPackageRequired(v.PackageName, v.Version))
+		case constraints.OLMConstraintType:
+			var v constraints.Constraint
+			if err := json.Unmarshal(p.Value, &v); err != nil {
+				return nil, nil, property.ParseError{Idx: i, Typ: p.Type, Err: err}
+			}
+			otherProps = append(otherProps, property.Property{
+				Type:  p.Type,
+				Value: p.Value,
+			})
 		}
 	}
 

--- a/pkg/registry/registry_to_model_test.go
+++ b/pkg/registry/registry_to_model_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,6 +38,7 @@ func testExpectedObjects() []string {
 }
 
 func testExpectedProperties() []property.Property {
+	constraint := `{"cel":{"rule":"properties.exists(p, p.type == \"certified\")"},"failureMessage":"require to have \"certified\""}`
 	props := []property.Property{
 		property.MustBuildPackage("etcd", "0.9.2"),
 		property.MustBuildGVKRequired("etcd.database.coreos.com", "v1beta2", "EtcdCluster"),
@@ -45,6 +47,10 @@ func testExpectedProperties() []property.Property {
 		property.MustBuildGVK("etcd.database.coreos.com", "v1beta2", "EtcdBackup"),
 		property.MustBuildGVK("etcd.database.coreos.com", "v1beta2", "EtcdRestore"),
 	}
+	props = append(props, property.Property{
+		Type:  "olm.constraint",
+		Value: json.RawMessage(constraint),
+	})
 	for _, obj := range testExpectedObjects() {
 		props = append(props, property.MustBuildBundleObjectData([]byte(obj)))
 	}

--- a/pkg/registry/registry_to_model_test.go
+++ b/pkg/registry/registry_to_model_test.go
@@ -38,7 +38,6 @@ func testExpectedObjects() []string {
 }
 
 func testExpectedProperties() []property.Property {
-	constraint := `{"cel":{"rule":"properties.exists(p, p.type == \"certified\")"},"failureMessage":"require to have \"certified\""}`
 	props := []property.Property{
 		property.MustBuildPackage("etcd", "0.9.2"),
 		property.MustBuildGVKRequired("etcd.database.coreos.com", "v1beta2", "EtcdCluster"),
@@ -46,11 +45,12 @@ func testExpectedProperties() []property.Property {
 		property.MustBuildGVK("etcd.database.coreos.com", "v1beta2", "EtcdCluster"),
 		property.MustBuildGVK("etcd.database.coreos.com", "v1beta2", "EtcdBackup"),
 		property.MustBuildGVK("etcd.database.coreos.com", "v1beta2", "EtcdRestore"),
+		property.Property{
+			Type:  "olm.constraint",
+			Value: json.RawMessage(`{"cel":{"rule":"properties.exists(p, p.type == \"certified\")"},"failureMessage":"require to have \"certified\""}`),
+		},
 	}
-	props = append(props, property.Property{
-		Type:  "olm.constraint",
-		Value: json.RawMessage(constraint),
-	})
+
 	for _, obj := range testExpectedObjects() {
 		props = append(props, property.MustBuildBundleObjectData([]byte(obj)))
 	}

--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -223,9 +223,9 @@ type LabelDependency struct {
 }
 
 type CelConstraint struct {
-	// Constraint message that surfaces in resolution
+	// Constraint failure message that surfaces in resolution
 	// This field is optional
-	Message string `json:"message" yaml:"message"`
+	FailureMessage string `json:"failureMessage" yaml:"failureMessage"`
 
 	// The cel struct that contraints CEL expression
 	// This field is required

--- a/vendor/github.com/operator-framework/api/pkg/constraints/constraint.go
+++ b/vendor/github.com/operator-framework/api/pkg/constraints/constraint.go
@@ -12,9 +12,9 @@ const OLMConstraintType = "olm.constraint"
 
 // Constraint holds parsed, potentially nested dependency constraints.
 type Constraint struct {
-	// Constraint message that surfaces in resolution
+	// Constraint failure message that surfaces in resolution
 	// This field is optional
-	Message string `json:"message,omitempty" yaml:"message,omitempty"`
+	FailureMessage string `json:"failureMessage,omitempty" yaml:"failureMessage,omitempty"`
 
 	// The cel struct that contraints CEL expression
 	Cel *Cel `json:"cel,omitempty" yaml:"cel,omitempty"`

--- a/vendor/github.com/operator-framework/api/pkg/validation/internal/good_practices.go
+++ b/vendor/github.com/operator-framework/api/pkg/validation/internal/good_practices.go
@@ -65,10 +65,10 @@ func validateResourceRequests(csv *operatorsv1alpha1.ClusterServiceVersion) (err
 	for _, dSpec := range deploymentSpec {
 		for _, c := range dSpec.Spec.Template.Spec.Containers {
 			if c.Resources.Requests == nil || !(len(c.Resources.Requests.Cpu().String()) != 0 && len(c.Resources.Requests.Memory().String()) != 0) {
-				msg := fmt.Errorf("unable to find the resource requests for the container %s. It is recommended "+
+				msg := fmt.Errorf("unable to find the resource requests for the container: (%s). It is recommended "+
 					"to ensure the resource request for CPU and Memory. Be aware that for some clusters configurations "+
 					"it is required to specify requests or limits for those values. Otherwise, the system or quota may "+
-					"reject Pod creation. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/", c.Name)
+					"reject Pod creation. More info: https://master.sdk.operatorframework.io/docs/best-practices/managing-resources/", c.Name)
 				warns = append(warns, msg)
 			}
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -416,7 +416,7 @@ github.com/opencontainers/go-digest
 ## explicit
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
-# github.com/operator-framework/api v0.11.0
+# github.com/operator-framework/api v0.11.1
 ## explicit
 github.com/operator-framework/api/pkg/constraints
 github.com/operator-framework/api/pkg/lib/version


### PR DESCRIPTION
Currently, the olm.constraint type is ignored and not recognized in
render and diff cmd. This commit is to add supoprt for constraint
type.

Signed-off-by: Vu Dinh <vudinh@outlook.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
