### PR TITLE
examples for `opm alpha render-graph` to generate channel graph images

### DIFF
--- a/cmd/opm/alpha/render-graph/cmd.go
+++ b/cmd/opm/alpha/render-graph/cmd.go
@@ -22,6 +22,32 @@ func NewCmd() *cobra.Command {
 		Short: "Generate mermaid-formatted view of upgrade graph of operators in an index",
 		Long:  `Generate mermaid-formatted view of upgrade graphs of operators in an index`,
 		Args:  cobra.MinimumNArgs(1),
+		Example: `
+#
+# Output channel graph of a catalog in mermaid format
+#
+$ opm alpha render-graph quay.io/operatorhubio/catalog:latest
+
+#
+# Output channel graph of a catalog and generate a scaled vector graphic (SVG) representation
+# Note:  this pipeline filters out the comments about lacking skipRange support
+#
+$ opm alpha render-graph quay.io/operatorhubio/catalog:latest | \
+    grep -Ev '^<!--.*$' | \
+    docker run --rm -i -v "$PWD":/data ghcr.io/mermaid-js/mermaid-cli/mermaid-cli -o /data/operatorhubio-catalog.svg
+
+# Note:  mermaid has a default maxTextSize of 30 000 characters.  To override this, generate a JSON-formatted initialization file for
+# mermaid like this (using 300 000 for the limit):
+$ cat << EOF > ./mermaid.json
+{ "maxTextSize": 300000 }
+EOF
+# and then pass the file for initialization configuration, via the '-c' option, like:
+$ opm alpha render-graph quay.io/operatorhubio/catalog:latest | \
+    grep -Ev '^<!--.*$' | \
+    docker run --rm -i -v "$PWD":/data ghcr.io/mermaid-js/mermaid-cli/mermaid-cli -c /data/mermaid.json -o /data/operatorhubio-catalog.svg
+
+
+		`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// The bundle loading impl is somewhat verbose, even on the happy path,
 			// so discard all logrus default logger logs. Any important failures will be

--- a/cmd/opm/render/cmd.go
+++ b/cmd/opm/render/cmd.go
@@ -50,6 +50,17 @@ $ opm render quay.io/operatorhubio/catalog:latest -o mermaid | \
     grep -Ev '^<!--.*$' | \
     docker run --rm -i -v "$PWD":/data ghcr.io/mermaid-js/mermaid-cli/mermaid-cli -o /data/operatorhubio-catalog.svg
 
+# Note:  mermaid has a default maxTextSize of 30 000 characters.  To override this, generate a JSON-formatted initialization file for
+# mermaid like this (using 300 000 for the limit):
+$ cat << EOF > ./mermaid.json
+{ "maxTextSize": 300000 }
+EOF
+# and then pass the file for initialization configuration, via the '-c' option, like:
+$ opm render quay.io/operatorhubio/catalog:latest -o mermaid | \
+    grep -Ev '^<!--.*$' | \
+    docker run --rm -i -v "$PWD":/data ghcr.io/mermaid-js/mermaid-cli/mermaid-cli -c /data/mermaid.json -o /data/operatorhubio-catalog.svg
+
+
 		`,
 		Args: cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/opm/render/cmd.go
+++ b/cmd/opm/render/cmd.go
@@ -26,42 +26,6 @@ func NewCmd() *cobra.Command {
 		Long: `Generate a declarative config blob from the provided index images, bundle images, and sqlite database files
 
 ` + sqlite.DeprecationMessage,
-		Example: `
-#
-# Output declarative configuration view of an index-image in JSON format
-#
-$ opm render quay.io/operatorhubio/catalog:latest
-
-#
-# Output declarative configuration view of a bundle-image in YAML format
-#
-$ opm render quay.io/operatorhubio/ack-apigatewayv2-controller@sha256:14c507f2ecb4a64928bcfcf5897f4495d9988f4d7ff58f41e029359a9fe78c38 -o yaml
-
-#
-# Output channel graph of a catalog in mermaid format
-#
-$ opm render quay.io/operatorhubio/catalog:latest -o mermaid
-
-#
-# Output channel graph of a catalog and generate a scaled vector graphic (SVG) representation
-# Note:  this pipeline filters out the comments about lacking skipRange support
-#
-$ opm render quay.io/operatorhubio/catalog:latest -o mermaid | \
-    grep -Ev '^<!--.*$' | \
-    docker run --rm -i -v "$PWD":/data ghcr.io/mermaid-js/mermaid-cli/mermaid-cli -o /data/operatorhubio-catalog.svg
-
-# Note:  mermaid has a default maxTextSize of 30 000 characters.  To override this, generate a JSON-formatted initialization file for
-# mermaid like this (using 300 000 for the limit):
-$ cat << EOF > ./mermaid.json
-{ "maxTextSize": 300000 }
-EOF
-# and then pass the file for initialization configuration, via the '-c' option, like:
-$ opm render quay.io/operatorhubio/catalog:latest -o mermaid | \
-    grep -Ev '^<!--.*$' | \
-    docker run --rm -i -v "$PWD":/data ghcr.io/mermaid-js/mermaid-cli/mermaid-cli -c /data/mermaid.json -o /data/operatorhubio-catalog.svg
-
-
-		`,
 		Args: cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			render.Refs = args

--- a/cmd/opm/render/cmd.go
+++ b/cmd/opm/render/cmd.go
@@ -26,6 +26,31 @@ func NewCmd() *cobra.Command {
 		Long: `Generate a declarative config blob from the provided index images, bundle images, and sqlite database files
 
 ` + sqlite.DeprecationMessage,
+		Example: `
+#
+# Output declarative configuration view of an index-image in JSON format
+#
+$ opm render quay.io/operatorhubio/catalog:latest
+
+#
+# Output declarative configuration view of a bundle-image in YAML format
+#
+$ opm render quay.io/operatorhubio/ack-apigatewayv2-controller@sha256:14c507f2ecb4a64928bcfcf5897f4495d9988f4d7ff58f41e029359a9fe78c38
+
+#
+# Output channel graph of a catalog in mermaid format
+#
+$ opm render quay.io/operatorhubio/catalog:latest -o mermaid
+
+#
+# Output channel graph of a catalog and generate a scaled vector graphic (SVG) representation
+# Note:  this pipeline filters out the comments about lacking skipRange support
+#
+$ opm render quay.io/operatorhubio/catalog:latest -o mermaid | \
+    grep -Ev '^<!--.*$' | \
+    docker run --rm -i -v "$PWD":/data ghcr.io/mermaid-js/mermaid-cli/mermaid-cli -o /data/operatorhubio-catalog.svg
+
+		`,
 		Args: cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			render.Refs = args

--- a/cmd/opm/render/cmd.go
+++ b/cmd/opm/render/cmd.go
@@ -35,7 +35,7 @@ $ opm render quay.io/operatorhubio/catalog:latest
 #
 # Output declarative configuration view of a bundle-image in YAML format
 #
-$ opm render quay.io/operatorhubio/ack-apigatewayv2-controller@sha256:14c507f2ecb4a64928bcfcf5897f4495d9988f4d7ff58f41e029359a9fe78c38
+$ opm render quay.io/operatorhubio/ack-apigatewayv2-controller@sha256:14c507f2ecb4a64928bcfcf5897f4495d9988f4d7ff58f41e029359a9fe78c38 -o yaml
 
 #
 # Output channel graph of a catalog in mermaid format


### PR DESCRIPTION
Signed-off-by: Jordan Keister <jordan@nimblewidget.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Adding examples of `opm alpha render-graph` so that we can provide examples of the more complex pipelines required to generate a picture of operator upgrade graphs.

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
