### PR TITLE
Addressing additional feedback from PR 1015

### DIFF
--- a/alpha/veneer/semver/semver.go
+++ b/alpha/veneer/semver/semver.go
@@ -128,8 +128,8 @@ func buildBundleList(bundles *[]semverVeneerBundleEntry, dict *map[string]struct
 	}
 }
 
-func readFile(data io.Reader) (*semverVeneer, error) {
-	fileData, err := io.ReadAll(data)
+func readFile(reader io.Reader) (*semverVeneer, error) {
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func readFile(data io.Reader) (*semverVeneer, error) {
 		GenerateMinorChannels: true,
 		AvoidSkipPatch:        false,
 	}
-	if err := yaml.Unmarshal(fileData, &sv); err != nil {
+	if err := yaml.Unmarshal(data, &sv); err != nil {
 		return nil, err
 	}
 	return &sv, nil

--- a/cmd/opm/alpha/veneer/semver.go
+++ b/cmd/opm/alpha/veneer/semver.go
@@ -23,22 +23,13 @@ func newSemverCmd() *cobra.Command {
 		Long:  "Generate a file-based catalog from a single 'semver veneer' file \nWhen FILE is '-' or not provided, the veneer is read from standard input",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var (
-				data io.Reader
-				err  error
-			)
-
 			// Handle different input argument types
-			if len(args) == 0 || args[0] == "-" {
-				// When no arguments or "-" is passed to the command,
-				// assume input is coming from stdin
-				data = cmd.InOrStdin()
-			} else {
-				// Otherwise open the file passed to the command
-				data, err = os.Open(args[0])
-				if err != nil {
-					return err
-				}
+			// When no arguments or "-" is passed to the command,
+			// assume input is coming from stdin
+			// Otherwise open the file passed to the command
+			data, err := openFileOrReadStdin(cmd, args)
+			if err != nil {
+				return err
 			}
 
 			var write func(declcfg.DeclarativeConfig, io.Writer) error
@@ -85,4 +76,11 @@ func newSemverCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&output, "output", "o", "json", "Output format (json|yaml|mermaid)")
 	return cmd
+}
+
+func openFileOrReadStdin(cmd *cobra.Command, args []string) (io.Reader, error) {
+	if len(args) == 0 || args[0] == "-" {
+		return cmd.InOrStdin(), nil
+	}
+	return os.Open(args[0])
 }


### PR DESCRIPTION
Signed-off-by: Catherine Chan-Tse <cchantse@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Addresses additional comments from https://github.com/operator-framework/operator-registry/pull/1015:
- moves semver command input handling logic out to a separate function
- renames readFile input argument to be more descriptive

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
