### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/alpha/action/migrate_test.go
+++ b/alpha/action/migrate_test.go
@@ -37,7 +37,7 @@ func TestMigrate(t *testing.T) {
 	err := generateSqliteFile(dbFile, sqliteBundles)
 	require.NoError(t, err)
 
-	reg, err := newMigrateRegistry(sqliteBundles)
+	reg, err := newMigrateRegistry(t, sqliteBundles)
 	require.NoError(t, err)
 
 	specs := []spec{
@@ -118,8 +118,8 @@ func TestMigrate(t *testing.T) {
 	}
 }
 
-func newMigrateRegistry(imageMap map[image.Reference]string) (image.Registry, error) {
-	subSqliteImage, err := generateSqliteFS(imageMap)
+func newMigrateRegistry(t *testing.T, imageMap map[image.Reference]string) (image.Registry, error) {
+	subSqliteImage, err := generateSqliteFS(t, imageMap)
 	if err != nil {
 		return nil, err
 	}

--- a/alpha/action/render_test.go
+++ b/alpha/action/render_test.go
@@ -33,7 +33,7 @@ func TestRender(t *testing.T) {
 		assertion require.ErrorAssertionFunc
 	}
 
-	reg, err := newRegistry()
+	reg, err := newRegistry(t)
 	require.NoError(t, err)
 	foov1csv, err := bundleImageV1.ReadFile("testdata/foo-bundle-v0.1.0/manifests/foo.v0.1.0.csv.yaml")
 	require.NoError(t, err)
@@ -563,7 +563,7 @@ func TestAllowRefMask(t *testing.T) {
 		expectErr error
 	}
 
-	reg, err := newRegistry()
+	reg, err := newRegistry(t)
 	require.NoError(t, err)
 
 	dir := t.TempDir()
@@ -766,13 +766,13 @@ var bundleImageV2NoCSVRelatedImages embed.FS
 //go:embed testdata/foo-index-v0.2.0-declcfg/foo/*
 var declcfgImage embed.FS
 
-func newRegistry() (image.Registry, error) {
+func newRegistry(t *testing.T) (image.Registry, error) {
 	imageMap := map[image.Reference]string{
 		image.SimpleReference("test.registry/foo-operator/foo-bundle:v0.1.0"): "testdata/foo-bundle-v0.1.0",
 		image.SimpleReference("test.registry/foo-operator/foo-bundle:v0.2.0"): "testdata/foo-bundle-v0.2.0",
 	}
 
-	subSqliteImage, err := generateSqliteFS(imageMap)
+	subSqliteImage, err := generateSqliteFS(t, imageMap)
 	if err != nil {
 		return nil, err
 	}
@@ -828,12 +828,8 @@ func newRegistry() (image.Registry, error) {
 	}, nil
 }
 
-func generateSqliteFS(imageMap map[image.Reference]string) (fs.FS, error) {
-	dir, err := os.MkdirTemp("", "opm-render-test-")
-	if err != nil {
-		return nil, err
-	}
-	defer os.RemoveAll(dir)
+func generateSqliteFS(t *testing.T, imageMap map[image.Reference]string) (fs.FS, error) {
+	dir := t.TempDir()
 
 	dbFile := filepath.Join(dir, "index.db")
 	if err := generateSqliteFile(dbFile, imageMap); err != nil {

--- a/alpha/property/property_test.go
+++ b/alpha/property/property_test.go
@@ -209,9 +209,7 @@ func TestFile_GetData(t *testing.T) {
 
 	for _, s := range specs {
 		t.Run(s.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "operator-registry-test-file-")
-			require.NoError(t, err)
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			if s.createFile != nil {
 				require.NoError(t, s.createFile(dir))

--- a/pkg/image/mock_test.go
+++ b/pkg/image/mock_test.go
@@ -2,7 +2,6 @@ package image
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,9 +15,7 @@ func TestMockRegistry(t *testing.T) {
 	dne := SimpleReference("dne")
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "reg-test-mock-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	r := MockRegistry{
 		RemoteImages: map[Reference]*MockImage{
@@ -44,7 +41,7 @@ func TestMockRegistry(t *testing.T) {
 
 	// Test unpack and labels of unpulled ref
 	require.Error(t, r.Unpack(ctx, exists, tmpDir))
-	_, err = r.Labels(ctx, exists)
+	_, err := r.Labels(ctx, exists)
 	require.Error(t, err)
 
 	// Test pull of existing ref

--- a/pkg/lib/bundle/generate_test.go
+++ b/pkg/lib/bundle/generate_test.go
@@ -181,8 +181,7 @@ COPY x/y/z /metadata/
 }
 
 func TestCopyYamlOutput(t *testing.T) {
-	testOutputDir, _ := ioutil.TempDir("./", "test-generate")
-	defer os.RemoveAll(testOutputDir)
+	testOutputDir := t.TempDir()
 
 	testContent := []byte{0, 1, 0, 0}
 	testManifestDir := "./testdata/generate/manifests"
@@ -224,8 +223,7 @@ func TestCopyYamlOutput_NoOutputDir(t *testing.T) {
 }
 
 func TestCopyYamlOutput_NestedCopy(t *testing.T) {
-	testOutputDir, _ := ioutil.TempDir("./", "test-generate")
-	defer os.RemoveAll(testOutputDir)
+	testOutputDir := t.TempDir()
 
 	testContent := []byte{0, 1, 0, 0}
 	testManifestDir := "./testdata/generate/nested_manifests"

--- a/pkg/lib/registry/registry_test.go
+++ b/pkg/lib/registry/registry_test.go
@@ -630,8 +630,7 @@ func TestCheckForBundles(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			tmpdir, err := os.MkdirTemp(".", "tmpdir-*")
-			defer os.RemoveAll(tmpdir)
+			tmpdir := t.TempDir()
 			db, cleanup := CreateTestDb(t)
 			defer cleanup()
 			load, err := sqlite.NewSQLLiteLoader(db)

--- a/pkg/registry/populator_test.go
+++ b/pkg/registry/populator_test.go
@@ -1184,9 +1184,7 @@ func TestDeprecatePackage(t *testing.T) {
 }
 
 func TestAddAfterDeprecate(t *testing.T) {
-	tmpdir, err := os.MkdirTemp(".", "add-after-deprecate-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	/*
 	                     (0.1) 0.1.2 <- 0.1.1 <- 0.1.0

--- a/pkg/sqlite/conversion_test.go
+++ b/pkg/sqlite/conversion_test.go
@@ -2,8 +2,6 @@ package sqlite
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -12,11 +10,7 @@ import (
 )
 
 func TestToModel(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "server_test-")
-	if err != nil {
-		logrus.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")
 
 	db, err := Open(dbPath)

--- a/pkg/sqlite/directory_test.go
+++ b/pkg/sqlite/directory_test.go
@@ -2,7 +2,6 @@ package sqlite
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,13 +37,7 @@ func TestDirectoryLoaderWithBadPackageData(t *testing.T) {
 	require.NoError(t, store.Migrate(context.TODO()))
 
 	// Copy golden manifests to a temp dir
-	dir, err := ioutil.TempDir("testdata", "manifests-")
-	require.NoError(t, err)
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	dir := t.TempDir()
 	require.NoError(t, copy.Copy("./testdata/loader_data", dir))
 
 	// Point the first channel at a CSV that doesn't exist


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	if err != nil {
		t.Fatal(err)
	}
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```

**Motivation for the change:**

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage 
- [x] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
