### PR TITLE
Add `add_mode` column to package table

### DIFF
--- a/pkg/lib/registry/registry.go
+++ b/pkg/lib/registry/registry.go
@@ -91,6 +91,9 @@ func (r RegistryUpdater) AddToRegistry(request AddToRegistryRequest) error {
 		simpleRefs = append(simpleRefs, image.SimpleReference(ref))
 	}
 
+	if request.Mode == "" {
+		request.Mode = registry.ReplacesMode
+	}
 	if err := populate(context.TODO(), dbLoader, graphLoader, dbQuerier, reg, simpleRefs, request.Mode, request.Overwrite); err != nil {
 		r.Logger.Debugf("unable to populate database: %s", err)
 

--- a/pkg/registry/bundlegraphloader.go
+++ b/pkg/registry/bundlegraphloader.go
@@ -35,6 +35,12 @@ func (g *BundleGraphLoader) AddBundleToGraph(bundle *Bundle, graph *Package, ann
 		graph.Name = bundle.Package
 	}
 
+	if skippatch {
+		graph.AddMode = SkipPatchMode
+	} else {
+		graph.AddMode = SemVerMode
+	}
+
 	newDefaultChannel := annotations.Annotations.DefaultChannelName
 	if newDefaultChannel != "" {
 		graph.DefaultChannel = newDefaultChannel

--- a/pkg/registry/bundlegraphloader_test.go
+++ b/pkg/registry/bundlegraphloader_test.go
@@ -68,6 +68,7 @@ func TestBundleGraphLoader(t *testing.T) {
 			expectedGraph: &Package{
 				Name:           "etcd",
 				DefaultChannel: "alpha",
+				AddMode:        SemVerMode,
 				Channels: map[string]Channel{
 					"alpha": {Head: BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"},
 						Nodes: map[BundleKey]map[BundleKey]struct{}{
@@ -149,6 +150,7 @@ func TestBundleGraphLoader(t *testing.T) {
 			expectedGraph: &Package{
 				Name:           "etcd",
 				DefaultChannel: "beta",
+				AddMode:        SemVerMode,
 				Channels: map[string]Channel{
 					"beta": {Head: BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"},
 						Nodes: map[BundleKey]map[BundleKey]struct{}{
@@ -186,6 +188,7 @@ func TestBundleGraphLoader(t *testing.T) {
 			expectedGraph: &Package{
 				Name:           "etcd",
 				DefaultChannel: "alpha",
+				AddMode:        SemVerMode,
 				Channels: map[string]Channel{
 					"beta": {Head: BundleKey{CsvName: "etcdoperator.v0.6.1", Version: "0.6.1"},
 						Nodes: map[BundleKey]map[BundleKey]struct{}{
@@ -217,6 +220,7 @@ func TestBundleGraphLoader(t *testing.T) {
 			expectedGraph: &Package{
 				Name:           "etcd",
 				DefaultChannel: "alpha",
+				AddMode:        SemVerMode,
 				Channels: map[string]Channel{
 					"alpha": {Head: BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"},
 						Nodes: map[BundleKey]map[BundleKey]struct{}{
@@ -271,6 +275,7 @@ func TestBundleGraphLoader(t *testing.T) {
 			expectedGraph: &Package{
 				Name:           "etcd",
 				DefaultChannel: "alpha",
+				AddMode:        SkipPatchMode,
 				Channels: map[string]Channel{
 					"alpha": {Head: BundleKey{CsvName: "etcdoperator.v0.9.3", Version: "0.9.3"},
 						Nodes: map[BundleKey]map[BundleKey]struct{}{

--- a/pkg/registry/channelupdateoptions.go
+++ b/pkg/registry/channelupdateoptions.go
@@ -5,12 +5,12 @@ import (
 	"strings"
 )
 
-type Mode int
+type Mode string
 
 const (
-	ReplacesMode = iota
-	SemVerMode
-	SkipPatchMode
+	ReplacesMode  Mode = "replaces"
+	SemVerMode    Mode = "semver"
+	SkipPatchMode Mode = "semver-skippatch"
 )
 
 func GetModeFromString(mode string) (Mode, error) {
@@ -22,6 +22,6 @@ func GetModeFromString(mode string) (Mode, error) {
 	case "semver-skippatch":
 		return SkipPatchMode, nil
 	default:
-		return -1, fmt.Errorf("Invalid channel update mode %s specified", mode)
+		return "", fmt.Errorf("Invalid channel update mode %s specified", mode)
 	}
 }

--- a/pkg/registry/empty.go
+++ b/pkg/registry/empty.go
@@ -88,6 +88,10 @@ func (EmptyQuery) GetDefaultChannelForPackage(ctx context.Context, pkgName strin
 	return "", errors.New("empty querier: cannot get default channel")
 }
 
+func (EmptyQuery) GetAddModeForPackage(ctx context.Context, pkgName string) (Mode, error) {
+	return "", errors.New("empty querier: cannot get add mode")
+}
+
 func (EmptyQuery) ListChannels(ctx context.Context, pkgName string) ([]string, error) {
 	return nil, errors.New("empty querier: cannot list channels")
 }

--- a/pkg/registry/graph.go
+++ b/pkg/registry/graph.go
@@ -9,6 +9,7 @@ type Package struct {
 	Name           string
 	DefaultChannel string
 	Channels       map[string]Channel
+	AddMode        Mode
 }
 
 func (p *Package) String() string {
@@ -17,6 +18,8 @@ func (p *Package) String() string {
 	b.WriteString(p.Name)
 	b.WriteString("\ndefault channel: ")
 	b.WriteString(p.DefaultChannel)
+	b.WriteString("\nadd mode: ")
+	b.WriteString(string(p.AddMode))
 	b.WriteString("\nchannels:\n")
 
 	for n, c := range p.Channels {

--- a/pkg/registry/interface.go
+++ b/pkg/registry/interface.go
@@ -9,8 +9,7 @@ import (
 type Load interface {
 	AddOperatorBundle(bundle *Bundle) error
 	AddBundleSemver(graph *Package, bundle *Bundle) error
-	AddPackageChannels(manifest PackageManifest) error
-	AddBundlePackageChannels(manifest PackageManifest, bundle *Bundle) error
+	AddPackageChannels(manifest PackageManifest, mode Mode) error
 	RemovePackage(packageName string) error
 	RemoveStrandedBundles() error
 	DeprecateBundle(path string) error
@@ -79,6 +78,8 @@ type Query interface {
 	GetBundlesForPackage(ctx context.Context, pkgName string) (map[BundleKey]struct{}, error)
 	// Get DefaultChannel for Package
 	GetDefaultChannelForPackage(ctx context.Context, pkgName string) (string, error)
+	// Get AddMode for Package
+	GetAddModeForPackage(ctx context.Context, pkgName string) (Mode, error)
 	// List channels for package
 	ListChannels(ctx context.Context, pkgName string) ([]string, error)
 	// Get CurrentCSV name for channel and package

--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -50,6 +50,15 @@ func (e OverwriteErr) Error() string {
 	return e.ErrorString
 }
 
+// AddModeError is an error that describes that an error with the add request with an incompatible add mode.
+type AddModeError struct {
+	ErrorString string
+}
+
+func (e AddModeError) Error() string {
+	return e.ErrorString
+}
+
 const (
 	GVKType        = "olm.gvk"
 	PackageType    = "olm.package"

--- a/pkg/sqlite/configmap.go
+++ b/pkg/sqlite/configmap.go
@@ -178,7 +178,7 @@ func (c *ConfigMapLoader) Populate() error {
 	}
 	for _, packageManifest := range parsedPackageManifests {
 		c.log.WithField("package", packageManifest.PackageName).Debug("loading package")
-		if err := c.store.AddPackageChannels(packageManifest); err != nil {
+		if err := c.store.AddPackageChannels(packageManifest, registry.ReplacesMode); err != nil {
 			errs = append(errs, fmt.Errorf("error loading package %s: %s", packageManifest.PackageName, err))
 		}
 	}

--- a/pkg/sqlite/directory.go
+++ b/pkg/sqlite/directory.go
@@ -170,7 +170,7 @@ func (d *DirectoryLoader) LoadPackagesWalkFunc(path string, f os.FileInfo, err e
 		return nil
 	}
 
-	if err := d.store.AddPackageChannels(manifest); err != nil {
+	if err := d.store.AddPackageChannels(manifest, registry.ReplacesMode); err != nil {
 		return fmt.Errorf("error loading package into db: %s", err)
 	}
 

--- a/pkg/sqlite/graphloader.go
+++ b/pkg/sqlite/graphloader.go
@@ -42,6 +42,12 @@ func (g *SQLGraphLoader) Generate(packageName string) (*registry.Package, error)
 	}
 	graph.DefaultChannel = defaultChannel
 
+	addMode, err := g.Querier.GetAddModeForPackage(ctx, packageName)
+	if err != nil {
+		return graph, err
+	}
+	graph.AddMode = addMode
+
 	channelEntries, err := g.Querier.GetChannelEntriesFromPackage(ctx, packageName)
 	if err != nil {
 		return graph, err

--- a/pkg/sqlite/load_test.go
+++ b/pkg/sqlite/load_test.go
@@ -142,7 +142,7 @@ func TestAddPackageChannels(t *testing.T) {
 			}
 
 			for i, pkg := range tt.args.pkgs {
-				errs := store.AddPackageChannels(pkg)
+				errs := store.AddPackageChannels(pkg, registry.ReplacesMode)
 				require.Equal(t, tt.expected.errs[i], errs, "expected %v, got %v", tt.expected.errs[i], errs)
 			}
 
@@ -180,7 +180,7 @@ func TestAddBundleSemver(t *testing.T) {
 			},
 		},
 		DefaultChannelName: "stable",
-	})
+	}, registry.SemVerMode)
 	require.NoError(t, err)
 
 	// Add semver bundles in non-semver order.
@@ -249,7 +249,7 @@ func TestClearNonHeadBundles(t *testing.T) {
 			},
 		},
 		DefaultChannelName: channel,
-	})
+	}, registry.ReplacesMode)
 	require.NoError(t, err)
 
 	// Clear everything but the default bundle
@@ -612,7 +612,7 @@ func TestDeprecationAwareLoader(t *testing.T) {
 			}
 
 			for _, pkg := range tt.fields.pkgs {
-				require.NoError(t, store.AddPackageChannels(pkg))
+				require.NoError(t, store.AddPackageChannels(pkg, registry.ReplacesMode))
 			}
 			for _, deprecatedPath := range tt.fields.deprecatedPaths {
 				require.NoError(t, store.DeprecateBundle(deprecatedPath))
@@ -881,7 +881,7 @@ func TestGetTailFromBundle(t *testing.T) {
 			}
 
 			for _, pkg := range tt.fields.pkgs {
-				require.NoError(t, store.AddPackageChannels(pkg))
+				require.NoError(t, store.AddPackageChannels(pkg, registry.ReplacesMode))
 			}
 			tx, err := db.Begin()
 			require.NoError(t, err)
@@ -1225,7 +1225,7 @@ func TestRemoveOverwrittenChannelHead(t *testing.T) {
 
 			for _, pkg := range tt.fields.pkgs {
 				// Throw away any errors loading packages (not testing this)
-				store.AddPackageChannels(pkg)
+				store.AddPackageChannels(pkg, registry.ReplacesMode)
 			}
 
 			getDefaultChannel := func(pkg string) sql.NullString {

--- a/pkg/sqlite/loadprocs.go
+++ b/pkg/sqlite/loadprocs.go
@@ -3,6 +3,8 @@ package sqlite
 import (
 	"database/sql"
 	"fmt"
+
+	"github.com/operator-framework/operator-registry/pkg/registry"
 )
 
 // TODO: Finish separating procedures from loader layer: make this a type to make
@@ -56,14 +58,14 @@ func addPackage(tx *sql.Tx, packageName string) error {
 	return nil
 }
 
-func addPackageIfNotExists(tx *sql.Tx, packageName string) error {
-	addPackage, err := tx.Prepare("insert or replace into package(name) values(?)")
+func addPackageIfNotExists(tx *sql.Tx, packageName string, addMode registry.Mode) error {
+	addPackage, err := tx.Prepare("insert or replace into package(name, add_mode) values(?, ?)")
 	if err != nil {
 		return err
 	}
 	defer addPackage.Close()
 
-	_, err = addPackage.Exec(packageName)
+	_, err = addPackage.Exec(packageName, addMode)
 	if err != nil {
 		return fmt.Errorf("failed to insert or replace package (%s): %s", packageName, err)
 	}

--- a/pkg/sqlite/migrations/014_package_add_mode.go
+++ b/pkg/sqlite/migrations/014_package_add_mode.go
@@ -1,0 +1,55 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+)
+
+const PackageAddModeMigrationKey = 14
+
+// Register this migration
+func init() {
+	registerMigration(PackageAddModeMigrationKey, packageAddModeMigration)
+}
+
+var packageAddModeMigration = &Migration{
+	Id: PackageAddModeMigrationKey,
+	Up: func(ctx context.Context, tx *sql.Tx) error {
+		sql := `
+		ALTER TABLE package
+		ADD COLUMN add_mode TEXT;
+		`
+		_, err := tx.ExecContext(ctx, sql)
+		return err
+	},
+	Down: func(ctx context.Context, tx *sql.Tx) error {
+		foreignKeyOff := `PRAGMA foreign_keys = 0`
+		createTempTable := `CREATE TABLE package_backup (name TEXT, default_channel TEXT)`
+		backupTargetTable := `INSERT INTO package_backup SELECT name, default_channel FROM package`
+		dropTargetTable := `DROP TABLE package`
+		renameBackUpTable := `ALTER TABLE package_backup RENAME TO package;`
+		foreignKeyOn := `PRAGMA foreign_keys = 1`
+		_, err := tx.ExecContext(ctx, foreignKeyOff)
+		if err != nil {
+			return err
+		}
+		_, err = tx.ExecContext(ctx, createTempTable)
+		if err != nil {
+			return err
+		}
+		_, err = tx.ExecContext(ctx, backupTargetTable)
+		if err != nil {
+			return err
+		}
+		_, err = tx.ExecContext(ctx, dropTargetTable)
+		if err != nil {
+			return err
+		}
+		_, err = tx.ExecContext(ctx, renameBackUpTable)
+		if err != nil {
+			return err
+		}
+		_, err = tx.ExecContext(ctx, foreignKeyOn)
+		return err
+	},
+}

--- a/pkg/sqlite/migrations/014_package_add_mode_test.go
+++ b/pkg/sqlite/migrations/014_package_add_mode_test.go
@@ -1,0 +1,79 @@
+package migrations_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/operator-framework/operator-registry/pkg/sqlite/migrations"
+)
+
+func TestPackageAddModeUp(t *testing.T) {
+	db, migrator, cleanup := CreateTestDbAt(t, migrations.PackageAddModeMigrationKey-1)
+	defer cleanup()
+
+	tx, err := db.Begin()
+	require.NoError(t, err)
+
+	// Add a bundle, channel, and package
+	for _, f := range []func() (sql.Result, error){
+		func() (sql.Result, error) {
+			return db.Exec("INSERT INTO operatorbundle(name) values(?)", "pkg.v0.1.0")
+		},
+		func() (sql.Result, error) {
+			return db.Exec("INSERT INTO channel(name, package_name) values(?, ?)", "channel", "pkg")
+		},
+		func() (sql.Result, error) {
+			return db.Exec("INSERT INTO package(name, default_channel) VALUES(?, ?)", "pkg", "channel")
+		},
+	} {
+		_, err := f()
+		require.NoError(t, err)
+	}
+	require.NoError(t, tx.Commit())
+
+	err = migrator.Up(context.TODO(), migrations.Only(migrations.PackageAddModeMigrationKey))
+	require.NoError(t, err)
+
+	// Check package table add_mode field is empty
+	query := `SELECT add_mode FROM package WHERE name=?`
+	rows, err := db.Query(query, "pkg")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	addMode := &sql.NullString{}
+	if rows.Next() {
+		require.NoError(t, rows.Scan(addMode))
+	}
+	require.False(t, addMode.Valid)
+}
+
+func TestPackageAddModeDown(t *testing.T) {
+	db, migrator, cleanup := CreateTestDbAt(t, migrations.PackageAddModeMigrationKey)
+	defer cleanup()
+
+	tx, err := db.Begin()
+	require.NoError(t, err)
+
+	// Add a bundle, channel, and package
+	for _, f := range []func() (sql.Result, error){
+		func() (sql.Result, error) {
+			return db.Exec("INSERT INTO operatorbundle(name) values(?)", "pkg.v0.1.0")
+		},
+		func() (sql.Result, error) {
+			return db.Exec("INSERT INTO channel(name, package_name) values(?, ?)", "channel", "pkg")
+		},
+		func() (sql.Result, error) {
+			return db.Exec("INSERT INTO package(name, default_channel) VALUES(?, ?)", "pkg", "channel")
+		},
+	} {
+		_, err := f()
+		require.NoError(t, err)
+	}
+	require.NoError(t, tx.Commit())
+
+	err = migrator.Down(context.TODO(), migrations.Only(migrations.PackageAddModeMigrationKey))
+	require.NoError(t, err)
+}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This PR introduces:
- an sqlite migration that adds an `add_mode` column to the `package` table.
- a new global sanity check that's part of the `add` command that causes failures when attempting to add with a mode that is incompatible with a package's previously used add mode.
- logic to ensure the `add_mode` column is correctly set when any of the existing supported add modes is used (replaces, semver, semver-skippatch)

**Motivation for the change:**
This change enshrines our existing guidance that add modes cannot be mixed and matched, by comparing the previously-used add mode with the currently requested add mode and emitting an error if they do not match. This functionality is crucial for ensuring that `opm` can maintain the integrity of the upgrade graph of each package in the catalog.

This is also a necessary pre-requisite for #949 , which will add a new add mode called "fbc" that will be able to idempotently convert FBC catalogs to sqlite. We need to be able to prevent declarative FBC-derived packages from being tampered with via imperative add commands.

**Downstream note**: This change will likely need to be backported to all versions we expect to support catalogs containing reverse-migrated packages so that we can ask users to upgrade to the `opm` binary that contains these extra add_mode checks. Users that use versions of `opm` without these checks will still be at risk for mixing/matching add modes despite our guidance that they should not.

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage 
- [x] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs`
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
