### PR TITLE
provide generic mechanism to propagate global flags to render.Run operations

### DIFF
--- a/alpha/action/list.go
+++ b/alpha/action/list.go
@@ -14,14 +14,16 @@ import (
 
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/alpha/model"
+	"github.com/operator-framework/operator-registry/pkg/image"
 )
 
 type ListPackages struct {
 	IndexReference string
+	Registry       image.Registry
 }
 
 func (l *ListPackages) Run(ctx context.Context) (*ListPackagesResult, error) {
-	m, err := indexRefToModel(ctx, l.IndexReference)
+	m, err := indexRefToModel(ctx, l.IndexReference, l.Registry)
 	if err != nil {
 		return nil, err
 	}
@@ -72,10 +74,11 @@ func getDisplayName(pkg model.Package) string {
 type ListChannels struct {
 	IndexReference string
 	PackageName    string
+	Registry       image.Registry
 }
 
 func (l *ListChannels) Run(ctx context.Context) (*ListChannelsResult, error) {
-	m, err := indexRefToModel(ctx, l.IndexReference)
+	m, err := indexRefToModel(ctx, l.IndexReference, l.Registry)
 	if err != nil {
 		return nil, err
 	}
@@ -128,10 +131,11 @@ func (r *ListChannelsResult) WriteColumns(w io.Writer) error {
 type ListBundles struct {
 	IndexReference string
 	PackageName    string
+	Registry       image.Registry
 }
 
 func (l *ListBundles) Run(ctx context.Context) (*ListBundlesResult, error) {
-	m, err := indexRefToModel(ctx, l.IndexReference)
+	m, err := indexRefToModel(ctx, l.IndexReference, l.Registry)
 	if err != nil {
 		return nil, err
 	}
@@ -179,10 +183,11 @@ func (r *ListBundlesResult) WriteColumns(w io.Writer) error {
 	return tw.Flush()
 }
 
-func indexRefToModel(ctx context.Context, ref string) (model.Model, error) {
+func indexRefToModel(ctx context.Context, ref string, reg image.Registry) (model.Model, error) {
 	render := Render{
 		Refs:           []string{ref},
 		AllowedRefMask: RefDCImage | RefDCDir | RefSqliteImage | RefSqliteFile,
+		Registry:       reg,
 	}
 	cfg, err := render.Run(ctx)
 	if err != nil {

--- a/cmd/opm/alpha/list/cmd.go
+++ b/cmd/opm/alpha/list/cmd.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/operator-framework/operator-registry/alpha/action"
+	"github.com/operator-framework/operator-registry/cmd/opm/internal/util"
 )
 
 const humanReadabilityOnlyNote = `NOTE: This is meant to be used for convenience and human-readability only. The
@@ -22,6 +23,7 @@ func NewCmd() *cobra.Command {
 
 ` + humanReadabilityOnlyNote,
 	}
+
 	list.AddCommand(newPackagesCmd(), newChannelsCmd(), newBundlesCmd())
 	return list
 }
@@ -37,7 +39,12 @@ func newPackagesCmd() *cobra.Command {
 ` + humanReadabilityOnlyNote,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			lp := action.ListPackages{IndexReference: args[0]}
+			reg, err := util.CreateCLIRegistry(cmd)
+			if err != nil {
+				logger.Fatal(err)
+			}
+			defer reg.Destroy()
+			lp := action.ListPackages{IndexReference: args[0], Registry: reg}
 			res, err := lp.Run(cmd.Context())
 			if err != nil {
 				logger.Fatal(err)
@@ -61,7 +68,12 @@ func newChannelsCmd() *cobra.Command {
 ` + humanReadabilityOnlyNote,
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			lc := action.ListChannels{IndexReference: args[0]}
+			reg, err := util.CreateCLIRegistry(cmd)
+			if err != nil {
+				logger.Fatal(err)
+			}
+			defer reg.Destroy()
+			lc := action.ListChannels{IndexReference: args[0], Registry: reg}
 			if len(args) > 1 {
 				lc.PackageName = args[1]
 			}
@@ -90,7 +102,12 @@ for each channel in which the bundle is present).
 ` + humanReadabilityOnlyNote,
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			lb := action.ListBundles{IndexReference: args[0]}
+			reg, err := util.CreateCLIRegistry(cmd)
+			if err != nil {
+				logger.Fatal(err)
+			}
+			defer reg.Destroy()
+			lb := action.ListBundles{IndexReference: args[0], Registry: reg}
 			if len(args) > 1 {
 				lb.PackageName = args[1]
 			}

--- a/cmd/opm/alpha/veneer/basic.go
+++ b/cmd/opm/alpha/veneer/basic.go
@@ -12,7 +12,6 @@ import (
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/alpha/veneer/basic"
 	"github.com/operator-framework/operator-registry/cmd/opm/internal/util"
-	containerd "github.com/operator-framework/operator-registry/pkg/image/containerdregistry"
 )
 
 func newBasicVeneerRenderCmd() *cobra.Command {
@@ -42,22 +41,7 @@ func newBasicVeneerRenderCmd() *cobra.Command {
 			// returned from veneer.Render and logged as fatal errors.
 			logrus.SetOutput(ioutil.Discard)
 
-			skipTLSVerify, useHTTP, err := util.GetTLSOptions(cmd)
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			cacheDir, err := os.MkdirTemp("", "veneer-registry-")
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			reg, err := containerd.NewRegistry(
-				containerd.WithCacheDir(cacheDir),
-				containerd.SkipTLSVerify(skipTLSVerify),
-				containerd.WithPlainHTTP(useHTTP),
-				containerd.WithLog(nullLogger()),
-			)
+			reg, err := util.CreateCLIRegistry(cmd)
 			if err != nil {
 				log.Fatalf("creating containerd registry: %v", err)
 			}
@@ -77,7 +61,5 @@ func newBasicVeneerRenderCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&output, "output", "o", "json", "Output format (json|yaml)")
-	cmd.Flags().Bool("skip-tls-verify", false, "disable TLS verification")
-	cmd.Flags().Bool("use-http", false, "use plain HTTP")
 	return cmd
 }

--- a/cmd/opm/alpha/veneer/cmd.go
+++ b/cmd/opm/alpha/veneer/cmd.go
@@ -1,17 +1,8 @@
 package veneer
 
 import (
-	"io/ioutil"
-
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
-
-func nullLogger() *logrus.Entry {
-	logger := logrus.New()
-	logger.SetOutput(ioutil.Discard)
-	return logrus.NewEntry(logger)
-}
 
 func NewCmd() *cobra.Command {
 	runCmd := &cobra.Command{

--- a/cmd/opm/alpha/veneer/semver.go
+++ b/cmd/opm/alpha/veneer/semver.go
@@ -12,7 +12,6 @@ import (
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/alpha/veneer/semver"
 	"github.com/operator-framework/operator-registry/cmd/opm/internal/util"
-	containerd "github.com/operator-framework/operator-registry/pkg/image/containerdregistry"
 	"github.com/spf13/cobra"
 )
 
@@ -47,22 +46,7 @@ func newSemverCmd() *cobra.Command {
 			// returned from veneer.Render and logged as fatal errors.
 			logrus.SetOutput(ioutil.Discard)
 
-			skipTLSVerify, useHTTP, err := util.GetTLSOptions(cmd)
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			cacheDir, err := os.MkdirTemp("", "veneer-registry-")
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			reg, err := containerd.NewRegistry(
-				containerd.WithCacheDir(cacheDir),
-				containerd.SkipTLSVerify(skipTLSVerify),
-				containerd.WithPlainHTTP(useHTTP),
-				containerd.WithLog(nullLogger()),
-			)
+			reg, err := util.CreateCLIRegistry(cmd)
 			if err != nil {
 				log.Fatalf("creating containerd registry: %v", err)
 			}

--- a/cmd/opm/index/cmd.go
+++ b/cmd/opm/index/cmd.go
@@ -32,12 +32,6 @@ func AddCommand(parent *cobra.Command) {
 	}
 
 	parent.AddCommand(cmd)
-	parent.PersistentFlags().Bool("skip-tls", false, "skip TLS certificate verification for container image registries while pulling bundles or index")
-	parent.PersistentFlags().Bool("skip-tls-verify", false, "skip TLS certificate verification for container image registries while pulling bundles")
-	parent.PersistentFlags().Bool("use-http", false, "use plain HTTP for container image registries while pulling bundles")
-	if err := parent.PersistentFlags().MarkDeprecated("skip-tls", "use --use-http and --skip-tls-verify instead"); err != nil {
-		logrus.Panic(err.Error())
-	}
 
 	cmd.AddCommand(newIndexDeleteCmd())
 	addIndexAddCmd(cmd)

--- a/cmd/opm/render/cmd.go
+++ b/cmd/opm/render/cmd.go
@@ -12,7 +12,6 @@ import (
 	"github.com/operator-framework/operator-registry/alpha/action"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/cmd/opm/internal/util"
-	containerd "github.com/operator-framework/operator-registry/pkg/image/containerdregistry"
 	"github.com/operator-framework/operator-registry/pkg/sqlite"
 )
 
@@ -48,24 +47,9 @@ func NewCmd() *cobra.Command {
 			// returned from render.Run and logged as fatal errors.
 			logrus.SetOutput(ioutil.Discard)
 
-			skipTLSVerify, useHTTP, err := util.GetTLSOptions(cmd)
+			reg, err := util.CreateCLIRegistry(cmd)
 			if err != nil {
 				log.Fatal(err)
-			}
-
-			cacheDir, err := os.MkdirTemp("", "render-registry-")
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			reg, err := containerd.NewRegistry(
-				containerd.WithCacheDir(cacheDir),
-				containerd.SkipTLSVerify(skipTLSVerify),
-				containerd.WithPlainHTTP(useHTTP),
-				containerd.WithLog(nullLogger()),
-			)
-			if err != nil {
-				log.Fatalf("creating containerd registry: %v", err)
 			}
 			defer reg.Destroy()
 
@@ -82,8 +66,6 @@ func NewCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&output, "output", "o", "json", "Output format (json|yaml|mermaid)")
-	cmd.Flags().Bool("skip-tls-verify", false, "disable TLS verification")
-	cmd.Flags().Bool("use-http", false, "use plain HTTP")
 	return cmd
 }
 

--- a/cmd/opm/root/cmd.go
+++ b/cmd/opm/root/cmd.go
@@ -30,6 +30,13 @@ func NewCmd() *cobra.Command {
 		Args: cobra.NoArgs,
 	}
 
+	cmd.PersistentFlags().Bool("skip-tls", false, "skip TLS certificate verification for container image registries while pulling bundles or index")
+	cmd.PersistentFlags().Bool("skip-tls-verify", false, "skip TLS certificate verification for container image registries while pulling bundles")
+	cmd.PersistentFlags().Bool("use-http", false, "use plain HTTP for container image registries while pulling bundles")
+	if err := cmd.PersistentFlags().MarkDeprecated("skip-tls", "use --use-http and --skip-tls-verify instead"); err != nil {
+		logrus.Panic(err.Error())
+	}
+
 	cmd.AddCommand(registry.NewOpmRegistryCmd(), alpha.NewCmd(), initcmd.NewCmd(), migrate.NewCmd(), serve.NewCmd(), render.NewCmd(), validate.NewCmd(), generate.NewCmd())
 	index.AddCommand(cmd)
 	version.AddCommand(cmd)


### PR DESCRIPTION
Signed-off-by: Jordan Keister <jordan@nimblewidget.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Provide a generic mechanism for propagating global flags (i.e. use-http, skip-tls-verify) into any caller of alpha/render/Run(). 
render.Run is updated to use the passed-in options IFF render.Reg is nil, which allows us to preserve call models which provide a ready containerd registry as well as customize call models which would instantiate the registry at that time.

I attempted to break NO API which is not "real alpha" (as opposed to gradations of alpha).  There is a viable backwards-compatible path for all non-veneer APIs.

**Motivation for the change:**
issue #931 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
