### PR TITLE
fix(validate): Fix constraint validation for non-CEL type

### DIFF
--- a/pkg/lib/bundle/validate_test.go
+++ b/pkg/lib/bundle/validate_test.go
@@ -41,7 +41,7 @@ func TestValidateBundleDependencies(t *testing.T) {
 			mediaType:   RegistryV1Type,
 			directory:   "./testdata/validate/invalid_dependencies_bundle/invalid_gvk_dependency/",
 			errs: []error{
-				fmt.Errorf("couldn't parse dependency of type olm.gvk"),
+				fmt.Errorf("couldn't parse dependency of type olm.gvk: unexpected end of JSON input"),
 			},
 		},
 		{

--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -222,16 +222,6 @@ type LabelDependency struct {
 	Label string `json:"label" yaml:"label"`
 }
 
-type CelConstraint struct {
-	// Constraint failure message that surfaces in resolution
-	// This field is optional
-	FailureMessage string `json:"failureMessage" yaml:"failureMessage"`
-
-	// The cel struct that contraints CEL expression
-	// This field is required
-	Cel *constraints.Cel `json:"cel" yaml:"cel"`
-}
-
 type GVKProperty struct {
 	// The group of GVK based property
 	Group string `json:"group" yaml:"group"`
@@ -301,25 +291,6 @@ func (pd *PackageDependency) Validate() []error {
 	return errs
 }
 
-// Validate will validate constraint type and return error(s)
-func (cc *CelConstraint) Validate() []error {
-	errs := []error{}
-	if cc.Cel == nil {
-		errs = append(errs, fmt.Errorf("The CEL field is missing"))
-	} else {
-		if cc.Cel.Rule == "" {
-			errs = append(errs, fmt.Errorf("The CEL expression is missing"))
-			return errs
-		}
-		validator := constraints.NewCelEnvironment()
-		_, err := validator.Validate(cc.Cel.Rule)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("Invalid CEL expression: %s", err.Error()))
-		}
-	}
-	return errs
-}
-
 // GetDependencies returns the list of dependency
 func (d *DependenciesFile) GetDependencies() []*Dependency {
 	var dependencies []*Dependency
@@ -337,38 +308,39 @@ func (e *Dependency) GetType() string {
 
 // GetTypeValue returns the dependency object that is converted
 // from value string
-func (e *Dependency) GetTypeValue() interface{} {
+func (e *Dependency) GetTypeValue() (interface{}, error) {
+	var err error
 	switch e.GetType() {
 	case GVKType:
 		dep := GVKDependency{}
-		err := json.Unmarshal([]byte(e.GetValue()), &dep)
+		err = json.Unmarshal([]byte(e.GetValue()), &dep)
 		if err != nil {
-			return nil
+			return nil, err
 		}
-		return dep
+		return dep, nil
 	case PackageType:
 		dep := PackageDependency{}
-		err := json.Unmarshal([]byte(e.GetValue()), &dep)
+		err = json.Unmarshal([]byte(e.GetValue()), &dep)
 		if err != nil {
-			return nil
+			return nil, err
 		}
-		return dep
+		return dep, nil
 	case LabelType:
 		dep := LabelDependency{}
-		err := json.Unmarshal([]byte(e.GetValue()), &dep)
+		err = json.Unmarshal([]byte(e.GetValue()), &dep)
 		if err != nil {
-			return nil
+			return nil, err
 		}
-		return dep
+		return dep, nil
 	case ConstraintType:
-		dep := CelConstraint{}
-		err := json.Unmarshal([]byte(e.GetValue()), &dep)
+		var dep constraints.Constraint
+		dep, err = constraints.Parse(e.Value)
 		if err != nil {
-			return nil
+			return nil, err
 		}
-		return dep
+		return dep, nil
 	}
-	return nil
+	return nil, nil
 }
 
 // GetValue returns the value content of dependency
@@ -409,4 +381,23 @@ func (a Annotations) SelectDefaultChannel() string {
 	sort.Strings(channels)
 
 	return channels[0]
+}
+
+// Validate CEL expression in CEL-type constraint
+func ValidateCEL(constraint constraints.Constraint) []error {
+	errs := []error{}
+	if constraint.Cel != nil {
+		if constraint.Cel.Rule == "" {
+			errs = append(errs, fmt.Errorf("The CEL expression is missing"))
+			return errs
+		}
+		validator := constraints.NewCelEnvironment()
+		_, err := validator.Validate(constraint.Cel.Rule)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("Invalid CEL expression: %s", err.Error()))
+		}
+		return errs
+	}
+
+	return errs
 }

--- a/pkg/registry/types_test.go
+++ b/pkg/registry/types_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/operator-framework/api/pkg/constraints"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,13 +18,6 @@ func TestCelConstraintValidation(t *testing.T) {
 		{
 			name:       "ValidCelConstraint",
 			constraint: `{"cel":{"rule":"properties.exists(p, p.type == 'olm.test' && (semver_compare(p.value, '1.0.0') == 0))"}}`,
-		},
-		{
-			name:       "InvalidCelConstraint/MissingCel",
-			constraint: `{}`,
-			errs: []error{
-				fmt.Errorf("The CEL field is missing"),
-			},
 		},
 		{
 			name:       "InvalidCelConstraint/MissingRule",
@@ -50,10 +44,10 @@ func TestCelConstraintValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var dep CelConstraint
+			var dep constraints.Constraint
 			err := json.Unmarshal([]byte(tt.constraint), &dep)
 			assert.NoError(t, err)
-			errs := dep.Validate()
+			errs := ValidateCEL(dep)
 			if len(tt.errs) > 0 {
 				assert.Error(t, errs[0])
 				assert.Contains(t, errs[0].Error(), tt.errs[0].Error())


### PR DESCRIPTION
Currently, the constraint type can be either CEL or compound constraint.
The existing constraint validation assumes every constraint is CEL-type
which is not correct. The new validation will parse JSON into constraint
type and will validate CEL expression if it is CEL-type.

Signed-off-by: Vu Dinh <vudinh@outlook.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
