### PR TITLE
Smooth phrasing in under-the-hood graph update passage

### DIFF
--- a/docs/design/opm-tooling.md
+++ b/docs/design/opm-tooling.md
@@ -116,23 +116,23 @@ Running this command will still generate the updated registry database, but it w
 
 In an effort to make channel head selection understandable and deterministic when bulk-adding bundles to an index using `--mode=replaces` (the default), the following heuristic has been adopted: the bundles with the highest version within a package are considered the heads of the channels they belong to.
 
-<ul>
-
 #### Under the Hood
 
-`opm` effectively decomposes bundle addition into three steps for each package:
+`opm` effectively decomposes bundle addition into the following steps for each package:
 
-1. Add bundles to the underlying data store
-2. Choose the channel heads and default channel
-3. Rebuild the update graph starting at the new heads
-
-Channel head -- the "latest" operator in a channel -- selection is now informed by [semver](https://semver.org/). The heurstic is simple, the bundle with the highest version in each channel becomes the new head. The default channel is then taken from the maximum versioned bundle which defines a default channel.
+- Add bundles to the underlying data store
+- Choose the channel heads and default channel
+- Rebuild the update graph starting at the new heads  
+   
+Channel head -- the "latest" operator in a channel -- selection is now informed by [semver](https://semver.org/). The heurstic is that the bundle with the highest version in each channel becomes the new head. The default channel is then taken from the maximum versioned bundle which defines a default channel.
 
 Starting from these heads, opm then rebuilds the entire update graph using the edges defined by the `replaces` and `skips` CSV fields.
 
-If a given CSV is missing a version field, all CSVs (sourced from the command's arguments) belonging package are elided from the input. Additionally, a non-zero exit code is returned from the command.
-CSVs without a version (and with duplicate versions) that are already part of the index are allowed so long as there is at least one CSV with a version field in the package that we can recognize as having the maximum version.
-When `--overwrite-latest` is set, all bundle in a package are deleted and passed in as "input", and thus are constrained by the rules set out in the first paragraph above; the exceptions set out in the second paragraph above do not apply, and violations cause the offending package to be excluded from the index.
+If a given CSV is missing a version field, the command ignores all CSVs (sourced from the command's arguments) belonging to that package and exits with a non-zero status code.  
+    
+CSVs without a version (and with duplicate versions) that are *already part of the index* are allowed so long as there is at least one CSV with a version field in the package that is recognizable as having the maximum version.  
+    
+When `--overwrite-latest` is set, all existing bundles in a package are processed as new "input", and are thus constrained by the rules for new bundles with no exception for previously-existing unversioned/duplicatively-versioned CSVs, and any offending package in input will be excluded from the resulting index.
 
 #### What does this mean for a package author?
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Attempt to make verbiage less complex by:
- removing commentary
- eliminating passive voice
- adding emphasis to distinguish between `new` and `already-present` CSV cases during graph rebuild
- eliminated paragraph references
- add whitespace to delimit complete thoughts and focus the eye on the fact that they were discrete

**Motivation for the change:**
As a first-touch user reading the docs, I found it difficult to follow the graph update section and thought it could be simplified while retaining intent

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
