### PR TITLE
update grpc-health-probe version to 4.8

### DIFF
--- a/release/goreleaser.opm.Dockerfile
+++ b/release/goreleaser.opm.Dockerfile
@@ -2,7 +2,7 @@
 #   build opm images. See the configurations in .goreleaser.yaml
 #   and .github/workflows/release.yaml.
 
-FROM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.6 as grpc_health_probe
+FROM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.8 as grpc_health_probe
 FROM gcr.io/distroless/static:debug
 COPY --from=grpc_health_probe /ko-app/grpc-health-probe /bin/grpc_health_probe
 COPY ["nsswitch.conf", "/etc/nsswitch.conf"]

--- a/upstream-builder.Dockerfile
+++ b/upstream-builder.Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /build
 
 COPY . .
 RUN make static
-RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.8 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-$(go env GOARCH) && \
     chmod +x /bin/grpc_health_probe
 

--- a/upstream-opm-builder.Dockerfile
+++ b/upstream-opm-builder.Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /build
 
 COPY . .
 RUN make static
-RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.8 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-$(go env GOARCH) && \
     chmod +x /bin/grpc_health_probe
 


### PR DESCRIPTION
**Description of the change:**

update the grpc-health-probe version to 4.8 for registry and opm builder

**Motivation for the change:**

The existing version 3.2 of grpc-health-probe uses go 1.13 which causes lots of vulnerabilities to appear  in security scans.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
