### PR TITLE
(feature) add skipRange support to `opm alpha render-graph` and provide the capability to filter mermaid output to a single package name

### DIFF
--- a/alpha/declcfg/write_test.go
+++ b/alpha/declcfg/write_test.go
@@ -472,16 +472,19 @@ func removeJSONWhitespace(cfg *DeclarativeConfig) {
 
 func TestWriteMermaidChannels(t *testing.T) {
 	type spec struct {
-		name     string
-		cfg      DeclarativeConfig
-		expected string
+		name          string
+		cfg           DeclarativeConfig
+		startEdge     string
+		packageFilter string
+		expected      string
 	}
 	specs := []spec{
 		{
-			name: "Success",
-			cfg:  buildValidDeclarativeConfig(true),
-			expected: `<!-- PLEASE NOTE:  skipRange edges are not currently displayed -->
-graph LR
+			name:          "SuccessNoFilters",
+			cfg:           buildValidDeclarativeConfig(true),
+			startEdge:     "",
+			packageFilter: "",
+			expected: `graph LR
   %% package "anakin"
   subgraph "anakin"
     %% channel "dark"
@@ -509,15 +512,52 @@ graph LR
       boba-fett-mando-boba-fett.v2.0.0["boba-fett.v2.0.0"]-- replaces --> boba-fett-mando-boba-fett.v1.0.0["boba-fett.v1.0.0"]
     end
   end
-<!-- PLEASE NOTE:  skipRange edges are not currently displayed -->
+`,
+		},
+		{
+			name:          "SuccessMinEdgeFilter",
+			cfg:           buildValidDeclarativeConfig(true),
+			startEdge:     "anakin.v0.1.0",
+			packageFilter: "",
+			expected: `graph LR
+  %% package "anakin"
+  subgraph "anakin"
+    %% channel "dark"
+    subgraph anakin-dark["dark"]
+      anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]
+      anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]
+      anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]-- skips --> anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]
+    end
+    %% channel "light"
+    subgraph anakin-light["light"]
+      anakin-light-anakin.v0.1.0["anakin.v0.1.0"]
+    end
+  end
+`,
+		},
+		{
+			name:          "SuccessPackageNameFilter",
+			cfg:           buildValidDeclarativeConfig(true),
+			startEdge:     "",
+			packageFilter: "boba-fett",
+			expected: `graph LR
+  %% package "boba-fett"
+  subgraph "boba-fett"
+    %% channel "mando"
+    subgraph boba-fett-mando["mando"]
+      boba-fett-mando-boba-fett.v1.0.0["boba-fett.v1.0.0"]
+      boba-fett-mando-boba-fett.v2.0.0["boba-fett.v2.0.0"]
+      boba-fett-mando-boba-fett.v2.0.0["boba-fett.v2.0.0"]-- replaces --> boba-fett-mando-boba-fett.v1.0.0["boba-fett.v1.0.0"]
+    end
+  end
 `,
 		},
 	}
-	startVersion := ""
 	for _, s := range specs {
 		t.Run(s.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			err := WriteMermaidChannels(s.cfg, &buf, startVersion)
+			writer := NewMermaidWriter(WithMinEdgeName(s.startEdge), WithSpecifiedPackageName(s.packageFilter))
+			err := writer.WriteChannels(s.cfg, &buf)
 			require.NoError(t, err)
 			require.Equal(t, s.expected, buf.String())
 		})

--- a/cmd/opm/alpha/veneer/semver.go
+++ b/cmd/opm/alpha/veneer/semver.go
@@ -40,8 +40,8 @@ func newSemverCmd() *cobra.Command {
 				write = declcfg.WriteYAML
 			case "mermaid":
 				write = func(cfg declcfg.DeclarativeConfig, writer io.Writer) error {
-					startVersion := ""
-					return declcfg.WriteMermaidChannels(cfg, writer, startVersion)
+					mermaidWriter := declcfg.NewMermaidWriter()
+					return mermaidWriter.WriteChannels(cfg, writer)
 				}
 			default:
 				return fmt.Errorf("invalid output format %q", output)


### PR DESCRIPTION
Signed-off-by: Jordan Keister <jordan@nimblewidget.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

add rendering of skipRange relationships to `opm alpha render-graph` and support an additional filter to allow users to limit results to a specific package in the catalog. 

From usage:
```
Flags:
  -h, --help                  help for render-graph
      --minimum-edge string   the channel edge to be used as the lower bound of the set of edges composing the upgrade graph; default is to include all edges
  -p, --package-name string   a specific package name to filter output; default is to include all packages in reference

Global Flags:
      --skip-tls-verify   skip TLS certificate verification for container image registries while pulling bundles
      --use-http          use plain HTTP for container image registries while pulling bundles
 ```     

**Motivation for the change:**
skipRange was supported in an earlier PR, but it started having complex interactions with this one, so I merged them here. 
skipRange was a glaring inadequacy of the tool, and there have been multiple requestors for a package-filter option. 


**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
