### PR TITLE
use "" instead of /tmp

### DIFF
--- a/pkg/lib/tmp/copy.go
+++ b/pkg/lib/tmp/copy.go
@@ -9,7 +9,7 @@ import (
 
 // CopyTmpDB reads the file at the given path and copies it to a tmp directory, returning the copied file path or an err
 func CopyTmpDB(original string) (path string, err error) {
-	dst, err := ioutil.TempFile("/tmp", "db-")
+	dst, err := ioutil.TempFile("", "db-")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Signed-off-by: perdasilva <perdasilva@redhat.com>

**Description of the change:**
Turns out "" is more robust!

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
