### PR TITLE
Makes codecov-action optional

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -22,5 +22,4 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           files: coverage.out
-          fail_ci_if_error: true
           functionalities: fixes


### PR DESCRIPTION
**Description of the change:**

We do not want to fail the job if codecov fails
to upload the report due to rate limiting.

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
