### PR TITLE
update opm dockerfile example to cache

### DIFF
--- a/opm-example.Dockerfile
+++ b/opm-example.Dockerfile
@@ -4,10 +4,11 @@ FROM quay.io/operator-framework/opm:latest
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]
-CMD ["serve", "/configs"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
 
-# Copy declarative config root into image at /configs
+# Copy declarative config root into image at /configs and pre-populate serve cache
 ADD index /configs
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
 
 # Set DC-specific label for the location of the DC root directory
 # in the image


### PR DESCRIPTION
Signed-off-by: Jordan Keister <jordan@nimblewidget.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
add cache build/use to example dockerfile, so folks don't run afoul of large FBCs' linear load times. 

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
