### PR TITLE
comment out CatalogDestination.BaseImage while we mature the concept

### DIFF
--- a/alpha/template/composite/composite.go
+++ b/alpha/template/composite/composite.go
@@ -215,9 +215,9 @@ func (t *Template) newCatalogBuilderMap(catalogs []Catalog, outputType string) (
 	setupErrors := map[string][]string{}
 	for _, catalog := range catalogs {
 		errs := []string{}
-		if catalog.Destination.BaseImage == "" {
-			errs = append(errs, "destination.baseImage must not be an empty string")
-		}
+		// if catalog.Destination.BaseImage == "" {
+		// 	errs = append(errs, "destination.baseImage must not be an empty string")
+		// }
 
 		if catalog.Destination.WorkingDir == "" {
 			errs = append(errs, "destination.workingDir must not be an empty string")

--- a/alpha/template/composite/composite_test.go
+++ b/alpha/template/composite/composite_test.go
@@ -42,7 +42,6 @@ schema: olm.composite.catalogs
 catalogs:
   - name: first-catalog
     destination:
-      baseImage: quay.io/operator-framework/opm:latest
       workingDir: contributions/first-catalog
     builders:
       - olm.builder.test
@@ -298,20 +297,17 @@ schema: olm.composite.catalogs
 catalogs:
   - name: first-catalog
     destination:
-      baseImage: quay.io/operator-framework/opm:latest
       workingDir: contributions/first-catalog
     builders:
       - olm.builder.semver
       - olm.builder.basic
   - name: second-catalog
     destination:
-      baseImage: quay.io/operator-framework/opm:latest
       workingDir: contributions/second-catalog
     builders:
       - olm.builder.semver
   - name: test-catalog
     destination:
-      baseImage: quay.io/operator-framework/opm:latest
       workingDir: contributions/test-catalog
     builders:
       - olm.builder.custom`
@@ -325,7 +321,6 @@ schema: invalid
 catalogs:
   - name: first-catalog
     destination:
-      baseImage: quay.io/operator-framework/opm:latest
       workingDir: contributions/first-catalog
     builders:
       - olm.builder.semver
@@ -494,22 +489,22 @@ func TestNewCatalogBuilderMap(t *testing.T) {
 				require.Equal(t, "getting builder \"invalid\" for catalog \"test-catalog\": unknown schema \"invalid\"", err.Error())
 			},
 		},
-		{
-			name: "BaseImage+WorkingDir invalid",
-			catalogs: []Catalog{
-				{
-					Name:        "test-catalog",
-					Destination: CatalogDestination{},
-					Builders: []string{
-						BasicBuilderSchema,
-					},
-				},
-			},
-			assertions: func(t *testing.T, builderMap *CatalogBuilderMap, err error) {
-				require.Error(t, err)
-				require.Equal(t, "catalog configuration file field validation failed: \nCatalog test-catalog:\n  - destination.baseImage must not be an empty string\n  - destination.workingDir must not be an empty string\n", err.Error())
-			},
-		},
+		// {
+		// 	name: "BaseImage+WorkingDir invalid",
+		// 	catalogs: []Catalog{
+		// 		{
+		// 			Name:        "test-catalog",
+		// 			Destination: CatalogDestination{},
+		// 			Builders: []string{
+		// 				BasicBuilderSchema,
+		// 			},
+		// 		},
+		// 	},
+		// 	assertions: func(t *testing.T, builderMap *CatalogBuilderMap, err error) {
+		// 		require.Error(t, err)
+		// 		require.Equal(t, "catalog configuration file field validation failed: \nCatalog test-catalog:\n  - destination.baseImage must not be an empty string\n  - destination.workingDir must not be an empty string\n", err.Error())
+		// 	},
+		// },
 	}
 
 	for _, tc := range testCases {

--- a/alpha/template/composite/composite_test.go
+++ b/alpha/template/composite/composite_test.go
@@ -463,7 +463,7 @@ func TestNewCatalogBuilderMap(t *testing.T) {
 					Name: "test-catalog",
 					Destination: CatalogDestination{
 						WorkingDir: "/",
-						BaseImage:  "base",
+						// BaseImage:  "base",
 					},
 					Builders: []string{
 						BasicBuilderSchema,
@@ -482,7 +482,7 @@ func TestNewCatalogBuilderMap(t *testing.T) {
 					Name: "test-catalog",
 					Destination: CatalogDestination{
 						WorkingDir: "/",
-						BaseImage:  "base",
+						// BaseImage:  "base",
 					},
 					Builders: []string{
 						"invalid",

--- a/alpha/template/composite/config.go
+++ b/alpha/template/composite/config.go
@@ -37,6 +37,6 @@ type Catalog struct {
 }
 
 type CatalogDestination struct {
-	BaseImage  string
+	// BaseImage  string
 	WorkingDir string
 }


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
comment out reliance on BaseImage

**Motivation for the change:**
The original concept os the BaseImage was intended to use the same version of opm for build/verify/serve, but the initial implementation had to be reverted.  While we mature that concept separately, we thought it seemed like a good idea to remove reliance on it (but neglected to in a previous PR). 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
