### PR TITLE
do not fatally exit from serve commands

### DIFF
--- a/cmd/opm/registry/serve.go
+++ b/cmd/opm/registry/serve.go
@@ -115,7 +115,7 @@ func serveFunc(cmd *cobra.Command, _ []string) error {
 
 	lis, err := net.Listen("tcp", ":"+port)
 	if err != nil {
-		logger.Fatalf("failed to listen: %s", err)
+		return fmt.Errorf("failed to listen: %s", err)
 	}
 
 	timeout, err := cmd.Flags().GetString("timeout-seconds")


### PR DESCRIPTION
Signed-off-by: Joe Lanford <joe.lanford@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

This commit ensures that we always cleanly return an error from the
serve function, thus ensuring that defered cleanups always happen.

**Motivation for the change:**

When we fatally exit directly in the serve functions, we do not give a
chance for the registered cleanup functions to run, resulting in
temporary files being left behind.



**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
