### PR TITLE
export parsed composite specs

### DIFF
--- a/alpha/template/composite/types.go
+++ b/alpha/template/composite/types.go
@@ -1,6 +1,12 @@
 package composite
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/operator-framework/operator-registry/pkg/image"
+)
 
 type TemplateDefinition struct {
 	Schema string
@@ -26,4 +32,30 @@ type CustomConfig struct {
 	Command string
 	Args    []string
 	Output  string
+}
+
+type BuilderMap map[string]Builder
+
+type CatalogBuilderMap map[string]BuilderMap
+
+type builderFunc func(BuilderConfig) Builder
+
+type Template struct {
+	catalogFile        io.Reader
+	contributionFile   io.Reader
+	validate           bool
+	outputType         string
+	registry           image.Registry
+	registeredBuilders map[string]builderFunc
+}
+
+type TemplateOption func(t *Template)
+
+type Specs struct {
+	CatalogSpec      *CatalogConfig
+	ContributionSpec *CompositeConfig
+}
+
+type HttpGetter interface {
+	Get(url string) (*http.Response, error)
 }


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
export parsed yaml/json specs so that other tooling can leverage it

**Motivation for the change:**
tap-fitter tooling will be able to generate some pipeline-specific pieces from the composite template, but the current implementation parses and executes the specs in an uninterrupted flow

example:
```golang
c := composite.NewTemplate(
         composite.WithCatalogFile(tempCatalog),
         composite.WithContributionFile(compositeReader)
)
specs, err := c.Parse()
```


**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
