### PR TITLE
change to log image ref value when resolving `name`

### DIFF
--- a/alpha/action/list_test.go
+++ b/alpha/action/list_test.go
@@ -28,7 +28,7 @@ foo   Foo Operator  beta
 		{
 			name:        "Error/UnknownIndex",
 			list:        ListPackages{IndexReference: "unknown-index"},
-			expectedErr: `render reference "unknown-index": error resolving name : object required`,
+			expectedErr: `render reference "unknown-index": error resolving name for image ref unknown-index: object required`,
 		},
 	}
 	for _, s := range specs {
@@ -79,7 +79,7 @@ foo      stable   foo.v0.2.0
 		{
 			name:        "Error/UnknownIndex",
 			list:        ListChannels{IndexReference: "unknown-index"},
-			expectedErr: `render reference "unknown-index": error resolving name : object required`,
+			expectedErr: `render reference "unknown-index": error resolving name for image ref unknown-index: object required`,
 		},
 		{
 			name:        "Error/UnknownPackage",
@@ -138,7 +138,7 @@ foo      stable   foo.v0.2.0  foo.v0.1.0  foo.v0.1.1,foo.v0.1.2  <0.2.0      tes
 		{
 			name:        "Error/UnknownIndex",
 			list:        ListBundles{IndexReference: "unknown-index"},
-			expectedErr: `render reference "unknown-index": error resolving name : object required`,
+			expectedErr: `render reference "unknown-index": error resolving name for image ref unknown-index: object required`,
 		},
 		{
 			name:        "Error/UnknownPackage",

--- a/pkg/image/containerdregistry/registry.go
+++ b/pkg/image/containerdregistry/registry.go
@@ -47,7 +47,7 @@ func (r *Registry) Pull(ctx context.Context, ref image.Reference) error {
 
 	name, root, err := r.resolver.Resolve(ctx, ref.String())
 	if err != nil {
-		return fmt.Errorf("error resolving name %s: %v", name, err)
+		return fmt.Errorf("error resolving name for image ref %s: %v", ref.String(), err)
 	}
 	r.log.Debugf("resolved name: %s", name)
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Updating error log when calling `Resolve` method to log `ref.String()` since if there is an error `name` will be `nil` and the logging an empty value is not helpful for troubleshooting.

**Motivation for the change:**
When running `opm add index` when `Resolve` fails, since `name` is nil the log message does not indicate which registry there is an issue with. Which leads to trying to trouble shoot is it the registry where the index resides, or the registry where the bundle exists (since in alot of cases these are different).

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
