### PR TITLE
opm migrate: add help text note about concatenated json format

### DIFF
--- a/cmd/opm/migrate/cmd.go
+++ b/cmd/opm/migrate/cmd.go
@@ -21,6 +21,10 @@ func NewCmd() *cobra.Command {
 		Short: "Migrate a sqlite-based index image or database file to a file-based catalog",
 		Long: `Migrate a sqlite-based index image or database file to a file-based catalog.
 
+NOTE: the --output=json format produces streamable, concatenated JSON files.
+These are suitable to opm and jq, but may not be supported by arbitrary JSON
+parsers that assume that a file contains exactly one valid JSON object.
+
 ` + sqlite.DeprecationMessage,
 		Args: cobra.ExactArgs(2),
 		PersistentPreRun: func(_ *cobra.Command, _ []string) {


### PR DESCRIPTION
Signed-off-by: Joe Lanford <joe.lanford@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Update `opm migrate` help text to explain that json output format produces concatenated JSON

**Motivation for the change:**
Concatenated JSON may come as a surprise to users, because not all tools/libraries support it.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
