### PR TITLE
WIP: composite veneer to generate multiple file-based catalog contributions

### DIFF
--- a/alpha/veneer/composite/builder.go
+++ b/alpha/veneer/composite/builder.go
@@ -1,0 +1,299 @@
+package composite
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+
+	"github.com/operator-framework/operator-registry/alpha/action"
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+	"github.com/operator-framework/operator-registry/alpha/veneer/basic"
+	"github.com/operator-framework/operator-registry/alpha/veneer/semver"
+	"github.com/operator-framework/operator-registry/pkg/image"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func CreateBuilders(bc BuildConfig, pcs []PackageConfig, imageRegistry image.Registry) ([]Builder, error) {
+	var errs []error
+
+	builderMap := map[string]*Builder{}
+	for _, ctlg := range bc.Catalogs {
+		if _, ok := builderMap[ctlg.Name]; ok {
+			errs = append(errs, fmt.Errorf("duplicate catalog build config name %q", ctlg.Name))
+			continue
+		}
+		builderMap[ctlg.Name] = &Builder{BuildConfig: ctlg}
+	}
+
+	for _, pc := range pcs {
+		for _, ctlg := range pc.Catalogs {
+			for _, bc := range ctlg.BuildConfigs {
+				builder, ok := builderMap[bc]
+				if !ok {
+					errs = append(errs, fmt.Errorf("unknown catalog build config name %q referenced in package %q config", bc, pc.packageName))
+					continue
+				}
+
+				var pb packageBuilder
+				switch ctlg.BuildStrategy.Name {
+				case BuildStrategyNameOPMBasicVeneer:
+					if ctlg.BuildStrategy.OPMBasicVeneer == nil {
+						errs = append(errs, fmt.Errorf("requested strategy %q not defined for catalog build %q in package %q", ctlg.BuildStrategy.Name, bc, pc.packageName))
+						continue
+					}
+					pb = basicVeneerBuilder{
+						OPMBasicVeneerStrategy: *ctlg.BuildStrategy.OPMBasicVeneer,
+						Registry:               imageRegistry,
+						workDir:                pc.directory,
+					}
+				case BuildStrategyNameOPMSemverVeneer:
+					if ctlg.BuildStrategy.OPMSemverVeneer == nil {
+						errs = append(errs, fmt.Errorf("requested strategy %q not defined for catalog build %q in package %q", ctlg.BuildStrategy.Name, bc, pc.packageName))
+						continue
+					}
+					pb = semverVeneerBuilder{
+						OPMSemverVeneerStrategy: *ctlg.BuildStrategy.OPMSemverVeneer,
+						Registry:                imageRegistry,
+						workDir:                 pc.directory,
+					}
+				case BuildStrategyNameCustom:
+					if ctlg.BuildStrategy.Custom == nil {
+						errs = append(errs, fmt.Errorf("requested strategy %q not defined for catalog build %q in package %q", ctlg.BuildStrategy.Name, bc, pc.packageName))
+						continue
+					}
+					pb = customBuilder{
+						CustomStrategy: *ctlg.BuildStrategy.Custom,
+						workDir:        pc.directory,
+					}
+				case BuildStrategyNameRaw:
+					if ctlg.BuildStrategy.Raw == nil {
+						errs = append(errs, fmt.Errorf("requested strategy %q not defined for catalog build %q in package %q", ctlg.BuildStrategy.Name, bc, pc.packageName))
+						continue
+					}
+					pb = rawBuilder{
+						RawStrategy: *ctlg.BuildStrategy.Raw,
+						workDir:     pc.directory,
+					}
+				default:
+					errs = append(errs, fmt.Errorf("unknown strategy %q references in catalog build %q for package %q config", ctlg.BuildStrategy.Name, bc, pc.packageName))
+					continue
+				}
+				builder.packageBuilders = append(builder.packageBuilders, pb)
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, errors.NewAggregate(errs)
+	}
+
+	builders := make([]Builder, 0, len(builderMap))
+	for _, ctlg := range bc.Catalogs {
+		builder := builderMap[ctlg.Name]
+		sort.Slice(builder.packageBuilders, func(i, j int) bool {
+			return builder.packageBuilders[i].PackageName() < builder.packageBuilders[j].PackageName()
+		})
+		builders = append(builders, *builder)
+	}
+	return builders, nil
+}
+
+type Builder struct {
+	BuildConfig     CatalogBuildConfig
+	packageBuilders []packageBuilder
+}
+
+func (b Builder) Packages() []string {
+	pkgs := sets.NewString()
+	for _, pb := range b.packageBuilders {
+		pkgs.Insert(pb.PackageName())
+	}
+	return pkgs.List()
+}
+
+func (b Builder) Build(ctx context.Context) error {
+	buildTempDir, err := os.MkdirTemp("", "fbcb-build-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(buildTempDir)
+
+	var (
+		catalogFBC  declcfg.DeclarativeConfig
+		packageFBCs []declcfg.DeclarativeConfig
+		errs        []error
+	)
+
+	for _, pb := range b.packageBuilders {
+		packageFBC, err := pb.Build(ctx)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		packageFBCs = append(packageFBCs, *packageFBC)
+
+		catalogFBC.Packages = append(catalogFBC.Packages, packageFBC.Packages...)
+		catalogFBC.Channels = append(catalogFBC.Channels, packageFBC.Channels...)
+		catalogFBC.Bundles = append(catalogFBC.Bundles, packageFBC.Bundles...)
+		catalogFBC.Others = append(catalogFBC.Others, packageFBC.Others...)
+	}
+
+	if len(errs) > 0 {
+		return errors.NewAggregate(errs)
+	}
+
+	if _, err := declcfg.ConvertToModel(catalogFBC); err != nil {
+		return err
+	}
+
+	for _, pfbc := range packageFBCs {
+		packageDir := filepath.Join(buildTempDir, pfbc.Packages[0].Name)
+		if err := os.MkdirAll(packageDir, 0777); err != nil {
+			return err
+		}
+		if err := writeFBCFile(pfbc, packageDir); err != nil {
+			return err
+		}
+	}
+
+	dockerfileDir := filepath.Dir(buildTempDir)
+	dockerfileName := filepath.Base(buildTempDir) + ".Dockerfile"
+	dockerfilePath := filepath.Join(dockerfileDir, dockerfileName)
+	dockerfile, err := os.Create(dockerfilePath)
+	if err != nil {
+		return err
+	}
+	defer dockerfile.Close()
+	defer os.RemoveAll(dockerfilePath)
+
+	gd := action.GenerateDockerfile{
+		BaseImage:   b.BuildConfig.Destination.BaseImage,
+		IndexDir:    filepath.Base(buildTempDir),
+		ExtraLabels: b.BuildConfig.Destination.ExtraLabels,
+		Writer:      dockerfile,
+	}
+	if err := gd.Run(); err != nil {
+		return err
+	}
+
+	cmdName := "docker"
+	args := []string{"build", "-t", b.BuildConfig.Destination.OutputImage, "-f", dockerfilePath, dockerfileDir}
+	cmd := exec.CommandContext(context.TODO(), cmdName, args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("run command %v: %v\n%s", append([]string{cmdName}, args...), err, string(out))
+	}
+	return nil
+}
+
+func writeFBCFile(fbc declcfg.DeclarativeConfig, packageDir string) error {
+	f, err := os.Create(filepath.Join(packageDir, "catalog.yaml"))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return declcfg.WriteYAML(fbc, f)
+}
+
+type packageBuilder interface {
+	PackageName() string
+	Build(ctx context.Context) (*declcfg.DeclarativeConfig, error)
+}
+
+var (
+	_ packageBuilder = &basicVeneerBuilder{}
+	_ packageBuilder = &semverVeneerBuilder{}
+	_ packageBuilder = &customBuilder{}
+	_ packageBuilder = &rawBuilder{}
+)
+
+type basicVeneerBuilder struct {
+	OPMBasicVeneerStrategy
+	image.Registry
+	workDir string
+}
+
+func (b basicVeneerBuilder) PackageName() string {
+	return filepath.Base(b.workDir)
+}
+
+func (b basicVeneerBuilder) Build(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
+	v := basic.Veneer{Registry: b.Registry}
+	f, err := os.Open(filepath.Join(b.workDir, b.InputFile))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return v.Render(ctx, f)
+}
+
+type semverVeneerBuilder struct {
+	OPMSemverVeneerStrategy
+	image.Registry
+	workDir string
+}
+
+func (b semverVeneerBuilder) PackageName() string {
+	return filepath.Base(b.workDir)
+}
+
+func (b semverVeneerBuilder) Build(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
+	data, err := os.ReadFile(filepath.Join(b.workDir, b.InputFile))
+	if err != nil {
+		return nil, fmt.Errorf("read input file %q: %v", b.InputFile, err)
+	}
+	v := semver.Veneer{Registry: b.Registry, Data: bytes.NewReader(data)}
+	return v.Render(ctx)
+}
+
+type customBuilder struct {
+	CustomStrategy
+	workDir string
+}
+
+func (b customBuilder) PackageName() string {
+	return filepath.Base(b.workDir)
+}
+
+func (b customBuilder) Build(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
+	var cmd *exec.Cmd
+	switch len(b.Command) {
+	case 0:
+		return nil, fmt.Errorf("command is not defined")
+	case 1:
+		cmd = exec.CommandContext(ctx, b.Command[0])
+	default:
+		cmd = exec.CommandContext(ctx, b.Command[0], b.Command[1:]...)
+	}
+	cmd.Dir = b.workDir
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("run command %v: %v\n%s", b.Command, err, string(out))
+	}
+
+	return declcfg.LoadReader(bytes.NewReader(out))
+}
+
+type rawBuilder struct {
+	RawStrategy
+	workDir string
+}
+
+func (b rawBuilder) PackageName() string {
+	return filepath.Base(b.workDir)
+}
+
+func (b rawBuilder) Build(ctx context.Context) (*declcfg.DeclarativeConfig, error) {
+	outputDir := filepath.Join(b.workDir, b.Directory)
+
+	r := action.Render{
+		AllowedRefMask: action.RefDCDir,
+		Refs:           []string{outputDir},
+	}
+	return r.Run(ctx)
+}

--- a/alpha/veneer/composite/config.go
+++ b/alpha/veneer/composite/config.go
@@ -1,0 +1,114 @@
+package composite
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"sigs.k8s.io/yaml"
+)
+
+func LoadBuildConfigFile(path string) (*BuildConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	bc := &BuildConfig{}
+	if err := yaml.Unmarshal(data, bc, func(decoder *json.Decoder) *json.Decoder {
+		decoder.DisallowUnknownFields()
+		return decoder
+	}); err != nil {
+		return nil, err
+	}
+	return bc, nil
+}
+
+type BuildConfig struct {
+	PackagesBaseDir string               `json:"packagesBaseDir"`
+	Catalogs        []CatalogBuildConfig `json:"catalogs"`
+}
+
+type CatalogBuildConfig struct {
+	Name        string             `json:"name"`
+	Destination CatalogDestination `json:"destination"`
+}
+
+type CatalogDestination struct {
+	BaseImage   string            `json:"baseImage"`
+	ExtraLabels map[string]string `json:"extraLabels"`
+	OutputImage string            `json:"outputImage"`
+}
+
+func LoadPackageConfigs(baseDir string) ([]PackageConfig, error) {
+	pkgConfigFiles, err := filepath.Glob(filepath.Join(baseDir, "*", "config.yaml"))
+	if err != nil {
+		return nil, err
+	}
+
+	pcs := make([]PackageConfig, 0, len(pkgConfigFiles))
+	for _, pkgConfigFile := range pkgConfigFiles {
+
+		pkgConfigData, err := os.ReadFile(pkgConfigFile)
+		if err != nil {
+			return nil, err
+		}
+		pc := &PackageConfig{}
+		if err := yaml.Unmarshal(pkgConfigData, pc); err != nil {
+			return nil, fmt.Errorf("parse file %q: %v", pkgConfigFile, err)
+		}
+		pc.directory = filepath.Dir(pkgConfigFile)
+		pc.packageName = filepath.Base(pc.directory)
+		for _, c := range pc.Catalogs {
+			c.packageName = pc.packageName
+		}
+		pcs = append(pcs, *pc)
+	}
+	return pcs, nil
+}
+
+type PackageConfig struct {
+	directory   string
+	packageName string
+
+	Catalogs []PackageBuildConfig `json:"catalogs"`
+}
+
+type PackageBuildConfig struct {
+	packageName string
+
+	BuildConfigs     []string              `json:"buildConfigs"`
+	WorkingDirectory string                `json:"workingDirectory"`
+	BuildStrategy    OperatorBuildStrategy `json:"buildStrategy"`
+}
+
+const (
+	BuildStrategyNameOPMBasicVeneer  = "opmBasicVeneer"
+	BuildStrategyNameOPMSemverVeneer = "opmSemverVeneer"
+	BuildStrategyNameCustom          = "custom"
+	BuildStrategyNameRaw             = "raw"
+)
+
+type OperatorBuildStrategy struct {
+	Name            string                   `json:"name"`
+	OPMBasicVeneer  *OPMBasicVeneerStrategy  `json:"opmBasicVeneer"`
+	OPMSemverVeneer *OPMSemverVeneerStrategy `json:"opmSemverVeneer"`
+	Custom          *CustomStrategy          `json:"custom"`
+	Raw             *RawStrategy             `json:"raw"`
+}
+
+type OPMBasicVeneerStrategy struct {
+	InputFile string `json:"input"`
+}
+
+type OPMSemverVeneerStrategy struct {
+	InputFile string `json:"input"`
+}
+
+type CustomStrategy struct {
+	Command []string `json:"command"`
+}
+
+type RawStrategy struct {
+	Directory string `json:"dir"`
+}

--- a/alpha/veneer/semver/semver.go
+++ b/alpha/veneer/semver/semver.go
@@ -92,7 +92,7 @@ func (v Veneer) Render(ctx context.Context) (*declcfg.DeclarativeConfig, error) 
 	buildBundleList(&sv.Fast.Bundles, &bundleDict)
 	buildBundleList(&sv.Stable.Bundles, &bundleDict)
 
-	for b, _ := range bundleDict {
+	for b := range bundleDict {
 		r := action.Render{
 			AllowedRefMask: action.RefBundleImage,
 			Refs:           []string{b},
@@ -262,7 +262,7 @@ func (sv *semverVeneer) generateChannels(semverChannels *semverRenderedChannelVe
 	// sort the channelkinds in ascending order so we can traverse the bundles in order of
 	// their source channel's priority
 	var keysByPriority []string
-	for k, _ := range channelPriorities {
+	for k := range channelPriorities {
 		keysByPriority = append(keysByPriority, k)
 	}
 	sort.Sort(byChannelPriority(keysByPriority))

--- a/cmd/opm/alpha/cmd.go
+++ b/cmd/opm/alpha/cmd.go
@@ -6,7 +6,7 @@ import (
 	"github.com/operator-framework/operator-registry/cmd/opm/alpha/bundle"
 	"github.com/operator-framework/operator-registry/cmd/opm/alpha/list"
 	rendergraph "github.com/operator-framework/operator-registry/cmd/opm/alpha/render-graph"
-	"github.com/operator-framework/operator-registry/cmd/opm/alpha/veneer"
+	renderveneer "github.com/operator-framework/operator-registry/cmd/opm/alpha/render-veneer"
 )
 
 func NewCmd() *cobra.Command {
@@ -21,7 +21,7 @@ func NewCmd() *cobra.Command {
 		bundle.NewCmd(),
 		list.NewCmd(),
 		rendergraph.NewCmd(),
-		veneer.NewCmd(),
+		renderveneer.NewCmd(),
 	)
 	return runCmd
 }

--- a/cmd/opm/alpha/render-veneer/basic.go
+++ b/cmd/opm/alpha/render-veneer/basic.go
@@ -2,7 +2,6 @@ package veneer
 
 import (
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -50,7 +49,7 @@ When FILE is '-' or not provided, the veneer is read from standard input`,
 			// The bundle loading impl is somewhat verbose, even on the happy path,
 			// so discard all logrus default logger logs. Any important failures will be
 			// returned from veneer.Render and logged as fatal errors.
-			logrus.SetOutput(ioutil.Discard)
+			logrus.SetOutput(io.Discard)
 
 			reg, err := util.CreateCLIRegistry(cmd)
 			if err != nil {

--- a/cmd/opm/alpha/render-veneer/cmd.go
+++ b/cmd/opm/alpha/render-veneer/cmd.go
@@ -16,6 +16,7 @@ func NewCmd() *cobra.Command {
 
 	runCmd.AddCommand(newBasicVeneerRenderCmd())
 	runCmd.AddCommand(newSemverCmd())
+	runCmd.AddCommand(newCompositeCmd())
 
 	return runCmd
 }

--- a/cmd/opm/alpha/render-veneer/composite.go
+++ b/cmd/opm/alpha/render-veneer/composite.go
@@ -1,0 +1,94 @@
+package veneer
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/operator-framework/operator-registry/alpha/veneer/composite"
+	"github.com/operator-framework/operator-registry/cmd/opm/internal/util"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+const def_filename = "composite.yaml"
+
+func newCompositeCmd() *cobra.Command {
+	var (
+		configFile      string
+		packagesBaseDir string
+		cacheDir        string
+	)
+	cmd := &cobra.Command{
+		Use:   "composite [-c CONFIGFILE|--cache-dir CACHEDIR]",
+		Short: "Unpack and build a composite veneer file",
+		Long: `Unpack and build a composite veneer file representing coordinated actions across a 
+cohort of contributions, according to the composite schema <foo-loc>.
+If the config file is not provided, it will be defaulted to a file 
+named "composite.yaml" in the current directory.
+If the cache dir is not provided, then the program will purge the cache upon completion.  
+To persist/reuse the cache, provide a cache-dir location.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			bc, err := composite.LoadBuildConfigFile(configFile)
+			if err != nil {
+				log.Fatalf("load build config file %q: %v", configFile, err)
+			}
+
+			configFileDir := filepath.Dir(configFile)
+			pcs, err := composite.LoadPackageConfigs(filepath.Join(configFileDir, bc.PackagesBaseDir))
+			if err != nil {
+				log.Fatalf("load package configs from base directory %q: %v", packagesBaseDir, err)
+			}
+
+			destroyCache := cacheDir == ""
+			if destroyCache {
+				cacheDir, err = os.MkdirTemp("", "composite-image-cache-")
+				if err != nil {
+					log.Fatalf("create temporary image cache directory: %v", err)
+				}
+			}
+
+			logrus.SetOutput(io.Discard)
+
+			reg, err := util.CreateCLIRegistry(cmd)
+			if err != nil {
+				log.Fatalf("creating containerd registry: %v", err)
+			}
+
+			if destroyCache {
+				defer reg.Destroy()
+			}
+
+			builders, err := composite.CreateBuilders(*bc, pcs, reg)
+			if err != nil {
+				log.Fatalf("create builders for each catalog and package: %v", err)
+			}
+
+			for _, b := range builders {
+				if err := b.Build(cmd.Context()); err != nil {
+					log.Fatal(err)
+				}
+			}
+
+			fmt.Println("\n\nSUMMARY:")
+			for _, b := range builders {
+				fmt.Printf("  Built catalog image %q with packages:\n", b.BuildConfig.Destination.OutputImage)
+				for _, pkg := range b.Packages() {
+					fmt.Printf("    %s\n", pkg)
+				}
+				fmt.Printf("\n")
+			}
+		},
+	}
+	cmd.Flags().StringVarP(&configFile, "config", "c", def_filename, "Path to composite config file.")
+	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "Path of persistent image cache directory.")
+
+	// ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	// defer cancel()
+	// if err := cmd.ExecuteContext(ctx); err != nil {
+	// 	log.Fatal(err)
+	// }
+	return cmd
+}

--- a/cmd/opm/alpha/render-veneer/semver.go
+++ b/cmd/opm/alpha/render-veneer/semver.go
@@ -3,7 +3,6 @@ package veneer
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -53,7 +52,7 @@ When FILE is '-' or not provided, the veneer is read from standard input`,
 			// The bundle loading impl is somewhat verbose, even on the happy path,
 			// so discard all logrus default logger logs. Any important failures will be
 			// returned from veneer.Render and logged as fatal errors.
-			logrus.SetOutput(ioutil.Discard)
+			logrus.SetOutput(io.Discard)
 
 			reg, err := util.CreateCLIRegistry(cmd)
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: Jordan Keister <jordan@nimblewidget.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
An approach to orchestrating multiple input veneer types (including custom) across multiple release actions with corresponding build approaches and toolchain designation for each. 
Starting out, this is an adoption of the process/spec expressed in https://github.com/joelanford/fbcb

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
