### PR TITLE
✨ adds some extra text context to sql statement errors

### DIFF
--- a/pkg/registry/populator.go
+++ b/pkg/registry/populator.go
@@ -255,7 +255,7 @@ func (i *DirectoryPopulator) loadManifestsSemver(bundle *Bundle, skippatch bool)
 	}
 
 	if err := i.loader.AddBundleSemver(updatedGraph, bundle); err != nil {
-		return fmt.Errorf("error loading bundle into db: %s", err)
+		return fmt.Errorf("error loading bundle %s into db: %s", bundle.Name, err)
 	}
 
 	return nil
@@ -268,7 +268,7 @@ func (i *DirectoryPopulator) loadOperatorBundle(manifest PackageManifest, bundle
 	}
 
 	if err := i.loader.AddBundlePackageChannels(manifest, bundle); err != nil {
-		return fmt.Errorf("error loading bundle into db: %s", err)
+		return fmt.Errorf("error loading bundle %s into db: %s", bundle.Name, err)
 	}
 
 	return nil

--- a/pkg/sqlite/loadprocs.go
+++ b/pkg/sqlite/loadprocs.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"database/sql"
+	"fmt"
 )
 
 // TODO: Finish separating procedures from loader layer: make this a type to make
@@ -15,7 +16,7 @@ func addChannelEntry(tx *sql.Tx, channelName, packageName, csvName string, depth
 
 	res, err := addChannelEntry.Exec(channelName, packageName, csvName, depth)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to insert channel_entry for channel (%s) and bundle (%s): %s", channelName, csvName, err)
 	}
 	currentID, err := res.LastInsertId()
 	if err != nil {
@@ -34,7 +35,7 @@ func addReplaces(tx *sql.Tx, replacesID, entryID int64) error {
 
 	_, err = addReplaces.Exec(replacesID, entryID)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to update channel_entry to set replaces (%d) for entry (%d): %s", replacesID, entryID, err)
 	}
 
 	return nil
@@ -49,7 +50,7 @@ func addPackage(tx *sql.Tx, packageName string) error {
 
 	_, err = addPackage.Exec(packageName)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to insert package (%s): %s", packageName, err)
 	}
 
 	return nil
@@ -64,7 +65,7 @@ func addPackageIfNotExists(tx *sql.Tx, packageName string) error {
 
 	_, err = addPackage.Exec(packageName)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to insert or replace package (%s): %s", packageName, err)
 	}
 
 	return nil
@@ -79,7 +80,7 @@ func addChannel(tx *sql.Tx, channelName, packageName, headCsvName string) error 
 
 	_, err = addChannel.Exec(channelName, packageName, headCsvName)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to insert channel (%s) for package (%s) with head (%s) : %s", channelName, packageName, headCsvName, err)
 	}
 
 	return nil
@@ -94,7 +95,8 @@ func updateChannel(tx *sql.Tx, channelName, packageName, headCsvName string) err
 
 	_, err = updateChannel.Exec(channelName, packageName, headCsvName)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to update channel (%s) for package (%s) with head (%s) : %s", channelName, packageName, headCsvName, err)
+
 	}
 
 	return nil
@@ -109,7 +111,7 @@ func addOrUpdateChannel(tx *sql.Tx, channelName, packageName, headCsvName string
 
 	_, err = addChannel.Exec(channelName, packageName, headCsvName)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to insert or update channel (%s) for package (%s) with head (%s) : %s", channelName, packageName, headCsvName, err)
 	}
 
 	return nil
@@ -124,7 +126,7 @@ func updateDefaultChannel(tx *sql.Tx, channelName, packageName string) error {
 
 	_, err = updateDefaultChannel.Exec(channelName, packageName)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to set default channel (%s) for package (%s): %s", channelName, packageName, err)
 	}
 
 	return nil
@@ -139,7 +141,7 @@ func truncChannelGraph(tx *sql.Tx, channelName, packageName string) error {
 
 	_, err = truncChannelGraph.Exec(channelName, packageName)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to delete channel entry for channel name (%s) and package (%s): %s", channelName, packageName, err)
 	}
 
 	return nil


### PR DESCRIPTION
**Description**
- Add some extra context to the errors, mainly to retrieve the data (SQL)


**Motivation**
- Try to reduce the toll until SQL not be removed. I.e., https://github.com/operator-framework/operator-registry/issues/952. Further info can be helpful for troubleshooting and trying to find workarounds. 

**Tested locally**

<img width="1280" alt="Screenshot 2022-05-18 at 14 10 44" src="https://user-images.githubusercontent.com/7708031/169046555-ac33011f-9bb5-44f7-ae61-72eaabe36f8c.png">

Closes https://github.com/operator-framework/operator-registry/issues/952 because, via OPM, we can only provide extra info to clarify the scenario/why the error occurs. 
