### PR TITLE
Enhance diff logic to set a new defaultChannel by adding a priority property to a channel

### DIFF
--- a/alpha/declcfg/declcfg_to_model.go
+++ b/alpha/declcfg/declcfg_to_model.go
@@ -53,9 +53,10 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 		}
 
 		mch := &model.Channel{
-			Package: mpkg,
-			Name:    c.Name,
-			Bundles: map[string]*model.Bundle{},
+			Package:    mpkg,
+			Name:       c.Name,
+			Bundles:    map[string]*model.Bundle{},
+			Properties: c.Properties,
 		}
 
 		cde := sets.NewString()

--- a/alpha/declcfg/declcfg_to_model.go
+++ b/alpha/declcfg/declcfg_to_model.go
@@ -53,9 +53,12 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 		}
 
 		mch := &model.Channel{
-			Package:    mpkg,
-			Name:       c.Name,
-			Bundles:    map[string]*model.Bundle{},
+			Package: mpkg,
+			Name:    c.Name,
+			Bundles: map[string]*model.Bundle{},
+			// NOTICE: The field Properties of the type Channel is for internal use only.
+			//   DO NOT use it for any public-facing functionalities.
+			//   This API is in alpha stage and it is subject to change.
 			Properties: c.Properties,
 		}
 

