### PR TITLE
`semver veneer`: validate bundle versions differ by more than build metadata

### DIFF
--- a/alpha/veneer/semver/semver_test.go
+++ b/alpha/veneer/semver/semver_test.go
@@ -581,6 +581,8 @@ func TestBailOnVersionBuildMetadata(t *testing.T) {
 				{Image: "repo/origin/a-v2.3.1"},
 				{Image: "repo/origin/a-v2.3.2"},
 				{Image: "repo/origin/a-v1.3.1-alpha"},
+				{Image: "repo/origin/a-v1.3.1-alpha+2001Jan21"},
+				{Image: "repo/origin/a-v1.3.1-alpha+2003May06"},
 			},
 		},
 	}
@@ -597,16 +599,18 @@ func TestBailOnVersionBuildMetadata(t *testing.T) {
 			{Schema: "olm.bundle", Image: "repo/origin/a-v0.1.1", Name: "a-v0.1.1", Properties: []property.Property{property.MustBuildPackage("a", "0.1.1")}},
 			{Schema: "olm.bundle", Image: "repo/origin/a-v1.1.0", Name: "a-v1.1.0", Properties: []property.Property{property.MustBuildPackage("a", "1.1.0")}},
 			{Schema: "olm.bundle", Image: "repo/origin/a-v1.2.1", Name: "a-v1.2.1", Properties: []property.Property{property.MustBuildPackage("a", "1.2.1")}},
+			{Schema: "olm.bundle", Image: "repo/origin/a-v1.3.1-alpha", Name: "a-v1.3.1-alpha", Properties: []property.Property{property.MustBuildPackage("a", "1.3.1-alpha")}},
 			{Schema: "olm.bundle", Image: "repo/origin/a-v1.3.1-alpha+2001Jan21", Name: "a-v1.3.1-alpha+2001Jan21", Properties: []property.Property{property.MustBuildPackage("a", "1.3.1-alpha+2001Jan21")}},
 			{Schema: "olm.bundle", Image: "repo/origin/a-v1.3.1", Name: "a-v1.3.1", Properties: []property.Property{property.MustBuildPackage("a", "1.3.1")}},
 			{Schema: "olm.bundle", Image: "repo/origin/a-v2.1.0", Name: "a-v2.1.0", Properties: []property.Property{property.MustBuildPackage("a", "2.1.0")}},
 			{Schema: "olm.bundle", Image: "repo/origin/a-v2.1.1", Name: "a-v2.1.1", Properties: []property.Property{property.MustBuildPackage("a", "2.1.1")}},
 			{Schema: "olm.bundle", Image: "repo/origin/a-v2.3.1", Name: "a-v2.3.1", Properties: []property.Property{property.MustBuildPackage("a", "2.3.1")}},
 			{Schema: "olm.bundle", Image: "repo/origin/a-v2.3.2", Name: "a-v2.3.2", Properties: []property.Property{property.MustBuildPackage("a", "2.3.2")}},
+			{Schema: "olm.bundle", Image: "repo/origin/a-v1.3.1-alpha+2003May06", Name: "a-v1.3.1-alpha+2003May06", Properties: []property.Property{property.MustBuildPackage("a", "1.3.1-alpha+2003May06")}},
 		},
 	}
 
-	t.Run("Abort on detected build metadata version data", func(t *testing.T) {
+	t.Run("Abort on unorderable build metadata version data", func(t *testing.T) {
 		_, err := sv.getVersionsFromStandardChannels(&dc)
 		require.Error(t, err)
 	})


### PR DESCRIPTION
Signed-off-by: Jordan Keister <jordan@nimblewidget.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
A quick PR to change behavior processing a list of bundles in a channel from
(before) rejection if any bundle versions contain build metadata
(after) rejection IFF any two bundles differ by only build metadata


Example captured `error` type with three package that collide based only on build-metadata versioning:
```"encountered bundle versions which differ only by build metadata, which cannot be ordered: [bundle version \"1.3.1-alpha\" cannot be compared to \"1.3.1-alpha+2001Jan21\", bundle version \"1.3.1-alpha\" cannot be compared to \"1.3.1-alpha+2003May06\"]"```

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
