### PR TITLE
(plain bundle usage) Documentation on how to add a plain bundle image to a file-based catalog

### DIFF
--- a/docs/design/bundle-sources.md
+++ b/docs/design/bundle-sources.md
@@ -2,7 +2,7 @@
 
 > **Warning:** Operator Lifecycle Manager (OLM) v1 features and components are still experimental. Early adopters and contributors should expect breaking changes. The following procedures are not recommended for use on production clusters.
 
-You can build a static collection of arbitrary Kubernetes manifests in the YAML format, or *plain bundle*, and add the image to a file-based catalog (FBC). The experimental `olm.bundle.mediatype` property of the `olm.bundle` schema object differentiates a plain bundle from a regular bundle. You must set the bundle media type property to `plain+v0` to specify a plain bundle.
+You can build a static collection of arbitrary Kubernetes manifests in the YAML format, or *plain bundle*, and add the image to a file-based catalog (FBC). The experimental `olm.bundle.mediatype` property of the `olm.bundle` schema object differentiates a plain bundle from a regular (`registry+v1`) bundle. You must set the bundle media type property to `plain+v0` to specify a plain bundle.
 
 For more information, see the [Plain Bundle Specification](https://github.com/operator-framework/rukpak/blob/main/docs/bundles/plain.md) in the RukPak repository.
 
@@ -72,9 +72,9 @@ Procedure
     ```sh
     LABEL operators.operatorframework.io.bundle.mediatype.v1=plain+v0
     LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
-    LABEL operators.operatorframework.io.bundle.package.v1=<operatorName>
+    LABEL operators.operatorframework.io.bundle.package.v1=<operator_name>
     LABEL operators.operatorframework.io.bundle.channels.v1=<channels>
-    LABEL operators.operatorframework.io.bundle.channel.default.v1=<defaultChannel>
+    LABEL operators.operatorframework.io.bundle.channel.default.v1=<default_channel>
     ```
 
 1. Build an OCI-compliant image using your preferred build tool, similar to the following example. You must use an image tag that references a repository where you have push access privileges.

--- a/docs/design/bundle-sources.md
+++ b/docs/design/bundle-sources.md
@@ -110,10 +110,10 @@ Procedure
     mkdir <catalog_dir>
     ```
 
-1. Create a Dockerfile that can build a catalog image by running the `opm generate dockerfile` command:
+1. In the same directory level, create a Dockerfile that can build a catalog image:
 
-    ```sh
-    opm generate dockerfile <catalog_dir>
+     ```sh
+    touch Dockerfile
     ```
 
     * The Dockerfile must be in the same parent directory as the catalog directory that you created in the previous step:
@@ -124,6 +124,17 @@ Procedure
         ├── <catalog_dir>
         └── <catalog_dir>.Dockerfile
         ```
+
+1. Make the below changes to your Dockerfile:
+  
+    *Example Dockerfile*
+
+    ```sh
+        FROM scratch
+        ADD <catalog_dir> /configs
+    ```
+
+    > **Note:** Use the `FROM scratch` directive to make the size of the image smaller. 
 
 1. Populate the catalog with the package definition for your Operator by running the `opm init` command:
 
@@ -173,7 +184,7 @@ Procedure
     ```json
     {
         "schema": "olm.bundle",
-        "name": "<operator_name>.<version>",
+        "name": "<operator_name>.v<version>",
         "package": "<operator_name>",
         "image": "quay.io/<organization_name>/<repository_name>:<image_tag>", 
         "properties": [
@@ -199,15 +210,17 @@ Procedure
     ```json
     {
         "schema": "olm.channel",
-        "name": "<default_channel_name>",
+        "name": "<desired_channel_name>",
         "package": "<operator_name>",
         "entries": [
             {
-                "name": "<operator_name>/<bundle_version>"
+                "name": "<operator_name>.v<version>"
             }
         ]
     }
     ```
+
+    > **Note:** Some examples for the <desired_channel_name> include `stable`, `fast`, and `preview`.
 
 <h3 id="verify-adding-a-plain-bundle-to-fbc">
 Verification

--- a/docs/design/bundle-sources.md
+++ b/docs/design/bundle-sources.md
@@ -42,7 +42,7 @@ Procedure
     └── deployment.yaml
     ```
 
-    * If you are using [kustomize](https://kustomize.io) to build your manifests from templates, you must redirect the output into a single file under the `manifests/` directory by running the following command:
+    * If you are using [kustomize](https://kustomize.io) to build your manifests from templates, you must redirect the output to one or more files under the `manifests/` directory. For example:
 
         ```sh
         kustomize build templates > manifests/manifests.yaml
@@ -62,10 +62,10 @@ Procedure
 
     ```sh
         FROM scratch
-        ADD catalog /configs
+        ADD manifests /manifests
     ```
 
-    > **Note:** Use the `FROM scratch` directive to make the size of the image smaller.
+    > **Note:** Use the `FROM scratch` directive to make the size of the image smaller. No other files or directories are required in the bundle image.
 
 1. Build an OCI-compliant image using your preferred build tool, similar to the following example. You must use an image tag that references a repository where you have push access privileges.
 

--- a/docs/design/bundle-sources.md
+++ b/docs/design/bundle-sources.md
@@ -1,0 +1,240 @@
+# Building a file-based catalog from a plain bundle image
+
+**IMPORTANT:** Operator Lifecycle Manager (OLM) v1 features and components are still experimental. Early adopters and contributors should expect breaking changes. The following procedures are not recommended for use on production clusters.
+
+You can build a static collection of arbitrary Kubernetes manifests in the YAML format, or *plain bundle*, and add the image to a file-based catalog (FBC). The experimental `olm.bundle.mediatype` property of the `olm.bundle` schema object differentiates a plain bundle from a regular bundle. You must set the bundle media type property to `plain+v0` to specify a plain bundle.
+
+For more information, see the [Plain Bundle Specification](https://github.com/operator-framework/rukpak/blob/main/docs/bundles/plain.md) in the RukPak repository.
+
+To build a file-based catalog from a plain bundle image, you must complete the following steps:
+
+* Create a plain bundle image
+* Create a file-based catalog
+* Add the plain bundle image to your file-based catalog
+* Build your catalog as an image
+* Publish your catalog image
+
+## Building a plain bundle image from an image source
+
+Currently, the Operator Controller only supports building a plain bundle image from an image source.
+
+*Prerequisites*
+
+* [`opm` CLI tool](https://github.com/operator-framework/operator-registry/releases)
+* Docker or Podman
+* Push access to an image registry, such as [Quay](https://quay.io)
+
+*Procedure*
+
+1. Verify that your Kubernetes manifests are in a flat directory at the root of your project similar to the following example:
+
+    ```sh
+    tree manifests
+    manifests
+    ├── namespace.yaml
+    ├── service_account.yaml
+    ├── cluster_role.yaml
+    ├── cluster_role_binding.yaml
+    └── deployment.yaml
+    ```
+
+    * If you are using [kustomize](https://kustomize.io) to build your manifests from templates, you must redirect the output into a single file under the `manifests/` directory by running the following command:
+
+        ```sh
+        kustomize build templates > manifests/manifests.yaml
+        ```
+
+   For more information, see [Building a plain bundle > Prerequisites](https://github.com/operator-framework/rukpak/blob/main/docs/bundles/plain.md#prerequisites).
+
+1. Create a Dockerfile at the root of your project:
+
+    ```sh
+    touch Dockerfile.plainbundle
+    ```
+
+1. Make the following changes to your Dockerfile:
+
+    *Example Dockerfile*
+
+    ```sh
+    FROM scratch
+    COPY manifests /manifests
+    ```
+
+    **NOTE:** Use the `FROM scratch` directive to make the size of the image smaller.
+
+1. Add the following labels to your Dockerfile:
+
+    ```sh
+    LABEL operators.operatorframework.io.bundle.mediatype.v1=plain+v0
+    LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+    LABEL operators.operatorframework.io.bundle.package.v1=testOperator
+    LABEL operators.operatorframework.io.bundle.channels.v1=preview
+    LABEL operators.operatorframework.io.bundle.channel.default.v1=preview
+    ```
+
+1. Build an OCI-compliant image using your preferred build tool, similar to the following example. You must use an image tag that references a repository where you have push access privileges.
+
+    *Example build command*
+
+    ```sh
+    docker build -f Dockerfile.plainbundle -t \
+    quay.io/<image_repo>/plainbundle:example .
+    ```
+
+1. Push the image to your remote registry:
+
+    ```sh
+    docker push quay.io/<image_repo>/plainbundle:example
+    ```
+
+*Additional resources*
+
+* [File-based catalog bundle schema](https://github.com/operator-framework/olm-docs/blob/master/content/en/docs/Reference/file-based-catalogs.md)
+* [OCI image specification](https://github.com/opencontainers/image-spec#oci-image-format-specification)
+* [RukPak > Building a plain bundle > Image source](https://github.com/operator-framework/rukpak/blob/main/docs/bundles/plain.md#image-source)
+* [RukPak > Sources > Images > Private image registries](https://github.com/operator-framework/rukpak/blob/main/docs/sources/image.md#private-image-registries)
+
+## Creating a file-based catalog
+
+If you do not have a file-based catalog, you must perform the following steps to initialize the catalog.
+
+*Prerequisites*
+
+* `opm` CLI tool
+* Docker or Podman
+
+*Procedure*
+
+1. Create a directory for the catalog by running the following command:
+
+    ```sh
+    mkdir <catalog_dir>
+    ```
+
+1. Create a Dockerfile that can build a catalog image by running the `opm generate dockerfile` command:
+
+    *Example `<catalog_name>-image.Dockerfile`*
+
+    ```sh
+    opm generate dockerfile <catalog_dir>
+    ```
+
+    *TIP:* If do not want to use the default upstream base image, you can specify a different image using the `-i` flag.
+
+    * The Dockerfile must be in the same parent directory as the catalog directory that you created in the previous step:
+        *Example directory structure*
+
+        ```sh
+        .
+        ├── <catalog_dir>
+        └── <catalog_dir>.Dockerfile
+        ```
+
+1. Populate the catalog with the package definition for your Operator by running the `opm init` command:
+
+    ```sh
+    opm init <operator_name> \
+    --default-channel=preview \
+    --description=./README.md \
+    --icon=./operator-icon.svg \
+    --output yaml \
+    > <catalog_dir>/index.yaml
+    ```
+
+    This command generates an `olm.package` declarative config blob in the specified catalog configuration file.
+
+## Adding a plain bundle to your file-based catalog
+
+Currently, the `opm render` command does not support adding plain bundles to catalogs. You must manually add plain bundles to your file-based catalog, as shown in the example below.
+
+*Prerequisites*
+
+* `opm` CLI tool
+* A plain bundle image
+* A file-based catalog
+* Push access to an image registry, such as [Quay](https://quay.io)
+* Docker or Podman
+
+*Procedure*
+
+1. Verify that your catalog's `index.json` or `index.yaml` file is similar to the following example:
+
+    *Example `<catalog_dir>/index.json` file*
+
+    ```json
+    {   
+        {
+         "schema": "olm.package",
+         "name": "<operator_name>",
+         "defaultChannel": "preview"
+        }    
+    }
+    ```
+
+1. To create an `olm.bundle` blob, edit your `index.json` or `index.yaml` file, similar to the following example:
+
+    *Example `<catalog_dir>/index.json` file*
+
+    ```json
+    {
+        "schema": "olm.bundle",
+        "name": "plainbundle:test",
+        "package": "<operator_name>",
+        "image": "quay.io/<image_repo>/plainbundle:test",
+        "properties": [
+            {
+                "type": "olm.package",
+                "value": {
+                "packageName": "<operator_name>",
+                "version": "0.0.3",
+                "olm.bundle.mediatype": "plain+v0"
+                }
+            }
+      ]
+    }
+    ```
+
+1. To create an `olm.channel` blob, edit your `index.json` or `index.yaml` file, similar to the following example:
+
+    *Example `<catalog_dir>/index.json` file*
+
+    ```json
+    {
+        "schema": "olm.channel",
+        "name": "preview",
+        "package": "<operator_name>",
+        "entries": [
+            {
+                "name": "plainbundle:test"
+            }
+        ]
+    }
+    ```
+
+*Verification*
+
+* Run the following command to validate your catalog:
+
+    ```sh
+    opm validate <catalog_directory>
+    ```
+
+    If there are no errors in your catalog, the command completes without output.
+
+## Building and publishing a file-based catalog
+
+*Procedure*
+
+1. Run the following command to build your catalog as an image:
+
+    ```sh
+    docker build -f <Dockerfile> -t \
+    quay.io/<image_repo>/plain-bundle-catalog:latest
+    ```
+
+1. Run the following command to push the catalog image:
+
+    ```sh
+    docker push quay.io/<image_repo>/plain-bundle-catalog:latest
+    ```

--- a/docs/design/bundle-sources.md
+++ b/docs/design/bundle-sources.md
@@ -1,6 +1,6 @@
 # Building a file-based catalog from a plain bundle image
 
-**IMPORTANT:** Operator Lifecycle Manager (OLM) v1 features and components are still experimental. Early adopters and contributors should expect breaking changes. The following procedures are not recommended for use on production clusters.
+> **Warning:** Operator Lifecycle Manager (OLM) v1 features and components are still experimental. Early adopters and contributors should expect breaking changes. The following procedures are not recommended for use on production clusters.
 
 You can build a static collection of arbitrary Kubernetes manifests in the YAML format, or *plain bundle*, and add the image to a file-based catalog (FBC). The experimental `olm.bundle.mediatype` property of the `olm.bundle` schema object differentiates a plain bundle from a regular bundle. You must set the bundle media type property to `plain+v0` to specify a plain bundle.
 
@@ -16,15 +16,19 @@ To build a file-based catalog from a plain bundle image, you must complete the f
 
 ## Building a plain bundle image from an image source
 
-Currently, the Operator Controller only supports building a plain bundle image from an image source.
+Currently, the Operator Controller only supports installing plain bundles created from a plain bundle image.
 
-*Prerequisites*
+<h3 id="prereqs-building-plain-bundle-from-image">
+Prerequisites
+</h3>
 
 * [`opm` CLI tool](https://github.com/operator-framework/operator-registry/releases)
 * Docker or Podman
 * Push access to an image registry, such as [Quay](https://quay.io)
 
-*Procedure*
+<h3 id="proc-building-plain-bundle-from-image">
+Procedure
+</h3>
 
 1. Verify that your Kubernetes manifests are in a flat directory at the root of your project similar to the following example:
 
@@ -61,16 +65,16 @@ Currently, the Operator Controller only supports building a plain bundle image f
     COPY manifests /manifests
     ```
 
-    **NOTE:** Use the `FROM scratch` directive to make the size of the image smaller.
+    > **Note:** Use the `FROM scratch` directive to make the size of the image smaller.
 
 1. Add the following labels to your Dockerfile:
 
     ```sh
     LABEL operators.operatorframework.io.bundle.mediatype.v1=plain+v0
     LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
-    LABEL operators.operatorframework.io.bundle.package.v1=testOperator
-    LABEL operators.operatorframework.io.bundle.channels.v1=preview
-    LABEL operators.operatorframework.io.bundle.channel.default.v1=preview
+    LABEL operators.operatorframework.io.bundle.package.v1=<operatorName>
+    LABEL operators.operatorframework.io.bundle.channels.v1=<channels>
+    LABEL operators.operatorframework.io.bundle.channel.default.v1=<defaultChannel>
     ```
 
 1. Build an OCI-compliant image using your preferred build tool, similar to the following example. You must use an image tag that references a repository where you have push access privileges.
@@ -88,7 +92,7 @@ Currently, the Operator Controller only supports building a plain bundle image f
     docker push quay.io/<image_repo>/plainbundle:example
     ```
 
-*Additional resources*
+### Additional resources
 
 * [File-based catalog bundle schema](https://github.com/operator-framework/olm-docs/blob/master/content/en/docs/Reference/file-based-catalogs.md)
 * [OCI image specification](https://github.com/opencontainers/image-spec#oci-image-format-specification)
@@ -99,12 +103,16 @@ Currently, the Operator Controller only supports building a plain bundle image f
 
 If you do not have a file-based catalog, you must perform the following steps to initialize the catalog.
 
-*Prerequisites*
+<h3 id="prereqs-creating-a-fbc">
+Prerequisites
+</h3>
 
 * `opm` CLI tool
 * Docker or Podman
 
-*Procedure*
+<h3 id="proc-creating-a-fbc">
+Procedure
+</h3>
 
 1. Create a directory for the catalog by running the following command:
 
@@ -120,7 +128,7 @@ If you do not have a file-based catalog, you must perform the following steps to
     opm generate dockerfile <catalog_dir>
     ```
 
-    *TIP:* If do not want to use the default upstream base image, you can specify a different image using the `-i` flag.
+    > **Note:** If do not want to use the default upstream base image, you can specify a different image using the `-i` flag.
 
     * The Dockerfile must be in the same parent directory as the catalog directory that you created in the previous step:
         *Example directory structure*
@@ -138,8 +146,8 @@ If you do not have a file-based catalog, you must perform the following steps to
     --default-channel=preview \
     --description=./README.md \
     --icon=./operator-icon.svg \
-    --output yaml \
-    > <catalog_dir>/index.yaml
+    --output json \
+    > <catalog_dir>/index.json
     ```
 
     This command generates an `olm.package` declarative config blob in the specified catalog configuration file.
@@ -148,7 +156,9 @@ If you do not have a file-based catalog, you must perform the following steps to
 
 Currently, the `opm render` command does not support adding plain bundles to catalogs. You must manually add plain bundles to your file-based catalog, as shown in the example below.
 
-*Prerequisites*
+<h3 id="prereqs-adding-a-plain-bundle-to-fbc">
+Prerequisites
+</h3>
 
 * `opm` CLI tool
 * A plain bundle image
@@ -156,7 +166,9 @@ Currently, the `opm render` command does not support adding plain bundles to cat
 * Push access to an image registry, such as [Quay](https://quay.io)
 * Docker or Podman
 
-*Procedure*
+<h3 id="proc-adding-a-plain-bundle-to-fbc">
+Procedure
+</h3>
 
 1. Verify that your catalog's `index.json` or `index.yaml` file is similar to the following example:
 
@@ -167,7 +179,7 @@ Currently, the `opm render` command does not support adding plain bundles to cat
         {
          "schema": "olm.package",
          "name": "<operator_name>",
-         "defaultChannel": "preview"
+         "defaultChannel": "<default_channel_name>"
         }    
     }
     ```
@@ -179,7 +191,7 @@ Currently, the `opm render` command does not support adding plain bundles to cat
     ```json
     {
         "schema": "olm.bundle",
-        "name": "plainbundle:test",
+        "name": "<bundle_name>",
         "package": "<operator_name>",
         "image": "quay.io/<image_repo>/plainbundle:test",
         "properties": [
@@ -187,9 +199,12 @@ Currently, the `opm render` command does not support adding plain bundles to cat
                 "type": "olm.package",
                 "value": {
                 "packageName": "<operator_name>",
-                "version": "0.0.3",
-                "olm.bundle.mediatype": "plain+v0"
+                "version": "0.0.3"
                 }
+            },
+            {
+                "type": "olm.bundle.mediatype",
+                "value": "plain+v0"
             }
       ]
     }
@@ -202,8 +217,53 @@ Currently, the `opm render` command does not support adding plain bundles to cat
     ```json
     {
         "schema": "olm.channel",
-        "name": "preview",
+        "name": "<default_channel_name>",
         "package": "<operator_name>",
+        "entries": [
+            {
+                "name": "<bundle_name>"
+            }
+        ]
+    }
+    ```
+
+<h3 id="verify-adding-a-plain-bundle-to-fbc">
+Verification
+</h3>
+
+1. Open your `index.json` or `index.yaml` file and ensure it is similar to the following example:
+
+    *Example `index.json` file*
+
+    ```json
+    {
+        "schema": "olm.package",
+        "name": "testOperator",
+        "defaultChannel": "preview"
+    }
+    {
+        "schema": "olm.bundle",
+        "name": "plainbundle:test",
+        "package": "testOperator",
+        "image": "quay.io/rashmigottipati/plainbundle:test",
+        "properties": [
+            {
+                "type": "olm.package",
+                "value": {
+                "packageName": "testOperator",
+                "version": "0.0.3"
+                }
+            },
+            {
+                "type": "olm.bundle.mediatype",
+                "value": "plain+v0"
+            }
+        ]
+    }
+    {
+        "schema": "olm.channel",
+        "name": "preview",
+        "package": "testOperator",
         "entries": [
             {
                 "name": "plainbundle:test"
@@ -212,9 +272,7 @@ Currently, the `opm render` command does not support adding plain bundles to cat
     }
     ```
 
-*Verification*
-
-* Run the following command to validate your catalog:
+1. Run the following command to validate your catalog:
 
     ```sh
     opm validate <catalog_directory>
@@ -224,7 +282,9 @@ Currently, the `opm render` command does not support adding plain bundles to cat
 
 ## Building and publishing a file-based catalog
 
-*Procedure*
+<h3 id="proc-building-and-publishing-a-fbc">
+Procedure
+</h3>
 
 1. Run the following command to build your catalog as an image:
 

--- a/docs/design/bundle-sources.md
+++ b/docs/design/bundle-sources.md
@@ -125,7 +125,7 @@ Procedure
         └── <catalog_dir>.Dockerfile
         ```
 
-1. Make the below changes to your Dockerfile:
+1. Make the following changes to your Dockerfile:
   
     *Example Dockerfile*
 
@@ -134,7 +134,7 @@ Procedure
         ADD <catalog_dir> /configs
     ```
 
-    > **Note:** Use the `FROM scratch` directive to make the size of the image smaller. 
+    > **Note:** Use the `FROM scratch` directive to make the size of the image smaller.
 
 1. Populate the catalog with the package definition for your Operator by running the `opm init` command:
 
@@ -148,7 +148,7 @@ Procedure
 
 ## Adding a plain bundle to your file-based catalog
 
-Currently, the `opm render` command does not support adding plain bundles to catalogs. You must manually add plain bundles to your file-based catalog, as shown in the example below.
+Currently, the `opm render` command does not support adding plain bundles to catalogs. You must manually add plain bundles to your file-based catalog, as shown in the following example.
 
 <h3 id="prereqs-adding-a-plain-bundle-to-fbc">
 Prerequisites
@@ -220,7 +220,7 @@ Procedure
     }
     ```
 
-    > **Note:** Some examples for the <desired_channel_name> include `stable`, `fast`, and `preview`.
+    > **Note:** Please refer to [channel naming conventions](https://olm.operatorframework.io/docs/best-practices/channel-naming/) for choosing the <desired_channel_name>. An example of the <desired_channel_name> is `candidate-v0`.
 
 <h3 id="verify-adding-a-plain-bundle-to-fbc">
 Verification
@@ -275,8 +275,8 @@ Procedure
 1. Run the following command to build your catalog as an image:
 
     ```sh
-    docker build -f <catalog_directory>.Dockerfile -t \
-   quay.io/<organization_name>/<repository_name>:<image_tag> .
+    docker build -f <catalog_dir>.Dockerfile -t \
+    quay.io/<organization_name>/<repository_name>:<image_tag> .
     ```
 
 1. Run the following command to push the catalog image:

--- a/docs/design/bundle-sources.md
+++ b/docs/design/bundle-sources.md
@@ -24,7 +24,7 @@ Prerequisites
 
 * [`opm` CLI tool](https://github.com/operator-framework/operator-registry/releases)
 * Docker or Podman
-* Push access to an image registry, such as [Quay](https://quay.io)
+* Push access to a container registry, such as [Quay](https://quay.io)
 
 <h3 id="proc-building-plain-bundle-from-image">
 Procedure
@@ -53,7 +53,7 @@ Procedure
 1. Create a Dockerfile at the root of your project:
 
     ```sh
-    touch Dockerfile.plainbundle
+    touch plainbundle.Dockerfile
     ```
 
 1. Make the following changes to your Dockerfile:
@@ -61,35 +61,25 @@ Procedure
     *Example Dockerfile*
 
     ```sh
-    FROM scratch
-    COPY manifests /manifests
+        FROM scratch
+        ADD catalog /configs
     ```
 
     > **Note:** Use the `FROM scratch` directive to make the size of the image smaller.
-
-1. Add the following labels to your Dockerfile:
-
-    ```sh
-    LABEL operators.operatorframework.io.bundle.mediatype.v1=plain+v0
-    LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
-    LABEL operators.operatorframework.io.bundle.package.v1=<operator_name>
-    LABEL operators.operatorframework.io.bundle.channels.v1=<channels>
-    LABEL operators.operatorframework.io.bundle.channel.default.v1=<default_channel>
-    ```
 
 1. Build an OCI-compliant image using your preferred build tool, similar to the following example. You must use an image tag that references a repository where you have push access privileges.
 
     *Example build command*
 
     ```sh
-    docker build -f Dockerfile.plainbundle -t \
-    quay.io/<image_repo>/plainbundle:example .
+    docker build -f plainbundle.Dockerfile -t \
+    quay.io/<organization_name>/<repository_name>:<image_tag> .
     ```
 
 1. Push the image to your remote registry:
 
     ```sh
-    docker push quay.io/<image_repo>/plainbundle:example
+    docker push quay.io/<organization_name>/<repository_name>:<image_tag>
     ```
 
 ### Additional resources
@@ -122,13 +112,9 @@ Procedure
 
 1. Create a Dockerfile that can build a catalog image by running the `opm generate dockerfile` command:
 
-    *Example `<catalog_name>-image.Dockerfile`*
-
     ```sh
     opm generate dockerfile <catalog_dir>
     ```
-
-    > **Note:** If do not want to use the default upstream base image, you can specify a different image using the `-i` flag.
 
     * The Dockerfile must be in the same parent directory as the catalog directory that you created in the previous step:
         *Example directory structure*
@@ -143,9 +129,6 @@ Procedure
 
     ```sh
     opm init <operator_name> \
-    --default-channel=preview \
-    --description=./README.md \
-    --icon=./operator-icon.svg \
     --output json \
     > <catalog_dir>/index.json
     ```
@@ -163,7 +146,7 @@ Prerequisites
 * `opm` CLI tool
 * A plain bundle image
 * A file-based catalog
-* Push access to an image registry, such as [Quay](https://quay.io)
+* Push access to a container registry, such as [Quay](https://quay.io)
 * Docker or Podman
 
 <h3 id="proc-adding-a-plain-bundle-to-fbc">
@@ -179,7 +162,6 @@ Procedure
         {
          "schema": "olm.package",
          "name": "<operator_name>",
-         "defaultChannel": "<default_channel_name>"
         }    
     }
     ```
@@ -191,15 +173,15 @@ Procedure
     ```json
     {
         "schema": "olm.bundle",
-        "name": "<bundle_name>",
+        "name": "<operator_name>.<version>",
         "package": "<operator_name>",
-        "image": "quay.io/<image_repo>/plainbundle:test",
+        "image": "quay.io/<organization_name>/<repository_name>:<image_tag>", 
         "properties": [
             {
                 "type": "olm.package",
                 "value": {
                 "packageName": "<operator_name>",
-                "version": "0.0.3"
+                "version": "<bundle_version>"
                 }
             },
             {
@@ -221,7 +203,7 @@ Procedure
         "package": "<operator_name>",
         "entries": [
             {
-                "name": "<bundle_name>"
+                "name": "<operator_name>/<bundle_version>"
             }
         ]
     }
@@ -238,20 +220,19 @@ Verification
     ```json
     {
         "schema": "olm.package",
-        "name": "testOperator",
-        "defaultChannel": "preview"
+        "name": "example-operator",
     }
     {
         "schema": "olm.bundle",
-        "name": "plainbundle:test",
-        "package": "testOperator",
-        "image": "quay.io/rashmigottipati/plainbundle:test",
+        "name": "example-operator.v0.0.1",
+        "package": "example-operator",
+        "image": "quay.io/rashmigottipati/example-operator-bundle:v0.0.1",
         "properties": [
             {
                 "type": "olm.package",
                 "value": {
-                "packageName": "testOperator",
-                "version": "0.0.3"
+                "packageName": "example-operator",
+                "version": "v0.0.1"
                 }
             },
             {
@@ -263,22 +244,14 @@ Verification
     {
         "schema": "olm.channel",
         "name": "preview",
-        "package": "testOperator",
+        "package": "example-operator",
         "entries": [
             {
-                "name": "plainbundle:test"
+                "name": "example-operator.v0.0.1"
             }
         ]
     }
     ```
-
-1. Run the following command to validate your catalog:
-
-    ```sh
-    opm validate <catalog_directory>
-    ```
-
-    If there are no errors in your catalog, the command completes without output.
 
 ## Building and publishing a file-based catalog
 
@@ -289,12 +262,12 @@ Procedure
 1. Run the following command to build your catalog as an image:
 
     ```sh
-    docker build -f <Dockerfile> -t \
-    quay.io/<image_repo>/plain-bundle-catalog:latest
+    docker build -f <catalog_directory>.Dockerfile -t \
+   quay.io/<organization_name>/<repository_name>:<image_tag> .
     ```
 
 1. Run the following command to push the catalog image:
 
     ```sh
-    docker push quay.io/<image_repo>/plain-bundle-catalog:latest
+    docker push quay.io/<organization_name>/<repository_name>:<image_tag>
     ```


### PR DESCRIPTION
**Description of the change:**
Write a plain bundle usage document by listing the process required to build a plain bundle image and add it to a file-based catalog.

**Motivation for the change:**
The goal of this document is to highlight steps to add a plain bundle image to a file-based catalog and enumerate the experimental `olm.bundle.mediatype` field. Currently,`opm` does not support plain bundles i.e. plain bundles cannot be rendered through `opm render` as the `plain+v0` format is just the manifests and `opm render` would require the `manifests` and `metadata` in order to be able to render the plain bundle. This documentation provides instructions on how to manually include the plain bundle in a file-based catalog. Please note that this is experimental for now and not  recommended for production usage.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [x] Docs updated or added to `/docs` 
- [x] Commit messages sensible and descriptive

Doc collaboration with @michaelryanpeter
