### PR TITLE
Update dockerfiles to contain user 1001

### DIFF
--- a/index.Dockerfile
+++ b/index.Dockerfile
@@ -6,6 +6,7 @@ COPY ["nsswitch.conf", "/etc/nsswitch.conf"]
 COPY database ./
 COPY --from=builder /bin/opm /opm
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
+USER 1001
 EXPOSE 50051
 ENTRYPOINT ["/opm"]
 CMD ["registry", "serve", "--database", "index.db"]

--- a/registry.Dockerfile
+++ b/registry.Dockerfile
@@ -13,6 +13,7 @@ FROM scratch
 COPY ["nsswitch.conf", "/etc/nsswitch.conf"]
 COPY --from=builder /build/bin/registry-server /registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
+USER 1001
 EXPOSE 50051
 ENTRYPOINT ["/registry-server"]
 CMD ["--database", "/bundles.db"]

--- a/release/goreleaser.opm.Dockerfile
+++ b/release/goreleaser.opm.Dockerfile
@@ -7,4 +7,5 @@ FROM gcr.io/distroless/static:debug
 COPY --from=grpc_health_probe /ko-app/grpc-health-probe /bin/grpc_health_probe
 COPY ["nsswitch.conf", "/etc/nsswitch.conf"]
 COPY opm /bin/opm
+USER 1001
 ENTRYPOINT ["/bin/opm"]

--- a/upstream-example.Dockerfile
+++ b/upstream-example.Dockerfile
@@ -8,6 +8,7 @@ COPY ["nsswitch.conf", "/etc/nsswitch.conf"]
 COPY --from=builder /bundles.db /bundles.db
 COPY --from=builder /bin/registry-server /registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
+USER 1001
 EXPOSE 50051
 ENTRYPOINT ["/registry-server"]
 CMD ["--database", "bundles.db"]


### PR DESCRIPTION
Signed-off-by: perdasilva <perdasilva@redhat.com>

**Description of the change:**
Updates Dockerfile definition to include `USER 1001`

**Motivation for the change:**
Due to PSA changes, catalog source pods will run under the restricted profile and cannot run as root.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
