### PR TITLE
Create database copy in tmp directory

### DIFF
--- a/pkg/lib/tmp/copy.go
+++ b/pkg/lib/tmp/copy.go
@@ -9,7 +9,7 @@ import (
 
 // CopyTmpDB reads the file at the given path and copies it to a tmp directory, returning the copied file path or an err
 func CopyTmpDB(original string) (path string, err error) {
-	dst, err := ioutil.TempFile(".", "db-")
+	dst, err := ioutil.TempFile("tmp", "db-")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Signed-off-by: perdasilva <perdasilva@redhat.com>

**Description of the change:**
opm registry serve creates a writable copy of the db to a tmp file. This file was being created at the root of the filesystem. This breaks on cluster due to permissions (can't write on /). This change creates the file in the tmp directory to not get caught by fs permissions.

**Motivation for the change:**
The recent security updates require us to run as non-root rendering '/' read-only. Also it's not good practice to write to the root.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
