### PR TITLE
(bug) fix permissions problems with pregen cache access

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3
 	golang.org/x/net v0.0.0-20220407224826-aac1ed45d8e3
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad
 	google.golang.org/grpc v1.45.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v0.0.0-20200709232328-d8193ee9cc3e
 	google.golang.org/protobuf v1.28.0
@@ -147,7 +148,6 @@ require (
 	go.opentelemetry.io/proto/otlp v0.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20220408190544-5352b0902921 // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
-	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect

--- a/pkg/registry/query.go
+++ b/pkg/registry/query.go
@@ -17,6 +17,11 @@ import (
 	"github.com/operator-framework/operator-registry/pkg/api"
 )
 
+const (
+	cachePermissionDir  = 0750
+	cachePermissionFile = 0640
+)
+
 type Querier struct {
 	*cache
 }
@@ -423,7 +428,7 @@ func newEphemeralCache() (*cache, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(filepath.Join(baseDir, "cache"), 0750); err != nil {
+	if err := os.MkdirAll(filepath.Join(baseDir, "cache"), cachePermissionDir); err != nil {
 		return nil, err
 	}
 	return &cache{
@@ -434,7 +439,7 @@ func newEphemeralCache() (*cache, error) {
 }
 
 func newPersistentCache(baseDir string) (*cache, error) {
-	if err := os.MkdirAll(baseDir, 0750); err != nil {
+	if err := os.MkdirAll(baseDir, cachePermissionDir); err != nil {
 		return nil, err
 	}
 	qc := &cache{baseDir: baseDir, persist: true}
@@ -498,7 +503,7 @@ func (qc *cache) repopulateCache(model digestableModel) error {
 			return err
 		}
 	}
-	if err := os.MkdirAll(filepath.Join(qc.baseDir, "cache"), 0750); err != nil {
+	if err := os.MkdirAll(filepath.Join(qc.baseDir, "cache"), cachePermissionDir); err != nil {
 		return err
 	}
 
@@ -511,7 +516,7 @@ func (qc *cache) repopulateCache(model digestableModel) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(qc.baseDir, "cache", "packages.json"), packageJson, 0640); err != nil {
+	if err := os.WriteFile(filepath.Join(qc.baseDir, "cache", "packages.json"), packageJson, cachePermissionFile); err != nil {
 		return err
 	}
 
@@ -528,7 +533,7 @@ func (qc *cache) repopulateCache(model digestableModel) error {
 					return err
 				}
 				filename := filepath.Join(qc.baseDir, "cache", fmt.Sprintf("%s_%s_%s.json", p.Name, ch.Name, b.Name))
-				if err := os.WriteFile(filename, jsonBundle, 0640); err != nil {
+				if err := os.WriteFile(filename, jsonBundle, cachePermissionFile); err != nil {
 					return err
 				}
 				qc.apiBundles[apiBundleKey{p.Name, ch.Name, b.Name}] = filename
@@ -537,7 +542,7 @@ func (qc *cache) repopulateCache(model digestableModel) error {
 	}
 	computedHash, err := model.GetDigest()
 	if err == nil {
-		if err := os.WriteFile(filepath.Join(qc.baseDir, "digest"), []byte(computedHash), 0640); err != nil {
+		if err := os.WriteFile(filepath.Join(qc.baseDir, "digest"), []byte(computedHash), cachePermissionFile); err != nil {
 			return err
 		}
 	} else if !errors.Is(err, errNonDigestable) {

--- a/pkg/registry/syscall_unix.go
+++ b/pkg/registry/syscall_unix.go
@@ -1,0 +1,8 @@
+//go:build !windows
+// +build !windows
+
+package registry
+
+import "golang.org/x/sys/unix"
+
+var umask = unix.Umask

--- a/pkg/registry/syscall_windows.go
+++ b/pkg/registry/syscall_windows.go
@@ -1,0 +1,6 @@
+//go:build windows
+// +build windows
+
+package registry
+
+var umask = func(i int) int { return 0 }


### PR DESCRIPTION
Signed-off-by: Jordan <jordan@nimblewidget.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
create `opm serve` cache artifacts to serve for any uid by generating as 0777 (dirs) / 0666 (files). 

Several options were evaluated, and we landed on a combo of relaxing the umask during cache generation coupled with updated permission of created artifacts to provide world read-/write-ability. 

| characterization | URI | verdict |
| ------------------- | ---------------------------- | --------- |
| original perms conflict | docker.io/grokspawn/catalog-permissions:orig | 0700/0600 *FAIL* |
| 0770/0660 perms | docker.io/grokspawn/catalog-permissions:permbump | 0700/0600 *FAIL* |
| 0777/0666 perms | docker.io/grokspawn/catalog-permissions:permbumpall | 0700/0600 *FAIL* |
| 0777/0666 perms + umask | docker.io/grokspawn/catalog-permissions:final-umask | 0777/0666 *SUCCESS* |
| 0750/0640 perms + umask | docker.io/grokspawn/opm:umask-no-other | 0750/0640 *SUCCESS* | 

To build a candidate opm replacement image, !!IN LINUX!! do 

```shell
cd $your-operator-registry-clone
GOENV=CGO_ENABLED=0 make static 
cp bin/opm .
docker build -f release/goreleaser.opm/Dockerfile -t [tag] .
docker push [tag]
```

Then create the catalog image:

```shell
mkdir -p /tmp/ctest
cd /tmp/ctest
mkdir catalog
[path-to-opm] generate dockerfile catalog
```

and finally, edit the `FROM` line in the `catalog.Dockerfile` to point to the pushed tag for the opm replacement image.

**Motivation for the change:**
c.f. OCPBUGS-650. 

Cache generation code was creating for uid 1001 and permissions of 0700 (dirs) / 0600 (files), so later deployment in a pod would fail unless uid matched.  

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
