### PR TITLE
Enforce Argument Count in Alpha Template Command

### DIFF
--- a/cmd/opm/alpha/template/basic.go
+++ b/cmd/opm/alpha/template/basic.go
@@ -25,7 +25,7 @@ func newBasicTemplateCmd() *cobra.Command {
 When FILE is '-' or not provided, the template is read from standard input`,
 		Long: `Generate a file-based catalog from a single 'basic template' file
 When FILE is '-' or not provided, the template is read from standard input`,
-		Args: cobra.MaximumNArgs(1),
+		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Handle different input argument types
 			// When no arguments or "-" is passed to the command,

--- a/cmd/opm/alpha/template/semver.go
+++ b/cmd/opm/alpha/template/semver.go
@@ -23,7 +23,7 @@ func newSemverTemplateCmd() *cobra.Command {
 When FILE is '-' or not provided, the template is read from standard input`,
 		Long: `Generate a file-based catalog from a single 'semver template' file
 When FILE is '-' or not provided, the template is read from standard input`,
-		Args: cobra.MaximumNArgs(1),
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Handle different input argument types
 			// When no arguments or "-" is passed to the command,


### PR DESCRIPTION
This is a simple change in order to force users to provide the appropriate context as an argument when running the command preventing the tool from hanging without it.

This solution was arrived upon in place of checking for the context's existence post CLI.