### PR TITLE
opm: always serve pprof endpoints, improve server allocations

### DIFF
--- a/pkg/cache/json.go
+++ b/pkg/cache/json.go
@@ -165,13 +165,14 @@ func (q *JSON) existingDigest() (string, error) {
 }
 
 func (q *JSON) computeDigest(fbcFsys fs.FS) (string, error) {
+	buf := make([]byte, 32*1024)
 	computedHasher := fnv.New64a()
-	if err := fsToTar(computedHasher, fbcFsys); err != nil {
+	if err := fsToTar(computedHasher, fbcFsys, buf); err != nil {
 		return "", err
 	}
 
 	if cacheFS, err := fs.Sub(os.DirFS(q.baseDir), jsonDir); err == nil {
-		if err := fsToTar(computedHasher, cacheFS); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := fsToTar(computedHasher, cacheFS, buf); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return "", fmt.Errorf("compute hash: %v", err)
 		}
 	}

--- a/pkg/cache/json.go
+++ b/pkg/cache/json.go
@@ -165,6 +165,8 @@ func (q *JSON) existingDigest() (string, error) {
 }
 
 func (q *JSON) computeDigest(fbcFsys fs.FS) (string, error) {
+	// We are not sensitive to the size of this buffer, we just need it to be shared.
+	// For simplicity, do the same as io.Copy() would.
 	buf := make([]byte, 32*1024)
 	computedHasher := fnv.New64a()
 	if err := fsToTar(computedHasher, fbcFsys, buf); err != nil {

--- a/pkg/cache/tar.go
+++ b/pkg/cache/tar.go
@@ -15,6 +15,8 @@ import (
 // permissions between source and destination filesystems.
 func fsToTar(w io.Writer, fsys fs.FS, buf []byte) error {
 	if buf == nil || len(buf) == 0 {
+		// We are not sensitive to the size of this buffer, we just need it to be shared.
+		// For simplicity, do the same as io.Copy() would.
 		buf = make([]byte, 32*1024)
 	}
 	tw := tar.NewWriter(w)

--- a/pkg/cache/tar_test.go
+++ b/pkg/cache/tar_test.go
@@ -51,7 +51,7 @@ func Test_fsToTar(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			w := bytes.Buffer{}
-			err := fsToTar(&w, tc.fsys())
+			err := fsToTar(&w, tc.fsys(), nil)
 			tc.expect(t, w.Bytes(), err)
 		})
 	}


### PR DESCRIPTION
There's no substantial runtime cost to serving the endpoints by default, and when things hit the fan you always need to query them in situ.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