--- a/alpha/declcfg/model_to_declcfg.go
+++ b/alpha/declcfg/model_to_declcfg.go
@@ -60,10 +60,11 @@ func traverseModelChannels(mpkg model.Package) ([]Channel, []Bundle) {
 	for _, ch := range mpkg.Channels {
 		// initialize channel
 		c := Channel{
-			Schema:  SchemaChannel,
-			Name:    ch.Name,
-			Package: ch.Package.Name,
-			Entries: []ChannelEntry{},
+			Schema:     SchemaChannel,
+			Name:       ch.Name,
+			Package:    ch.Package.Name,
+			Entries:    []ChannelEntry{},
+			Properties: ch.Properties,
 		}
 
 		for _, chb := range ch.Bundles {

--- a/alpha/declcfg/model_to_declcfg.go
+++ b/alpha/declcfg/model_to_declcfg.go
@@ -60,10 +60,13 @@ func traverseModelChannels(mpkg model.Package) ([]Channel, []Bundle) {
 	for _, ch := range mpkg.Channels {
 		// initialize channel
 		c := Channel{
-			Schema:     SchemaChannel,
-			Name:       ch.Name,
-			Package:    ch.Package.Name,
-			Entries:    []ChannelEntry{},
+			Schema:  SchemaChannel,
+			Name:    ch.Name,
+			Package: ch.Package.Name,
+			Entries: []ChannelEntry{},
+			// NOTICE: The field Properties of the type Channel is for internal use only.
+			//   DO NOT use it for any public-facing functionalities.
+			//   This API is in alpha stage and it is subject to change.
 			Properties: ch.Properties,
 		}
 

--- a/alpha/model/model.go
+++ b/alpha/model/model.go
@@ -131,9 +131,10 @@ func (i *Icon) validateData() error {
 }
 
 type Channel struct {
-	Package *Package
-	Name    string
-	Bundles map[string]*Bundle
+	Package    *Package
+	Name       string
+	Bundles    map[string]*Bundle
+	Properties []property.Property
 }
 
 // TODO(joelanford): This function determines the channel head by finding the bundle that has 0

--- a/alpha/model/model.go
+++ b/alpha/model/model.go
@@ -131,9 +131,12 @@ func (i *Icon) validateData() error {
 }
 
 type Channel struct {
-	Package    *Package
-	Name       string
-	Bundles    map[string]*Bundle
+	Package *Package
+	Name    string
+	Bundles map[string]*Bundle
+	// NOTICE: The field Properties of the type Channel is for internal use only.
+	//   DO NOT use it for any public-facing functionalities.
+	//   This API is in alpha stage and it is subject to change.
 	Properties []property.Property
 }
 

--- a/alpha/property/property.go
+++ b/alpha/property/property.go
@@ -39,6 +39,12 @@ type Package struct {
 	Version     string `json:"version"`
 }
 
+type Channel struct {
+	ChannelName string `json:"channelName"`
+	//Priority    string `json:"priority"`
+	Priority int `json:"priority"`
+}
+
 type PackageRequired struct {
 	PackageName  string `json:"packageName"`
 	VersionRange string `json:"versionRange"`
@@ -118,6 +124,7 @@ type Properties struct {
 	GVKs             []GVK             `hash:"set"`
 	GVKsRequired     []GVKRequired     `hash:"set"`
 	BundleObjects    []BundleObject    `hash:"set"`
+	Channels         []Channel         `hash:"set"`
 
 	Others []Property `hash:"set"`
 }
@@ -128,6 +135,7 @@ const (
 	TypeGVK             = "olm.gvk"
 	TypeGVKRequired     = "olm.gvk.required"
 	TypeBundleObject    = "olm.bundle.object"
+	TypeChannel         = "olm.channel"
 )
 
 func Parse(in []Property) (*Properties, error) {
@@ -164,6 +172,12 @@ func Parse(in []Property) (*Properties, error) {
 				return nil, ParseError{Idx: i, Typ: prop.Type, Err: err}
 			}
 			out.BundleObjects = append(out.BundleObjects, p)
+		case TypeChannel:
+			var p Channel
+			if err := json.Unmarshal(prop.Value, &p); err != nil {
+				return nil, ParseError{Idx: i, Typ: prop.Type, Err: err}
+			}
+			out.Channels = append(out.Channels, p)
 		default:
 			var p json.RawMessage
 			if err := json.Unmarshal(prop.Value, &p); err != nil {
@@ -264,4 +278,7 @@ func MustBuildBundleObjectRef(ref string) Property {
 }
 func MustBuildBundleObjectData(data []byte) Property {
 	return MustBuild(&BundleObject{File: File{data: data}})
+}
+func MustBuildChannelPriority(name string, priority int) Property {
+	return MustBuild(&Channel{ChannelName: name, Priority: priority})
 }

--- a/alpha/property/property.go
+++ b/alpha/property/property.go
@@ -39,6 +39,9 @@ type Package struct {
 	Version     string `json:"version"`
 }
 
+// NOTICE: The Channel properties are for internal use only.
+//   DO NOT use it for any public-facing functionalities.
+//   This API is in alpha stage and it is subject to change.
 type Channel struct {
 	ChannelName string `json:"channelName"`
 	//Priority    string `json:"priority"`
@@ -172,6 +175,9 @@ func Parse(in []Property) (*Properties, error) {
 				return nil, ParseError{Idx: i, Typ: prop.Type, Err: err}
 			}
 			out.BundleObjects = append(out.BundleObjects, p)
+		// NOTICE: The Channel properties are for internal use only.
+		//   DO NOT use it for any public-facing functionalities.
+		//   This API is in alpha stage and it is subject to change.
 		case TypeChannel:
 			var p Channel
 			if err := json.Unmarshal(prop.Value, &p); err != nil {
@@ -279,6 +285,10 @@ func MustBuildBundleObjectRef(ref string) Property {
 func MustBuildBundleObjectData(data []byte) Property {
 	return MustBuild(&BundleObject{File: File{data: data}})
 }
+
+// NOTICE: The Channel properties are for internal use only.
+//   DO NOT use it for any public-facing functionalities.
+//   This API is in alpha stage and it is subject to change.
 func MustBuildChannelPriority(name string, priority int) Property {
 	return MustBuild(&Channel{ChannelName: name, Priority: priority})
 }

--- a/alpha/property/scheme.go
+++ b/alpha/property/scheme.go
@@ -12,6 +12,7 @@ func init() {
 		reflect.TypeOf(&GVK{}):             TypeGVK,
 		reflect.TypeOf(&GVKRequired{}):     TypeGVKRequired,
 		reflect.TypeOf(&BundleObject{}):    TypeBundleObject,
+		reflect.TypeOf(&Channel{}):         TypeChannel,
 	}
 }
 

--- a/alpha/property/scheme.go
+++ b/alpha/property/scheme.go
@@ -12,7 +12,10 @@ func init() {
 		reflect.TypeOf(&GVK{}):             TypeGVK,
 		reflect.TypeOf(&GVKRequired{}):     TypeGVKRequired,
 		reflect.TypeOf(&BundleObject{}):    TypeBundleObject,
-		reflect.TypeOf(&Channel{}):         TypeChannel,
+		// NOTICE: The Channel properties are for internal use only.
+		//   DO NOT use it for any public-facing functionalities.
+		//   This API is in alpha stage and it is subject to change.
+		reflect.TypeOf(&Channel{}): TypeChannel,
 	}
 }
 


### PR DESCRIPTION
**Description of the change:**
This PoC was driven from a discussion in the oc-mirror project
https://github.com/openshift/oc-mirror/issues/453

There are scenarios where the default channel for a package is not updated when diff filters out all the packages within original default channel.

This PR proposes a solution to this issue by adding a channel priority property and logic in the diff code that will use this new priority to set the defaultChannel 

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
