### PR TITLE
fix: use gnutar in macos github action to avoid corrupting tar file contents

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -88,7 +88,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_ARGS: release --rm-dist -f release/goreleaser.darwin.yaml --skip-validate ${{ github.event_name == 'pull_request' && '--snapshot' || '' }}
 
-      - run: tar -cvf dist-darwin.tar dist
+      - run: gtar -cvf dist-darwin.tar dist
       - uses: actions/upload-artifact@v2
         with:
           name: dist-darwin


### PR DESCRIPTION


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Workaround for https://github.com/actions/virtual-environments/issues/2619

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>

**Motivation for the change:**
Avoid corrupted darwin binaries

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
