### PR TITLE
use mount flag to force consistent selinux labelling between host/guest on generated files

### DIFF
--- a/alpha/veneer/composite/builder.go
+++ b/alpha/veneer/composite/builder.go
@@ -82,7 +82,7 @@ func (bb *BasicBuilder) Build(dir string, vd VeneerDefinition) error {
 		"run",
 		"--rm",
 		"-v",
-		fmt.Sprintf("%s:%s", bb.builderCfg.CurrentDirectory, bb.builderCfg.ContainerCfg.WorkingDir),
+		fmt.Sprintf("%s:%s:Z", bb.builderCfg.CurrentDirectory, bb.builderCfg.ContainerCfg.WorkingDir),
 		bb.builderCfg.ContainerCfg.BaseImage,
 		"alpha",
 		"render-veneer",
@@ -141,7 +141,7 @@ func (sb *SemverBuilder) Build(dir string, vd VeneerDefinition) error {
 		"run",
 		"--rm",
 		"-v",
-		fmt.Sprintf("%s:%s", sb.builderCfg.CurrentDirectory, sb.builderCfg.ContainerCfg.WorkingDir),
+		fmt.Sprintf("%s:%s:Z", sb.builderCfg.CurrentDirectory, sb.builderCfg.ContainerCfg.WorkingDir),
 		sb.builderCfg.ContainerCfg.BaseImage,
 		"alpha",
 		"render-veneer",
@@ -200,7 +200,7 @@ func (rb *RawBuilder) Build(dir string, vd VeneerDefinition) error {
 		"run",
 		"--rm",
 		"-v",
-		fmt.Sprintf("%s:%s", rb.builderCfg.CurrentDirectory, rb.builderCfg.ContainerCfg.WorkingDir),
+		fmt.Sprintf("%s:%s:Z", rb.builderCfg.CurrentDirectory, rb.builderCfg.ContainerCfg.WorkingDir),
 		"--entrypoint=cat", // This assumes that the `cat` command is available in the container -- Should we also build a `... render-veneer raw` command to ensure consistent operation? Does OPM already have a way to render a raw FBC?
 		rb.builderCfg.ContainerCfg.BaseImage,
 		path.Join(rb.builderCfg.ContainerCfg.WorkingDir, rawConfig.Input))
@@ -281,7 +281,7 @@ func validate(containerCfg ContainerConfig, dir string) error {
 		"run",
 		"--rm",
 		"-v",
-		fmt.Sprintf("%s:%s", dir, containerCfg.WorkingDir),
+		fmt.Sprintf("%s:%s:Z", dir, containerCfg.WorkingDir),
 		containerCfg.BaseImage,
 		"validate",
 		containerCfg.WorkingDir)


### PR DESCRIPTION
Signed-off-by: Jordan <jordan@nimblewidget.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**
without this flag, there is inconsistent labeling between intermediate composite template products on the host and the container which will (read-only) access them. 
When selinux is in enforcing mode, these steps will fail to execute. 
For more info, https://projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
