### PR TITLE
OCPBUGS-929: fix help text for render-graph

### DIFF
--- a/cmd/opm/alpha/render-graph/cmd.go
+++ b/cmd/opm/alpha/render-graph/cmd.go
@@ -18,7 +18,7 @@ func NewCmd() *cobra.Command {
 		minEdge string
 	)
 	cmd := &cobra.Command{
-		Use:   "render-graph [index-image | fbc-dir | bundle-image]",
+		Use:   "render-graph [index-image | fbc-dir]",
 		Short: "Generate mermaid-formatted view of upgrade graph of operators in an index",
 		Long:  `Generate mermaid-formatted view of upgrade graphs of operators in an index`,
 		Args:  cobra.MinimumNArgs(1),


### PR DESCRIPTION
Signed-off-by: Jordan Keister <jordan@nimblewidget.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
left in 'bundle-image' in the help comment as a potential input type, even though bundle images are not a supported catalog type & were removed in recent commit. 

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
