### PR TITLE
left-right swap mermaid edge vertices from render-graph

### DIFF
--- a/alpha/declcfg/write.go
+++ b/alpha/declcfg/write.go
@@ -124,12 +124,12 @@ func (writer *MermaidWriter) WriteChannels(cfg DeclarativeConfig, out io.Writer)
 
 					if len(ce.Replaces) > 0 {
 						replacesId := fmt.Sprintf("%s-%s", channelID, ce.Replaces)
-						pkgBuilder.WriteString(fmt.Sprintf("      %s[%q]-- %s --> %s[%q]\n", entryId, ce.Name, "replaces", replacesId, ce.Replaces))
+						pkgBuilder.WriteString(fmt.Sprintf("      %s[%q]-- %s --> %s[%q]\n", replacesId, ce.Replaces, "replace", entryId, ce.Name))
 					}
 					if len(ce.Skips) > 0 {
 						for _, s := range ce.Skips {
 							skipsId := fmt.Sprintf("%s-%s", channelID, s)
-							pkgBuilder.WriteString(fmt.Sprintf("      %s[%q]-- %s --> %s[%q]\n", entryId, ce.Name, "skips", skipsId, s))
+							pkgBuilder.WriteString(fmt.Sprintf("      %s[%q]-- %s --> %s[%q]\n", skipsId, s, "skip", entryId, ce.Name))
 						}
 					}
 					if len(ce.SkipRange) > 0 {
@@ -138,7 +138,7 @@ func (writer *MermaidWriter) WriteChannels(cfg DeclarativeConfig, out io.Writer)
 							for _, edgeName := range filteredChannel.Entries {
 								if skipRange(versionMap[edgeName.Name]) {
 									skipRangeId := fmt.Sprintf("%s-%s", channelID, edgeName.Name)
-									pkgBuilder.WriteString(fmt.Sprintf("      %s[%q]-- \"%s(%s)\" --> %s[%q]\n", entryId, ce.Name, "skipRange", ce.SkipRange, skipRangeId, edgeName.Name))
+									pkgBuilder.WriteString(fmt.Sprintf("      %s[%q]-- \"%s(%s)\" --> %s[%q]\n", skipRangeId, edgeName.Name, "skipRange", ce.SkipRange, entryId, ce.Name))
 								}
 							}
 						} else {

--- a/alpha/declcfg/write_test.go
+++ b/alpha/declcfg/write_test.go
@@ -491,16 +491,16 @@ func TestWriteMermaidChannels(t *testing.T) {
     subgraph anakin-dark["dark"]
       anakin-dark-anakin.v0.0.1["anakin.v0.0.1"]
       anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]
-      anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]-- replaces --> anakin-dark-anakin.v0.0.1["anakin.v0.0.1"]
+      anakin-dark-anakin.v0.0.1["anakin.v0.0.1"]-- replace --> anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]
       anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]
-      anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]-- replaces --> anakin-dark-anakin.v0.0.1["anakin.v0.0.1"]
-      anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]-- skips --> anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]
+      anakin-dark-anakin.v0.0.1["anakin.v0.0.1"]-- replace --> anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]
+      anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]-- skip --> anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]
     end
     %% channel "light"
     subgraph anakin-light["light"]
       anakin-light-anakin.v0.0.1["anakin.v0.0.1"]
       anakin-light-anakin.v0.1.0["anakin.v0.1.0"]
-      anakin-light-anakin.v0.1.0["anakin.v0.1.0"]-- replaces --> anakin-light-anakin.v0.0.1["anakin.v0.0.1"]
+      anakin-light-anakin.v0.0.1["anakin.v0.0.1"]-- replace --> anakin-light-anakin.v0.1.0["anakin.v0.1.0"]
     end
   end
   %% package "boba-fett"
@@ -509,7 +509,7 @@ func TestWriteMermaidChannels(t *testing.T) {
     subgraph boba-fett-mando["mando"]
       boba-fett-mando-boba-fett.v1.0.0["boba-fett.v1.0.0"]
       boba-fett-mando-boba-fett.v2.0.0["boba-fett.v2.0.0"]
-      boba-fett-mando-boba-fett.v2.0.0["boba-fett.v2.0.0"]-- replaces --> boba-fett-mando-boba-fett.v1.0.0["boba-fett.v1.0.0"]
+      boba-fett-mando-boba-fett.v1.0.0["boba-fett.v1.0.0"]-- replace --> boba-fett-mando-boba-fett.v2.0.0["boba-fett.v2.0.0"]
     end
   end
 `,
@@ -526,7 +526,7 @@ func TestWriteMermaidChannels(t *testing.T) {
     subgraph anakin-dark["dark"]
       anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]
       anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]
-      anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]-- skips --> anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]
+      anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]-- skip --> anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]
     end
     %% channel "light"
     subgraph anakin-light["light"]
@@ -547,7 +547,7 @@ func TestWriteMermaidChannels(t *testing.T) {
     subgraph boba-fett-mando["mando"]
       boba-fett-mando-boba-fett.v1.0.0["boba-fett.v1.0.0"]
       boba-fett-mando-boba-fett.v2.0.0["boba-fett.v2.0.0"]
-      boba-fett-mando-boba-fett.v2.0.0["boba-fett.v2.0.0"]-- replaces --> boba-fett-mando-boba-fett.v1.0.0["boba-fett.v1.0.0"]
+      boba-fett-mando-boba-fett.v1.0.0["boba-fett.v1.0.0"]-- replace --> boba-fett-mando-boba-fett.v2.0.0["boba-fett.v2.0.0"]
     end
   end
 `,


### PR DESCRIPTION
Signed-off-by: Jordan Keister <jordan@nimblewidget.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Folks expressed some confusion that because the upgrade graph edges are always in the form  "greater [replaces|skips] lesser" led to a right-to-left interpretation.  
This PR reverses the ordering and replaces the verb with a role designation (e.g. "replace" instead of "replaces", etc.) in order to read left-to-right. 

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
