### PR TITLE
(feature) arbitrary base-version specification for mermaid upgrade-graph output

### DIFF
--- a/alpha/declcfg/write.go
+++ b/alpha/declcfg/write.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/blang/semver/v4"
+	"github.com/operator-framework/operator-registry/alpha/property"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/yaml"
 )
@@ -15,60 +17,81 @@ import (
 // writes out the channel edges of the declarative config graph in a mermaid format capable of being pasted into
 // mermaid renderers like github, mermaid.live, etc.
 // output is sorted lexicographically by package name, and then by channel name
+// if provided, minEdgeName will be used as the lower bound for edges in the output graph
 //
 // NB:  Output has wrapper comments stating the skipRange edge caveat in HTML comment format, which cannot be parsed by mermaid renderers.
-//      This is deliberate, and intended as an explicit acknowledgement of the limitations, instead of requiring the user to notice the missing edges upon inspection.
+//
+//	This is deliberate, and intended as an explicit acknowledgement of the limitations, instead of requiring the user to notice the missing edges upon inspection.
 //
 // Example output:
 // <!-- PLEASE NOTE:  skipRange edges are not currently displayed -->
 // graph LR
-//   %% package "neuvector-certified-operator-rhmp"
-//   subgraph "neuvector-certified-operator-rhmp"
-//      %% channel "beta"
-//      subgraph neuvector-certified-operator-rhmp-beta["beta"]
-// 	      neuvector-certified-operator-rhmp-beta-neuvector-operator.v1.2.8["neuvector-operator.v1.2.8"]
-// 	      neuvector-certified-operator-rhmp-beta-neuvector-operator.v1.2.9["neuvector-operator.v1.2.9"]
-// 	      neuvector-certified-operator-rhmp-beta-neuvector-operator.v1.3.0["neuvector-operator.v1.3.0"]
-// 	      neuvector-certified-operator-rhmp-beta-neuvector-operator.v1.3.0["neuvector-operator.v1.3.0"]-- replaces --> neuvector-certified-operator-rhmp-beta-neuvector-operator.v1.2.8["neuvector-operator.v1.2.8"]
-// 	      neuvector-certified-operator-rhmp-beta-neuvector-operator.v1.3.0["neuvector-operator.v1.3.0"]-- skips --> neuvector-certified-operator-rhmp-beta-neuvector-operator.v1.2.9["neuvector-operator.v1.2.9"]
-//     end
-//   end
+//
+//	  %% package "neuvector-certified-operator-rhmp"
+//	  subgraph "neuvector-certified-operator-rhmp"
+//	     %% channel "beta"
+//	     subgraph neuvector-certified-operator-rhmp-beta["beta"]
+//		      neuvector-certified-operator-rhmp-beta-neuvector-operator.v1.2.8["neuvector-operator.v1.2.8"]
+//		      neuvector-certified-operator-rhmp-beta-neuvector-operator.v1.2.9["neuvector-operator.v1.2.9"]
+//		      neuvector-certified-operator-rhmp-beta-neuvector-operator.v1.3.0["neuvector-operator.v1.3.0"]
+//		      neuvector-certified-operator-rhmp-beta-neuvector-operator.v1.3.0["neuvector-operator.v1.3.0"]-- replaces --> neuvector-certified-operator-rhmp-beta-neuvector-operator.v1.2.8["neuvector-operator.v1.2.8"]
+//		      neuvector-certified-operator-rhmp-beta-neuvector-operator.v1.3.0["neuvector-operator.v1.3.0"]-- skips --> neuvector-certified-operator-rhmp-beta-neuvector-operator.v1.2.9["neuvector-operator.v1.2.9"]
+//	    end
+//	  end
+//
 // end
 // <!-- PLEASE NOTE:  skipRange edges are not currently displayed -->
-func WriteMermaidChannels(cfg DeclarativeConfig, out io.Writer) error {
+func WriteMermaidChannels(cfg DeclarativeConfig, out io.Writer, minEdgeName string) error {
 	pkgs := map[string]*strings.Builder{}
 
 	sort.Slice(cfg.Channels, func(i, j int) bool {
 		return cfg.Channels[i].Name < cfg.Channels[j].Name
 	})
 
-	for _, c := range cfg.Channels {
-		pkgBuilder, ok := pkgs[c.Package]
-		if !ok {
-			pkgBuilder = &strings.Builder{}
-			pkgs[c.Package] = pkgBuilder
+	versionMap, err := getBundleVersions(&cfg)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := versionMap[minEdgeName]; !ok {
+		if minEdgeName != "" {
+			return fmt.Errorf("unknown minimum edge name: %q", minEdgeName)
 		}
-		channelID := fmt.Sprintf("%s-%s", c.Package, c.Name)
-		pkgBuilder.WriteString(fmt.Sprintf("    %%%% channel %q\n", c.Name))
-		pkgBuilder.WriteString(fmt.Sprintf("    subgraph %s[%q]\n", channelID, c.Name))
+	}
 
-		for _, ce := range c.Entries {
-			entryId := fmt.Sprintf("%s-%s", channelID, ce.Name)
-			pkgBuilder.WriteString(fmt.Sprintf("      %s[%q]\n", entryId, ce.Name))
-
-			// no support for SkipRange yet
-			if len(ce.Replaces) > 0 {
-				replacesId := fmt.Sprintf("%s-%s", channelID, ce.Replaces)
-				pkgBuilder.WriteString(fmt.Sprintf("      %s[%q]-- %s --> %s[%q]\n", entryId, ce.Name, "replaces", replacesId, ce.Replaces))
+	for _, c := range cfg.Channels {
+		filteredChannel := filterChannel(&c, versionMap, minEdgeName)
+		if filteredChannel != nil {
+			pkgBuilder, ok := pkgs[c.Package]
+			if !ok {
+				pkgBuilder = &strings.Builder{}
+				pkgs[c.Package] = pkgBuilder
 			}
-			if len(ce.Skips) > 0 {
-				for _, s := range ce.Skips {
-					skipsId := fmt.Sprintf("%s-%s", channelID, s)
-					pkgBuilder.WriteString(fmt.Sprintf("      %s[%q]-- %s --> %s[%q]\n", entryId, ce.Name, "skips", skipsId, s))
+
+			channelID := fmt.Sprintf("%s-%s", filteredChannel.Package, filteredChannel.Name)
+			pkgBuilder.WriteString(fmt.Sprintf("    %%%% channel %q\n", filteredChannel.Name))
+			pkgBuilder.WriteString(fmt.Sprintf("    subgraph %s[%q]\n", channelID, filteredChannel.Name))
+
+			for _, ce := range filteredChannel.Entries {
+				if versionMap[ce.Name].GE(versionMap[minEdgeName]) {
+					entryId := fmt.Sprintf("%s-%s", channelID, ce.Name)
+					pkgBuilder.WriteString(fmt.Sprintf("      %s[%q]\n", entryId, ce.Name))
+
+					// no support for SkipRange yet
+					if len(ce.Replaces) > 0 {
+						replacesId := fmt.Sprintf("%s-%s", channelID, ce.Replaces)
+						pkgBuilder.WriteString(fmt.Sprintf("      %s[%q]-- %s --> %s[%q]\n", entryId, ce.Name, "replaces", replacesId, ce.Replaces))
+					}
+					if len(ce.Skips) > 0 {
+						for _, s := range ce.Skips {
+							skipsId := fmt.Sprintf("%s-%s", channelID, s)
+							pkgBuilder.WriteString(fmt.Sprintf("      %s[%q]-- %s --> %s[%q]\n", entryId, ce.Name, "skips", skipsId, s))
+						}
+					}
 				}
 			}
+			pkgBuilder.WriteString("    end\n")
 		}
-		pkgBuilder.WriteString("    end\n")
 	}
 
 	out.Write([]byte("<!-- PLEASE NOTE:  skipRange edges are not currently displayed -->\n"))
@@ -89,6 +112,85 @@ func WriteMermaidChannels(cfg DeclarativeConfig, out io.Writer) error {
 	out.Write([]byte("<!-- PLEASE NOTE:  skipRange edges are not currently displayed -->\n"))
 
 	return nil
+}
+
+// filters the channel edges to include only those which are greater-than-or-equal to the edge named by startVersion
+// returns a nil channel if all edges are filtered out
+func filterChannel(c *Channel, versionMap map[string]semver.Version, minEdgeName string) *Channel {
+	// short-circuit if no specified startVersion
+	if minEdgeName == "" {
+		return c
+	}
+	// convert the edge name to the version so we don't have to duplicate the lookup
+	minVersion := versionMap[minEdgeName]
+
+	out := &Channel{Name: c.Name, Package: c.Package, Properties: c.Properties, Entries: []ChannelEntry{}}
+	for _, ce := range c.Entries {
+		filteredCe := ChannelEntry{Name: ce.Name}
+		// short-circuit to take the edge name (but no references to earlier versions)
+		if ce.Name == minEdgeName {
+			out.Entries = append(out.Entries, filteredCe)
+			continue
+		}
+		// if len(ce.SkipRange) > 0 {
+		// }
+		if len(ce.Replaces) > 0 {
+			if versionMap[ce.Replaces].GTE(minVersion) {
+				filteredCe.Replaces = ce.Replaces
+			}
+		}
+		if len(ce.Skips) > 0 {
+			filteredSkips := []string{}
+			for _, s := range ce.Skips {
+				if versionMap[s].GTE(minVersion) {
+					filteredSkips = append(filteredSkips, s)
+				}
+			}
+			if len(filteredSkips) > 0 {
+				filteredCe.Skips = filteredSkips
+			}
+		}
+		if len(filteredCe.Replaces) > 0 || len(filteredCe.Skips) > 0 {
+			out.Entries = append(out.Entries, filteredCe)
+		}
+	}
+
+	if len(out.Entries) > 0 {
+		return out
+	} else {
+		return nil
+	}
+}
+
+func parseVersionProperty(b *Bundle) (*semver.Version, error) {
+	props, err := property.Parse(b.Properties)
+	if err != nil {
+		return nil, fmt.Errorf("parse properties for bundle %q: %v", b.Name, err)
+	}
+	if len(props.Packages) != 1 {
+		return nil, fmt.Errorf("bundle %q has multiple %q properties, expected exactly 1", b.Name, property.TypePackage)
+	}
+	v, err := semver.Parse(props.Packages[0].Version)
+	if err != nil {
+		return nil, fmt.Errorf("bundle %q has invalid version %q: %v", b.Name, props.Packages[0].Version, err)
+	}
+
+	return &v, nil
+}
+
+func getBundleVersions(cfg *DeclarativeConfig) (map[string]semver.Version, error) {
+	entries := make(map[string]semver.Version)
+	for index := range cfg.Bundles {
+		if _, ok := entries[cfg.Bundles[index].Name]; !ok {
+			ver, err := parseVersionProperty(&cfg.Bundles[index])
+			if err != nil {
+				return entries, err
+			}
+			entries[cfg.Bundles[index].Name] = *ver
+		}
+	}
+
+	return entries, nil
 }
 
 func WriteJSON(cfg DeclarativeConfig, w io.Writer) error {

--- a/alpha/declcfg/write_test.go
+++ b/alpha/declcfg/write_test.go
@@ -513,10 +513,11 @@ graph LR
 `,
 		},
 	}
+	startVersion := ""
 	for _, s := range specs {
 		t.Run(s.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			err := WriteMermaidChannels(s.cfg, &buf)
+			err := WriteMermaidChannels(s.cfg, &buf, startVersion)
 			require.NoError(t, err)
 			require.Equal(t, s.expected, buf.String())
 		})

--- a/cmd/opm/alpha/cmd.go
+++ b/cmd/opm/alpha/cmd.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/operator-framework/operator-registry/cmd/opm/alpha/bundle"
 	"github.com/operator-framework/operator-registry/cmd/opm/alpha/list"
+	rendergraph "github.com/operator-framework/operator-registry/cmd/opm/alpha/render-graph"
 	"github.com/operator-framework/operator-registry/cmd/opm/alpha/veneer"
 )
 
@@ -19,6 +20,7 @@ func NewCmd() *cobra.Command {
 	runCmd.AddCommand(
 		bundle.NewCmd(),
 		list.NewCmd(),
+		rendergraph.NewCmd(),
 		veneer.NewCmd(),
 	)
 	return runCmd

--- a/cmd/opm/alpha/render-graph/cmd.go
+++ b/cmd/opm/alpha/render-graph/cmd.go
@@ -1,0 +1,52 @@
+package rendergraph
+
+import (
+	"io"
+	"log"
+	"os"
+
+	"github.com/operator-framework/operator-registry/alpha/action"
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+	"github.com/operator-framework/operator-registry/cmd/opm/internal/util"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func NewCmd() *cobra.Command {
+	var (
+		render  action.Render
+		minEdge string
+	)
+	cmd := &cobra.Command{
+		Use:   "render-graph [index-image | fbc-dir | bundle-image]",
+		Short: "Generate mermaid-formatted view of upgrade graph of operators in an index",
+		Long:  `Generate mermaid-formatted view of upgrade graphs of operators in an index`,
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			// The bundle loading impl is somewhat verbose, even on the happy path,
+			// so discard all logrus default logger logs. Any important failures will be
+			// returned from render.Run and logged as fatal errors.
+			logrus.SetOutput(io.Discard)
+
+			registry, err := util.CreateCLIRegistry(cmd)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			render.Refs = args
+			render.AllowedRefMask = action.RefBundleImage | action.RefDCImage | action.RefDCDir // all non-sqlite
+			render.Registry = registry
+
+			cfg, err := render.Run(cmd.Context())
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if err := declcfg.WriteMermaidChannels(*cfg, os.Stdout, minEdge); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+	cmd.Flags().StringVar(&minEdge, "minimum-edge", "", "the channel edge to be used as the lower bound of the set of edges composing the upgrade graph")
+	return cmd
+}

--- a/cmd/opm/alpha/veneer/semver.go
+++ b/cmd/opm/alpha/veneer/semver.go
@@ -39,7 +39,10 @@ func newSemverCmd() *cobra.Command {
 			case "yaml":
 				write = declcfg.WriteYAML
 			case "mermaid":
-				write = declcfg.WriteMermaidChannels
+				write = func(cfg declcfg.DeclarativeConfig, writer io.Writer) error {
+					startVersion := ""
+					return declcfg.WriteMermaidChannels(cfg, writer, startVersion)
+				}
 			default:
 				return fmt.Errorf("invalid output format %q", output)
 			}

--- a/cmd/opm/render/cmd.go
+++ b/cmd/opm/render/cmd.go
@@ -36,10 +36,8 @@ func NewCmd() *cobra.Command {
 				write = declcfg.WriteYAML
 			case "json":
 				write = declcfg.WriteJSON
-			case "mermaid":
-				write = declcfg.WriteMermaidChannels
 			default:
-				log.Fatalf("invalid --output value %q, expected (json|yaml|mermaid)", output)
+				log.Fatalf("invalid --output value %q, expected (json|yaml)", output)
 			}
 
 			// The bundle loading impl is somewhat verbose, even on the happy path,
@@ -65,7 +63,7 @@ func NewCmd() *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().StringVarP(&output, "output", "o", "json", "Output format (json|yaml|mermaid)")
+	cmd.Flags().StringVarP(&output, "output", "o", "json", "Output format (json|yaml)")
 	return cmd
 }
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

In recognition of the "bolted on" nature of the previous work, this PR moves the command to a standalone `opm alpha render-graph` command with a `--minimum-edge` option to constrain the output. 

**Motivation for the change:**

There has been increasing friction with the `opm render` infrastructure and the seemingly-orthogonal desire to express an upgrade graph in mermaid format. 

This came to a crisis when implementing the ability to specify a minimum-edge-name capability to filter out earlier edges from the graph.  

** Examples **

*** Full index graph ***
`./bin/opm alpha render-graph quay.io/jordankeister/cool-catalog:v1.24.0` gives the entire upgrade graph in the catalog

*** Minimum-edge graph ***
`./bin/opm alpha render-graph quay.io/jordankeister/cool-catalog:v1.24.0 --minimum-edge testoperator.v0.3.0` expresses the upgrade graph starting at the minimum edge and including all higher-versioned edges

*** Use with file-based-catalog ***
With a catalog or operator contribution in FBC format in a local directory /tmp/catalog (file-based-catalogs are always an [arbitrary directory hierarchy](https://olm.operatorframework.io/docs/reference/file-based-catalogs/#composability))
`./bin/opm alpha render-graph /tmp/catalog` will render the entire graph of all channels/operators expressed in the FBC. 

*** Restricting graphs to a single operator ***
This is outside the scope of this PR, but can be performed in a variety of ways, for e.g.:
1. `opm migrate <indexRef> <outputDir>` will generate discrete output directories for each operator
2. `opm render` of an index, with `yq` magic to extract only the operator of interest, like: 
```
opm render registry.redhat.io/redhat/redhat-marketplace-index:v4.11 -o yaml | yq 'select(.package == "redis-enterprise-operator-cert-rhmp" or .name == "redis-enterprise-operator-cert-rhmp")' > /tmp/catalog/redis.yaml
opm alpha render-graph /tmp/catalog
```





**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
