### PR TITLE
OCPBUGS-1272 Add pipe support to "opm alpha render-veneer basic"

### DIFF
--- a/alpha/declcfg/load.go
+++ b/alpha/declcfg/load.go
@@ -118,7 +118,9 @@ func extractCSV(objs []string) string {
 	return ""
 }
 
-func readYAMLOrJSON(r io.Reader) (*DeclarativeConfig, error) {
+// LoadReader reads yaml or json from the passed in io.Reader and unmarshals it into a DeclarativeConfig struct.
+// Path references will not be de-referenced so callers are responsible for de-referencing if necessary.
+func LoadReader(r io.Reader) (*DeclarativeConfig, error) {
 	cfg := &DeclarativeConfig{}
 	dec := yaml.NewYAMLOrJSONDecoder(r, 4096)
 	for {
@@ -173,7 +175,7 @@ func LoadFile(root fs.FS, path string) (*DeclarativeConfig, error) {
 	}
 	defer file.Close()
 
-	cfg, err := readYAMLOrJSON(file)
+	cfg, err := LoadReader(file)
 	if err != nil {
 		return nil, err
 	}

--- a/alpha/declcfg/load_test.go
+++ b/alpha/declcfg/load_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/operator-framework/operator-registry/alpha/property"
 )
 
-func TestReadYAMLOrJSON(t *testing.T) {
+func TestLoadReader(t *testing.T) {
 	type spec struct {
 		name              string
 		fsys              fs.FS
@@ -80,7 +80,7 @@ func TestReadYAMLOrJSON(t *testing.T) {
 			f, err := s.fsys.Open(s.path)
 			require.NoError(t, err)
 
-			cfg, err := readYAMLOrJSON(f)
+			cfg, err := LoadReader(f)
 			s.assertion(t, err)
 			if err == nil {
 				require.NotNil(t, cfg)

--- a/cmd/opm/alpha/veneer/cmd.go
+++ b/cmd/opm/alpha/veneer/cmd.go
@@ -1,6 +1,9 @@
 package veneer
 
 import (
+	"io"
+	"os"
+
 	"github.com/spf13/cobra"
 )
 
@@ -15,4 +18,12 @@ func NewCmd() *cobra.Command {
 	runCmd.AddCommand(newSemverCmd())
 
 	return runCmd
+}
+
+func openFileOrStdin(cmd *cobra.Command, args []string) (io.ReadCloser, string, error) {
+	if len(args) == 0 || args[0] == "-" {
+		return io.NopCloser(cmd.InOrStdin()), "stdin", nil
+	}
+	reader, err := os.Open(args[0])
+	return reader, args[0], err
 }

--- a/cmd/opm/alpha/veneer/semver.go
+++ b/cmd/opm/alpha/veneer/semver.go
@@ -18,19 +18,22 @@ import (
 func newSemverCmd() *cobra.Command {
 	output := ""
 	cmd := &cobra.Command{
-		Use:   "semver [FILE]",
-		Short: "Generate a file-based catalog from a single 'semver veneer' file \nWhen FILE is '-' or not provided, the veneer is read from standard input",
-		Long:  "Generate a file-based catalog from a single 'semver veneer' file \nWhen FILE is '-' or not provided, the veneer is read from standard input",
-		Args:  cobra.MaximumNArgs(1),
+		Use: "semver [FILE]",
+		Short: `Generate a file-based catalog from a single 'semver veneer' file
+When FILE is '-' or not provided, the veneer is read from standard input`,
+		Long: `Generate a file-based catalog from a single 'semver veneer' file
+When FILE is '-' or not provided, the veneer is read from standard input`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Handle different input argument types
 			// When no arguments or "-" is passed to the command,
 			// assume input is coming from stdin
 			// Otherwise open the file passed to the command
-			data, source, err := openFileOrReadStdin(cmd, args)
+			data, source, err := openFileOrStdin(cmd, args)
 			if err != nil {
 				return err
 			}
+			defer data.Close()
 
 			var write func(declcfg.DeclarativeConfig, io.Writer) error
 			switch output {
@@ -79,19 +82,4 @@ func newSemverCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&output, "output", "o", "json", "Output format (json|yaml|mermaid)")
 	return cmd
-}
-
-func openFileOrReadStdin(cmd *cobra.Command, args []string) (io.Reader, string, error) {
-	var err error = nil
-	var source string = ""
-	var reader io.Reader
-
-	if len(args) == 0 || args[0] == "-" {
-		reader = cmd.InOrStdin()
-		source = "stdin"
-	} else {
-		reader, err = os.Open(args[0])
-		source = args[0]
-	}
-	return reader, source, err
 }


### PR DESCRIPTION
Add pipe support to the render-veneer basic command and expand basic veneer validation checks.

Signed-off-by: Catherine Chan-Tse <cchantse@redhat.com>

**Description of the change:**
- Add pipe support to "opm alpha render-veneer basic"
- Expand basic veneer validation checks and fail when non-veneer bundles are passed in

**Motivation for the change:**
- Addresses OCPBUGS-1272

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
