### PR TITLE
Add /opm directory dedicated to the 1001 user

### DIFF
--- a/release/goreleaser.opm.Dockerfile
+++ b/release/goreleaser.opm.Dockerfile
@@ -1,11 +1,16 @@
 # NOTE: This Dockerfile is used in conjuction with GoReleaser to
 #   build opm images. See the configurations in .goreleaser.yaml
 #   and .github/workflows/release.yaml.
+FROM alpine as fsutil
+RUN mkdir -p /opm
 
 FROM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.11 as grpc_health_probe
 FROM gcr.io/distroless/static:debug
 COPY --from=grpc_health_probe /ko-app/grpc-health-probe /bin/grpc_health_probe
+# directory dedicated to the 1001 user
+COPY --from=fsutil --chown=1001:1001 ["/opm", "/opm"]
 COPY ["nsswitch.conf", "/etc/nsswitch.conf"]
 COPY opm /bin/opm
+
 USER 1001
 ENTRYPOINT ["/bin/opm"]


### PR DESCRIPTION
Signed-off-by: perdasilva <perdasilva@redhat.com>

**Description of the change:**
Adds a /opm directory to the opm container with ownership to the 1001 user. 
Right now this will be used to fix a bug in the operator-sdk project for legacy (sqlite) catalogs. Though it pays to have a user owner directory in the container for the future in case it is needed.

**Motivation for the change:**
Recent changes that added a user to the opm container. This broke the operator-sdk `run bundle` command because it wants to create a directory in the container as part of the pod command.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
