### PR TITLE
removing channel property as a remnant of oc mirror diff migration

### DIFF
--- a/alpha/property/property.go
+++ b/alpha/property/property.go
@@ -39,16 +39,6 @@ type Package struct {
 	Version     string `json:"version"`
 }
 
-// NOTICE: The Channel properties are for internal use only.
-//
-//	DO NOT use it for any public-facing functionalities.
-//	This API is in alpha stage and it is subject to change.
-type Channel struct {
-	ChannelName string `json:"channelName"`
-	//Priority    string `json:"priority"`
-	Priority int `json:"priority"`
-}
-
 type PackageRequired struct {
 	PackageName  string `json:"packageName"`
 	VersionRange string `json:"versionRange"`
@@ -128,7 +118,6 @@ type Properties struct {
 	GVKs             []GVK             `hash:"set"`
 	GVKsRequired     []GVKRequired     `hash:"set"`
 	BundleObjects    []BundleObject    `hash:"set"`
-	Channels         []Channel         `hash:"set"`
 
 	Others []Property `hash:"set"`
 }
@@ -176,15 +165,6 @@ func Parse(in []Property) (*Properties, error) {
 				return nil, ParseError{Idx: i, Typ: prop.Type, Err: err}
 			}
 			out.BundleObjects = append(out.BundleObjects, p)
-		// NOTICE: The Channel properties are for internal use only.
-		//   DO NOT use it for any public-facing functionalities.
-		//   This API is in alpha stage and it is subject to change.
-		case TypeChannel:
-			var p Channel
-			if err := json.Unmarshal(prop.Value, &p); err != nil {
-				return nil, ParseError{Idx: i, Typ: prop.Type, Err: err}
-			}
-			out.Channels = append(out.Channels, p)
 		default:
 			var p json.RawMessage
 			if err := json.Unmarshal(prop.Value, &p); err != nil {
@@ -285,12 +265,4 @@ func MustBuildBundleObjectRef(ref string) Property {
 }
 func MustBuildBundleObjectData(data []byte) Property {
 	return MustBuild(&BundleObject{File: File{data: data}})
-}
-
-// NOTICE: The Channel properties are for internal use only.
-//
-//	DO NOT use it for any public-facing functionalities.
-//	This API is in alpha stage and it is subject to change.
-func MustBuildChannelPriority(name string, priority int) Property {
-	return MustBuild(&Channel{ChannelName: name, Priority: priority})
 }

--- a/alpha/property/scheme.go
+++ b/alpha/property/scheme.go
@@ -12,10 +12,6 @@ func init() {
 		reflect.TypeOf(&GVK{}):             TypeGVK,
 		reflect.TypeOf(&GVKRequired{}):     TypeGVKRequired,
 		reflect.TypeOf(&BundleObject{}):    TypeBundleObject,
-		// NOTICE: The Channel properties are for internal use only.
-		//   DO NOT use it for any public-facing functionalities.
-		//   This API is in alpha stage and it is subject to change.
-		reflect.TypeOf(&Channel{}): TypeChannel,
 	}
 }
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**
removing remnants left behind when oc mirror migrated the alpha diff capabilities to it

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
