### PR TITLE
opm render: update help text to mention that output is a stream to stdout

### DIFF
--- a/cmd/opm/render/cmd.go
+++ b/cmd/opm/render/cmd.go
@@ -22,8 +22,10 @@ func NewCmd() *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "render [index-image | bundle-image | sqlite-file]...",
-		Short: "Generate a declarative config blob from catalogs and bundles",
-		Long: `Generate a declarative config blob from the provided index images, bundle images, and sqlite database files
+		Short: "Generate a stream of file-based catalog objects from catalogs and bundles",
+		Long: `Generate a stream of file-based catalog objects to stdout from the provided
+catalog images, file-based catalog directories, bundle images, and sqlite
+database files.
 
 ` + sqlite.DeprecationMessage,
 		Args: cobra.MinimumNArgs(1),
@@ -63,7 +65,7 @@ func NewCmd() *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().StringVarP(&output, "output", "o", "json", "Output format (json|yaml)")
+	cmd.Flags().StringVarP(&output, "output", "o", "json", "Output format of the streamed file-based catalog objects (json|yaml)")
 	return cmd
 }
 


### PR DESCRIPTION

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Update `opm render` help text:
1. Use file-based catalog terminology instead of "declarative configs"
2. Include the fact that the output is a stream of objects to stdout, not a single object.

**Motivation for the change:**
General documentation maintenance and to help clarify the format of data that is produced (its a stream of documents, not one document).

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
