### PR TITLE
add skipRange support to render-graph

### DIFF
--- a/alpha/declcfg/write_test.go
+++ b/alpha/declcfg/write_test.go
@@ -472,16 +472,17 @@ func removeJSONWhitespace(cfg *DeclarativeConfig) {
 
 func TestWriteMermaidChannels(t *testing.T) {
 	type spec struct {
-		name     string
-		cfg      DeclarativeConfig
-		expected string
+		name      string
+		cfg       DeclarativeConfig
+		startEdge string
+		expected  string
 	}
 	specs := []spec{
 		{
-			name: "Success",
-			cfg:  buildValidDeclarativeConfig(true),
-			expected: `<!-- PLEASE NOTE:  skipRange edges are not currently displayed -->
-graph LR
+			name:      "SuccessNoFilters",
+			cfg:       buildValidDeclarativeConfig(true),
+			startEdge: "",
+			expected: `graph LR
   %% package "anakin"
   subgraph "anakin"
     %% channel "dark"
@@ -509,15 +510,33 @@ graph LR
       boba-fett-mando-boba-fett.v2.0.0["boba-fett.v2.0.0"]-- replaces --> boba-fett-mando-boba-fett.v1.0.0["boba-fett.v1.0.0"]
     end
   end
-<!-- PLEASE NOTE:  skipRange edges are not currently displayed -->
+`,
+		},
+		{
+			name:      "SuccessMinEdgeFilter",
+			cfg:       buildValidDeclarativeConfig(true),
+			startEdge: "anakin.v0.1.0",
+			expected: `graph LR
+  %% package "anakin"
+  subgraph "anakin"
+    %% channel "dark"
+    subgraph anakin-dark["dark"]
+      anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]
+      anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]
+      anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]-- skips --> anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]
+    end
+    %% channel "light"
+    subgraph anakin-light["light"]
+      anakin-light-anakin.v0.1.0["anakin.v0.1.0"]
+    end
+  end
 `,
 		},
 	}
-	startVersion := ""
 	for _, s := range specs {
 		t.Run(s.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			err := WriteMermaidChannels(s.cfg, &buf, startVersion)
+			err := WriteMermaidChannels(s.cfg, &buf, s.startEdge)
 			require.NoError(t, err)
 			require.Equal(t, s.expected, buf.String())
 		})


### PR DESCRIPTION
Signed-off-by: Jordan Keister <jordan@nimblewidget.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
mermaid output of channels will express skipRange relationships between nodes

**Motivation for the change:**
tired of the header/footer always expressing the feature's shortcomings ;) 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
