### PR TITLE
 Avoid opening the termination log as executable

### DIFF
--- a/pkg/lib/log/writerhook.go
+++ b/pkg/lib/log/writerhook.go
@@ -44,7 +44,7 @@ func AddHooks(hooks ...*WriterHook) {
 }
 
 func AddDefaultWriterHooks(terminationLogPath string) error {
-	terminationLogFile, err := os.OpenFile(terminationLogPath, os.O_WRONLY|os.O_CREATE, 0755)
+	terminationLogFile, err := os.OpenFile(terminationLogPath, os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

`terminationLogFile` is unnecessarily opened with all executable bits set.  
This PR removes the executable bits.


**Motivation for the change:**
Creating executable log files may have undesirable consequences.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
