### PR TITLE
OPECO-2646: exclude bundles with `olm.deprecated` property when rendering

### DIFF
--- a/pkg/sqlite/conversion.go
+++ b/pkg/sqlite/conversion.go
@@ -76,7 +76,19 @@ func populateModelChannels(ctx context.Context, pkgs model.Model, q *SQLQuerier)
 	if err != nil {
 		return err
 	}
+	deprecatedValue, err := json.Marshal(registry.DeprecatedProperty{})
+	if err != nil {
+		return err
+	}
+ConvertBundles:
 	for _, bundle := range bundles {
+		for _, prop := range bundle.Properties {
+			if prop.Type == registry.DeprecatedType && prop.Value == string(deprecatedValue) {
+				// bundle contains `olm.Deprecated` property
+				// exclude this bundle from being rendered
+				continue ConvertBundles
+			}
+		}
 		pkg, ok := pkgs[bundle.PackageName]
 		if !ok {
 			return fmt.Errorf("unknown package %q for bundle %q", bundle.PackageName, bundle.CsvName)

--- a/pkg/sqlite/conversion.go
+++ b/pkg/sqlite/conversion.go
@@ -76,14 +76,11 @@ func populateModelChannels(ctx context.Context, pkgs model.Model, q *SQLQuerier)
 	if err != nil {
 		return err
 	}
-	deprecatedValue, err := json.Marshal(registry.DeprecatedProperty{})
-	if err != nil {
-		return err
-	}
+
 ConvertBundles:
 	for _, bundle := range bundles {
 		for _, prop := range bundle.Properties {
-			if prop.Type == registry.DeprecatedType && prop.Value == string(deprecatedValue) {
+			if prop.Type == registry.DeprecatedType {
 				// bundle contains `olm.Deprecated` property
 				// exclude this bundle from being rendered
 				continue ConvertBundles


### PR DESCRIPTION
**Description of the change:**

- Previous bundle deprecation was handled by assigning a property to the olm.bundle object of `olm.deprecated`.  SQLite DBs had to have all valid upgrade edges supported by olm.bundle information in order to prevent foreign key violations.  This property meant that the bundle was to be ignored & never installed. FBC has a simpler method for achieving the same goal which is to not include the bundle.  Upgrade edges from it may still be specified, and the bundle will not be installable.

**Motivation for the change:**

- Excluding bundles with the `olm.deprecated` property when rendering as this property isn't relevant for FBC, so bundles containing this property should be omitted from the catalog rendered by opm.
