### PR TITLE
fix(opm): adds removal of empty packages when using opm diff in headsOnly mode

### DIFF
--- a/alpha/declcfg/diff.go
+++ b/alpha/declcfg/diff.go
@@ -101,7 +101,10 @@ func (g *DiffGenerator) Run(oldModel, newModel model.Model) (model.Model, error)
 					if len(ch.Bundles) == 0 {
 						delete(outputPkg.Channels, ch.Name)
 					}
-
+				}
+				if len(outputPkg.Channels) == 0 {
+					// Remove empty packages.
+					delete(outputModel, outputPkg.Name)
 				}
 			}
 		}

--- a/alpha/declcfg/diff_test.go
+++ b/alpha/declcfg/diff_test.go
@@ -1272,6 +1272,66 @@ func TestDiffHeadsOnly(t *testing.T) {
 			expCfg: DeclarativeConfig{},
 		},
 		{
+			name: "NoDiff/EmptyBundleWithInclude",
+			newCfg: DeclarativeConfig{
+				Packages: []Package{
+					{Schema: schemaPackage, Name: "etcd", DefaultChannel: "stable"},
+				},
+				Channels: []Channel{
+					{Schema: schemaChannel, Name: "stable", Package: "etcd", Entries: []ChannelEntry{
+						{Name: "etcd.v0.9.0"},
+						{Name: "etcd.v0.9.1", Replaces: "etcd.v0.9.0"},
+					}},
+					{Schema: schemaChannel, Name: "clusterwide", Package: "etcd", Entries: []ChannelEntry{
+						{Name: "etcd.v0.9.1-clusterwide"},
+					}},
+				},
+				Bundles: []Bundle{
+					{
+						Schema:  schemaBundle,
+						Name:    "etcd.v0.9.0",
+						Package: "etcd",
+						Image:   "reg/etcd:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("etcd", "0.9.1"),
+						},
+					},
+					{
+						Schema:  schemaBundle,
+						Name:    "etcd.v0.9.1",
+						Package: "etcd",
+						Image:   "reg/etcd:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("etcd", "0.9.1"),
+						},
+					},
+					{
+						Schema:  schemaBundle,
+						Name:    "etcd.v0.9.1-clusterwide",
+						Package: "etcd",
+						Image:   "reg/etcd:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("etcd", "0.9.1-clusterwide"),
+						},
+					},
+				},
+			},
+			g: &DiffGenerator{
+				IncludeAdditively: false,
+				Includer: DiffIncluder{
+					Packages: []DiffIncludePackage{
+						{
+							Name: "etcd",
+							AllChannels: DiffIncludeChannel{
+								Versions: []semver.Version{{Major: 0, Minor: 9, Patch: 2}},
+							},
+						},
+					},
+				},
+			},
+			expCfg: DeclarativeConfig{},
+		},
+		{
 			name: "HasDiff/OneBundle",
 			newCfg: DeclarativeConfig{
 				Packages: []Package{


### PR DESCRIPTION
opm diff in headsOnly mode with an include config will prune all empty channels
from a package which can leave the output config with an empty package. This change
will remove any empty packages after the channel pruning.

Fixes #904

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This PR removes empty packages when using `opm alpha diff` with no previous reference.


**Motivation for the change:**
To ensure file-based catalogs are not being created with invalid packages by `opm alpha diff`

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
