### PR TITLE
fix: don't panic when closing registry querier

### DIFF
--- a/cmd/opm/serve/serve.go
+++ b/cmd/opm/serve/serve.go
@@ -103,10 +103,10 @@ func (s *serve) run(ctx context.Context) error {
 	s.logger = s.logger.WithFields(logrus.Fields{"configs": s.configDir, "port": s.port})
 
 	store, err := registry.NewQuerierFromFS(os.DirFS(s.configDir), s.cacheDir)
-	defer store.Close()
 	if err != nil {
 		return err
 	}
+	defer store.Close()
 	if s.cacheOnly {
 		return nil
 	}


### PR DESCRIPTION


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

This commit refactors the `registry.Querier` load behavior such that:
1. If any error occurs creating a `Querier`, any necessary cleanup happens and a nil `Querier` is returned.
2. `Querier.Close` checks for a nil cache before attempting a close of the `Querier`'s underlying cache.

**Motivation for the change:**

When [certain errors](https://github.com/operator-framework/operator-registry/blob/249ae621bb8fa6fc8a8e4a5ae26355577393f127/pkg/registry/query.go#L414-L416) occur loading a `registry.Querier`, it is possible for a `Querier` to be returned with a nil cache. This causes a panic when `Close` is later called on the `Querier`.

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage 
- [x] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
