### PR TITLE
fix(diff): adds empty channel pruning with an include config on lates…

### DIFF
--- a/alpha/declcfg/diff.go
+++ b/alpha/declcfg/diff.go
@@ -99,20 +99,19 @@ func (g *DiffGenerator) Run(oldModel, newModel model.Model) (model.Model, error)
 			if err := latestPruneFromOutput(); err != nil {
 				return nil, err
 			}
-		} else {
-			for _, outputPkg := range outputModel {
-				for _, ch := range outputPkg.Channels {
-					if len(ch.Bundles) == 0 {
-						delete(outputPkg.Channels, ch.Name)
-					}
-				}
-				if len(outputPkg.Channels) == 0 {
-					// Remove empty packages.
-					delete(outputModel, outputPkg.Name)
-				}
-			}
 		}
 
+		for _, outputPkg := range outputModel {
+			for _, ch := range outputPkg.Channels {
+				if len(ch.Bundles) == 0 {
+					delete(outputPkg.Channels, ch.Name)
+				}
+			}
+			if len(outputPkg.Channels) == 0 {
+				// Remove empty packages.
+				delete(outputModel, outputPkg.Name)
+			}
+		}
 	case isInclude: // Add included objects to outputModel.
 
 		// Assume heads-only is false for include additively since we already have the channel heads

--- a/alpha/declcfg/diff_test.go
+++ b/alpha/declcfg/diff_test.go
@@ -131,6 +131,76 @@ func TestDiffLatest(t *testing.T) {
 			expCfg: DeclarativeConfig{},
 		},
 		{
+			name:   "HasDiff/EmptyChannel",
+			oldCfg: DeclarativeConfig{},
+			newCfg: DeclarativeConfig{
+				Packages: []Package{
+					{Schema: schemaPackage, Name: "foo", DefaultChannel: "stable"},
+				},
+				Channels: []Channel{
+					{Schema: schemaChannel, Name: "stable", Package: "foo", Entries: []ChannelEntry{
+						{Name: "foo.v0.2.0"},
+					}},
+					{Schema: schemaChannel, Name: "v1", Package: "foo", Entries: []ChannelEntry{
+						{Name: "foo.v0.1.0"},
+					}},
+				},
+				Bundles: []Bundle{
+					{
+						Schema:  schemaBundle,
+						Name:    "foo.v0.1.0",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.1.0"),
+						},
+					},
+					{
+						Schema:  schemaBundle,
+						Name:    "foo.v0.2.0",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.2.0"),
+						},
+					},
+				},
+			},
+			g: &DiffGenerator{
+				Includer: DiffIncluder{
+					Packages: []DiffIncludePackage{
+						{
+							Name: "foo",
+							AllChannels: DiffIncludeChannel{
+								Versions: []semver.Version{semver.MustParse("0.2.0")},
+							},
+						},
+					},
+				},
+			},
+			expCfg: DeclarativeConfig{
+				Packages: []Package{
+					{Schema: schemaPackage, Name: "foo", DefaultChannel: "stable"},
+				},
+				Channels: []Channel{
+					{Schema: schemaChannel, Name: "stable", Package: "foo", Entries: []ChannelEntry{
+						{Name: "foo.v0.2.0"},
+					}},
+				},
+				Bundles: []Bundle{
+					{
+						Schema:  schemaBundle,
+						Name:    "foo.v0.2.0",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.2.0"),
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "HasDiff/OneModifiedBundle",
 			oldCfg: DeclarativeConfig{
 				Packages: []Package{
@@ -1331,6 +1401,76 @@ func TestDiffHeadsOnly(t *testing.T) {
 				},
 			},
 			expCfg: DeclarativeConfig{},
+		},
+		{
+			name: "HasDiff/EmptyChannel",
+			newCfg: DeclarativeConfig{
+				Packages: []Package{
+					{Schema: schemaPackage, Name: "foo", DefaultChannel: "stable"},
+				},
+				Channels: []Channel{
+					{Schema: schemaChannel, Name: "stable", Package: "foo", Entries: []ChannelEntry{
+						{Name: "foo.v0.2.0"},
+					}},
+					{Schema: schemaChannel, Name: "v1", Package: "foo", Entries: []ChannelEntry{
+						{Name: "foo.v0.1.0"},
+					}},
+				},
+				Bundles: []Bundle{
+					{
+						Schema:  schemaBundle,
+						Name:    "foo.v0.1.0",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.1.0"),
+						},
+					},
+					{
+						Schema:  schemaBundle,
+						Name:    "foo.v0.2.0",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.2.0"),
+						},
+					},
+				},
+			},
+			g: &DiffGenerator{
+				HeadsOnly: true,
+				Includer: DiffIncluder{
+					Packages: []DiffIncludePackage{
+						{
+							Name: "foo",
+							AllChannels: DiffIncludeChannel{
+								Versions: []semver.Version{semver.MustParse("0.2.0")},
+							},
+						},
+					},
+				},
+			},
+			expCfg: DeclarativeConfig{
+				Packages: []Package{
+					{Schema: schemaPackage, Name: "foo", DefaultChannel: "stable"},
+				},
+				Channels: []Channel{
+					{Schema: schemaChannel, Name: "stable", Package: "foo", Entries: []ChannelEntry{
+						{Name: "foo.v0.2.0"},
+					}},
+				},
+				Bundles: []Bundle{
+					{
+						Schema:  schemaBundle,
+						Name:    "foo.v0.2.0",
+						Package: "foo",
+						Image:   "reg/foo:latest",
+						Properties: []property.Property{
+							property.MustBuildPackage("foo", "0.2.0"),
+						},
+					},
+				},
+			},
 		},
 		{
 			name: "HasDiff/OneBundle",


### PR DESCRIPTION
…t mode

Fixes #957

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

This PR adds a fix and tests for `opm alpha diff` to ensure empty channels are pruned when heads-only is false.

**Motivation for the change:**
To fix a bug opm diff methods

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE NUMBER>

-->
