### PR TITLE
[BUGFIX] Allow absolute filepaths for resolving catalog config

### DIFF
--- a/alpha/template/composite/composite.go
+++ b/alpha/template/composite/composite.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 
 	"github.com/operator-framework/operator-registry/pkg/image"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -88,7 +89,7 @@ type HttpGetter interface {
 func FetchCatalogConfig(path string, httpGetter HttpGetter) (io.ReadCloser, error) {
 	var tempCatalog io.ReadCloser
 	catalogURI, err := url.ParseRequestURI(path)
-	if err != nil {
+	if err != nil || filepath.IsAbs(path) {
 		tempCatalog, err = os.Open(path)
 		if err != nil {
 			return nil, fmt.Errorf("opening catalog config file %q: %v", path, err)

--- a/alpha/template/composite/composite.go
+++ b/alpha/template/composite/composite.go
@@ -98,9 +98,9 @@ func FetchCatalogConfig(path string, httpGetter HttpGetter) (io.ReadCloser, erro
 		if err != nil {
 			return nil, fmt.Errorf("opening catalog config file %q: %v", path, err)
 		}
+	} else {
 		// Evalute remote catalog config
 		// If URi is valid, execute fetch
-	} else {
 		tempResp, err := httpGetter.Get(catalogURI.String())
 		if err != nil {
 			return nil, fmt.Errorf("fetching remote catalog config file %q: %v", path, err)

--- a/alpha/template/composite/composite.go
+++ b/alpha/template/composite/composite.go
@@ -86,14 +86,20 @@ type HttpGetter interface {
 // FetchCatalogConfig will fetch the catalog configuration file from the given path.
 // The path can be a local file path OR a URL that returns the raw contents of the catalog
 // configuration file.
+// The filepath can be structured relative or as an absolute path
 func FetchCatalogConfig(path string, httpGetter HttpGetter) (io.ReadCloser, error) {
 	var tempCatalog io.ReadCloser
 	catalogURI, err := url.ParseRequestURI(path)
+	// Evalute local catalog config
+	// URI parse will fail on relative filepaths
+	// Check if path is an absolute filepath
 	if err != nil || filepath.IsAbs(path) {
 		tempCatalog, err = os.Open(path)
 		if err != nil {
 			return nil, fmt.Errorf("opening catalog config file %q: %v", path, err)
 		}
+		// Evalute remote catalog config
+		// If URi is valid, execute fetch
 	} else {
 		tempResp, err := httpGetter.Get(catalogURI.String())
 		if err != nil {

--- a/alpha/template/composite/composite_test.go
+++ b/alpha/template/composite/composite_test.go
@@ -593,7 +593,7 @@ func TestFetchCatalogConfig(t *testing.T) {
 		},
 		{
 			name: "Successful absolute reference file fetch",
-			path: testDir + "file/test.yaml",
+			path: testDir + "/file/test.yaml",
 			fakeGetter: &fakeGetter{
 				catalog:     validCatalog,
 				shouldError: true,
@@ -606,7 +606,7 @@ func TestFetchCatalogConfig(t *testing.T) {
 		},
 		{
 			name: "Failed absolute reference file fetch",
-			path: testDir + "file/test.yaml",
+			path: testDir + "/file/test.yaml",
 			fakeGetter: &fakeGetter{
 				catalog:     validCatalog,
 				shouldError: true,

--- a/alpha/template/composite/composite_test.go
+++ b/alpha/template/composite/composite_test.go
@@ -614,7 +614,7 @@ func TestFetchCatalogConfig(t *testing.T) {
 			createFile: false,
 			assertions: func(t *testing.T, rc io.ReadCloser, err error) {
 				require.Error(t, err)
-				strVal := "opening catalog config file \"" + testDir + "/file/faketest.yaml\": open file/test.yaml: no such file or directory"
+				strVal := "opening catalog config file \"" + testDir + "/file/faketest.yaml\": open " + testDir + "/file/faketest.yaml: no such file or directory"
 				require.Equal(t, strVal, err.Error())
 			},
 		},

--- a/alpha/template/composite/composite_test.go
+++ b/alpha/template/composite/composite_test.go
@@ -604,6 +604,20 @@ func TestFetchCatalogConfig(t *testing.T) {
 				require.NotNil(t, rc)
 			},
 		},
+		{
+			name: "Failed absolute reference file fetch",
+			path: testDir + "/file/faketest.yaml",
+			fakeGetter: &fakeGetter{
+				catalog:     validCatalog,
+				shouldError: true,
+			},
+			createFile: false,
+			assertions: func(t *testing.T, rc io.ReadCloser, err error) {
+				require.Error(t, err)
+				strVal := "opening catalog config file \"" + testDir + "/file/faketest.yaml\": open file/test.yaml: no such file or directory"
+				require.Equal(t, strVal, err.Error())
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/alpha/template/composite/composite_test.go
+++ b/alpha/template/composite/composite_test.go
@@ -614,7 +614,8 @@ func TestFetchCatalogConfig(t *testing.T) {
 			createFile: false,
 			assertions: func(t *testing.T, rc io.ReadCloser, err error) {
 				require.Error(t, err)
-				require.Equal(t, "opening catalog config file \"file/test.yaml\": open file/test.yaml: no such file or directory", err.Error())
+				strVal := "opening catalog config file \"" + testDir + "/file/test.yaml\": open file/test.yaml: no such file or directory"
+				require.Equal(t, strVal, err.Error())
 			},
 		},
 	}

--- a/alpha/template/composite/composite_test.go
+++ b/alpha/template/composite/composite_test.go
@@ -604,20 +604,6 @@ func TestFetchCatalogConfig(t *testing.T) {
 				require.NotNil(t, rc)
 			},
 		},
-		{
-			name: "Failed absolute reference file fetch",
-			path: testDir + "/file/test.yaml",
-			fakeGetter: &fakeGetter{
-				catalog:     validCatalog,
-				shouldError: true,
-			},
-			createFile: false,
-			assertions: func(t *testing.T, rc io.ReadCloser, err error) {
-				require.Error(t, err)
-				strVal := "opening catalog config file \"" + testDir + "/file/test.yaml\": open file/test.yaml: no such file or directory"
-				require.Equal(t, strVal, err.Error())
-			},
-		},
 	}
 
 	for _, tc := range testCases {

--- a/alpha/template/composite/composite_test.go
+++ b/alpha/template/composite/composite_test.go
@@ -592,33 +592,6 @@ func TestFetchCatalogConfig(t *testing.T) {
 				require.Equal(t, "opening catalog config file \"file/test.yaml\": open file/test.yaml: no such file or directory", err.Error())
 			},
 		},
-		{
-			name: "Successful absolute reference file fetch",
-			path: testDir + "/file/test.yaml",
-			fakeGetter: &fakeGetter{
-				catalog:     validCatalog,
-				shouldError: true,
-			},
-			createFile: true,
-			assertions: func(t *testing.T, rc io.ReadCloser, err error) {
-				require.NoError(t, err)
-				require.NotNil(t, rc)
-			},
-		},
-		{
-			name: "Failed absolute reference file fetch",
-			path: testDir + "/file/faketest.yaml",
-			fakeGetter: &fakeGetter{
-				catalog:     validCatalog,
-				shouldError: true,
-			},
-			createFile: false,
-			assertions: func(t *testing.T, rc io.ReadCloser, err error) {
-				require.Error(t, err)
-				strVal := "opening catalog config file \"" + testDir + "/file/faketest.yaml\": open " + testDir + "/file/faketest.yaml: no such file or directory"
-				require.Equal(t, strVal, err.Error())
-			},
-		},
 	}
 
 	for _, tc := range testCases {

--- a/alpha/template/composite/composite_test.go
+++ b/alpha/template/composite/composite_test.go
@@ -571,7 +571,8 @@ func TestFetchCatalogConfig(t *testing.T) {
 			name: "Successful file fetch",
 			path: "file/test.yaml",
 			fakeGetter: &fakeGetter{
-				catalog: validCatalog,
+				catalog:     validCatalog,
+				shouldError: true,
 			},
 			createFile: true,
 			assertions: func(t *testing.T, rc io.ReadCloser, err error) {

--- a/alpha/template/composite/composite_test.go
+++ b/alpha/template/composite/composite_test.go
@@ -540,6 +540,8 @@ func TestFetchCatalogConfig(t *testing.T) {
 		assertions func(t *testing.T, rc io.ReadCloser, err error)
 	}
 
+	testDir := t.TempDir()
+
 	testCases := []testCase{
 		{
 			name: "Successful HTTP fetch",
@@ -589,9 +591,33 @@ func TestFetchCatalogConfig(t *testing.T) {
 				require.Equal(t, "opening catalog config file \"file/test.yaml\": open file/test.yaml: no such file or directory", err.Error())
 			},
 		},
+		{
+			name: "Successful absolute reference file fetch",
+			path: testDir + "file/test.yaml",
+			fakeGetter: &fakeGetter{
+				catalog:     validCatalog,
+				shouldError: true,
+			},
+			createFile: true,
+			assertions: func(t *testing.T, rc io.ReadCloser, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, rc)
+			},
+		},
+		{
+			name: "Failed absolute reference file fetch",
+			path: testDir + "file/test.yaml",
+			fakeGetter: &fakeGetter{
+				catalog:     validCatalog,
+				shouldError: true,
+			},
+			createFile: false,
+			assertions: func(t *testing.T, rc io.ReadCloser, err error) {
+				require.Error(t, err)
+				require.Equal(t, "opening catalog config file \"file/test.yaml\": open file/test.yaml: no such file or directory", err.Error())
+			},
+		},
 	}
-
-	testDir := t.TempDir()
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
**Description of the change:**
Adds an additional check to the Catalog Config fetching function to allow absolute file paths to be resolved. 

**Motivation for the change:**
When adding support for remote catalog configurations, the resolver lost the ability to use absolute filepaths and could only handle relative paths. 
