### PR TITLE
chore: update o-f/api version to v0.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/onsi/gomega v1.15.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6
-	github.com/operator-framework/api v0.11.1
+	github.com/operator-framework/api v0.12.0
 	github.com/otiai10/copy v1.2.0
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -652,8 +652,8 @@ github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700 h1:e
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
-github.com/operator-framework/api v0.11.1 h1:5eNUMplyL/GZrnBgG4SS2csO3+Fl4F79OqXN6POHQyA=
-github.com/operator-framework/api v0.11.1/go.mod h1:FTiYGm11fZQ3cSX+EQHc/UWoGZAwkGfyeHU+wMJ8jmA=
+github.com/operator-framework/api v0.12.0 h1:aHxHk50/Y1J4Ogdk2J6tYofgX+GEqyBPCMyun+JFqV4=
+github.com/operator-framework/api v0.12.0/go.mod h1:FTiYGm11fZQ3cSX+EQHc/UWoGZAwkGfyeHU+wMJ8jmA=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=

--- a/vendor/github.com/operator-framework/api/pkg/constraints/constraint.go
+++ b/vendor/github.com/operator-framework/api/pkg/constraints/constraint.go
@@ -25,14 +25,15 @@ type Constraint struct {
 	// GVK defines a constraint for a GVK.
 	GVK *GVKConstraint `json:"gvk,omitempty" yaml:"gvk,omitempty"`
 
-	// All, Any, and None are compound constraints. See this enhancement for details:
+	// All, Any, and Not are compound constraints. See this enhancement for details:
 	// https://github.com/operator-framework/enhancements/blob/master/enhancements/compound-bundle-constraints.md
 	All *CompoundConstraint `json:"all,omitempty" yaml:"all,omitempty"`
 	Any *CompoundConstraint `json:"any,omitempty" yaml:"any,omitempty"`
-	// A note on None: this constraint is not particularly useful by itself.
+	// A note on Not: this constraint isn't particularly useful by itself.
 	// It should be used within an All constraint alongside some other constraint type
-	// since saying "none of these GVKs/packages/etc." without an alternative doesn't make sense.
-	None *CompoundConstraint `json:"none,omitempty" yaml:"none,omitempty"`
+	// since saying "do not use any of these GVKs/packages/etc." without an alternative
+	// doesn't make sense.
+	Not *CompoundConstraint `json:"not,omitempty" yaml:"not,omitempty"`
 }
 
 // CompoundConstraint holds a list of potentially nested constraints

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -420,7 +420,7 @@ github.com/opencontainers/go-digest
 ## explicit
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
-# github.com/operator-framework/api v0.11.1
+# github.com/operator-framework/api v0.12.0
 ## explicit
 github.com/operator-framework/api/pkg/constraints
 github.com/operator-framework/api/pkg/lib/version


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Updating the operator framework API version to be v0.12.0.

**Motivation for the change:**
The latest version of the operator framework API, [v0.12.0](https://github.com/operator-framework/api/releases), is out and includes a breaking change by removing the "None" constraint and replacing it with "Not".

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
