### PR TITLE
fix(opm diff): handle cyclic dependency graph

### DIFF
--- a/alpha/action/diff.go
+++ b/alpha/action/diff.go
@@ -32,8 +32,8 @@ type Diff struct {
 	Logger *logrus.Entry
 }
 
-func (a Diff) Run(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
-	if err := a.validate(); err != nil {
+func (diff Diff) Run(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
+	if err := diff.validate(); err != nil {
 		return nil, err
 	}
 
@@ -42,8 +42,8 @@ func (a Diff) Run(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
 
 	// Heads-only mode does not require an old ref, so there may be nothing to render.
 	var oldModel model.Model
-	if len(a.OldRefs) != 0 {
-		oldRender := Render{Refs: a.OldRefs, Registry: a.Registry, AllowedRefMask: mask}
+	if len(diff.OldRefs) != 0 {
+		oldRender := Render{Refs: diff.OldRefs, Registry: diff.Registry, AllowedRefMask: mask}
 		oldCfg, err := oldRender.Run(ctx)
 		if err != nil {
 			if errors.Is(err, ErrNotAllowed) {
@@ -57,7 +57,7 @@ func (a Diff) Run(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
 		}
 	}
 
-	newRender := Render{Refs: a.NewRefs, Registry: a.Registry, AllowedRefMask: mask}
+	newRender := Render{Refs: diff.NewRefs, Registry: diff.Registry, AllowedRefMask: mask}
 	newCfg, err := newRender.Run(ctx)
 	if err != nil {
 		if errors.Is(err, ErrNotAllowed) {
@@ -71,10 +71,10 @@ func (a Diff) Run(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
 	}
 
 	g := &declcfg.DiffGenerator{
-		Logger:            a.Logger,
-		SkipDependencies:  a.SkipDependencies,
-		Includer:          convertIncludeConfigToIncluder(a.IncludeConfig),
-		IncludeAdditively: a.IncludeAdditively,
+		Logger:            diff.Logger,
+		SkipDependencies:  diff.SkipDependencies,
+		Includer:          convertIncludeConfigToIncluder(diff.IncludeConfig),
+		IncludeAdditively: diff.IncludeAdditively,
 	}
 	diffModel, err := g.Run(oldModel, newModel)
 	if err != nil {


### PR DESCRIPTION
While generating a diff from a catalog that has operators that specify dependencies
that are cyclic in nature, eg a->b, b->a, the `opm alpha diff` command hangs. This
was happening because while generating the diff, the command does a breadth-first
search of the dependency graph generated by the operator bundles, but did not keep
a track of the already visited bundles. As a result, when there was a cycle in the
dependency graph, the command was stuck in an infinite loop.

This PR fixes the issue by keeping track of the already visited bundles during the
search, and moving the search forward with only the bundles that haven't been visited
before.

Fixes #936

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
