### PR TITLE
Introduce golangci-lint to the repository

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -10,14 +10,31 @@ on:
       - '!doc/**'
 
 jobs:
-  sanity:
+  verify:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
           go-version: '~1.18'
-      - name: Install goimports
-        run: go install golang.org/x/tools/cmd/goimports@latest
       - name: Run sanity checks
-        run: make vendor && make lint && git diff --exit-code
+        run: make verify
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '~1.18'
+      - name: Cache build and module paths
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run golangci linting checks
+        run: make lint

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,45 @@
+run:
+  # Default timeout is 1m, up to give more room
+  timeout: 4m
+
+linters:
+  enable:
+  - asciicheck
+  - deadcode
+  - depguard
+  - gofmt
+  - goimports
+  - importas
+  - revive
+  - misspell
+  - stylecheck
+  - tparallel
+  - unconvert
+  - unparam
+  - whitespace
+
+linters-settings:
+  importas:
+    alias:
+    - pkg: k8s.io/api/core/v1
+      alias: corev1
+    - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+      alias: metav1
+    - pkg: k8s.io/apimachinery/pkg/api/errors
+      alias: apierrors
+    - pkg: github.com/operator-framework/api/pkg/operators/v1alpha1
+      alias: operatorsv1alpha1
+  revive:
+    rules:
+    - name: dot-imports
+      severity: warning
+      disabled: true
+  stylecheck:
+    dot-import-whitelist:
+      - github.com/onsi/gomega
+      - github.com/onsi/ginkgo
+  goimports:
+    local-prefixes: github.com/operator-framework/operator-registry
+
+output:
+  format: tab

--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,13 @@ vendor:
 	$(GO) mod vendor
 	$(GO) mod verify
 
+.PHONY: verify
+verify: vendor
+	git diff --exit-code
+
 .PHONY: lint
-lint:
-	find . -name '*.go' -not -path "./vendor/*" | xargs goimports -w
+lint: golangci-lint ## Run golangci-lint linter checks.
+	$(GOLANGCI_LINT) run
 
 .PHONY: codegen
 codegen:
@@ -165,10 +169,12 @@ $(LOCALBIN):
 ## Tool Binaries
 GORELEASER ?= $(LOCALBIN)/goreleaser
 GINKGO ?= $(LOCALBIN)/ginkgo
+GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 GORELEASER_VERSION ?= v1.8.3
 GINKGO_VERSION ?= v2.1.3
+GOLANGCI_LINT_VERSION ?= v1.45.2
 
 .PHONY: goreleaser
 goreleaser: $(GORELEASER) ## Download goreleaser locally if necessary.
@@ -179,3 +185,8 @@ $(GORELEASER): $(LOCALBIN)
 ginkgo: $(GINKGO) ## Download ginkgo locally if necessary.
 $(GINKGO): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install $(GO_INSTALL_OPTS) github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)
+
+.PHONY: golangci-lint
+golangci-lint: $(GOLANGCI_LINT)
+$(GOLANGCI_LINT): $(LOCALBIN) ## Download golangci-lint locally if necessary.
+	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Adds the golangci-lint tool to the repository to consolidate the various linting checks into a single tool. Updates the GHA workflow to run the 'make lint' Makefile target during CI runs.

**Motivation for the change:**
Closes #1000 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
