### PR TITLE
migrate: support migration of FBC to latest preferred FBC

### DIFF
--- a/alpha/action/migrate.go
+++ b/alpha/action/migrate.go
@@ -31,9 +31,7 @@ func (m Migrate) Run(ctx context.Context) error {
 	r := Render{
 		Refs: []string{m.CatalogRef},
 
-		// Only allow sqlite images and files to be migrated. Other types cannot
-		// always be migrated cleanly because they may contain file references.
-		// Rendered sqlite databases never contain file references.
+		// Only allow sqlite images and files to be migrated.
 		AllowedRefMask: RefSqliteImage | RefSqliteFile,
 
 		skipSqliteDeprecationLog: true,

--- a/alpha/action/migrate.go
+++ b/alpha/action/migrate.go
@@ -29,12 +29,11 @@ func (m Migrate) Run(ctx context.Context) error {
 	}
 
 	r := Render{
-		Refs: []string{m.CatalogRef},
+		Refs:    []string{m.CatalogRef},
+		Migrate: true,
 
-		// Only allow sqlite images and files to be migrated.
-		AllowedRefMask: RefSqliteImage | RefSqliteFile,
-
-		skipSqliteDeprecationLog: true,
+		// Only allow catalogs to be migrated.
+		AllowedRefMask: RefSqliteImage | RefSqliteFile | RefDCImage | RefDCDir,
 	}
 	if m.Registry != nil {
 		r.Registry = m.Registry

--- a/alpha/action/render_test.go
+++ b/alpha/action/render_test.go
@@ -294,8 +294,8 @@ func TestRender(t *testing.T) {
 							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
 							property.MustBuildPackage("foo", "0.1.0"),
 							property.MustBuildPackageRequired("bar", "<0.1.0"),
-							property.MustBuildBundleObjectData(foov1csv),
-							property.MustBuildBundleObjectData(foov1crd),
+							property.MustBuildBundleObject(foov1csv),
+							property.MustBuildBundleObject(foov1crd),
 						},
 						RelatedImages: []declcfg.RelatedImage{
 							{
@@ -319,8 +319,8 @@ func TestRender(t *testing.T) {
 							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
 							property.MustBuildPackage("foo", "0.2.0"),
 							property.MustBuildPackageRequired("bar", "<0.1.0"),
-							property.MustBuildBundleObjectData(foov2csv),
-							property.MustBuildBundleObjectData(foov2crd),
+							property.MustBuildBundleObject(foov2csv),
+							property.MustBuildBundleObject(foov2crd),
 						},
 						RelatedImages: []declcfg.RelatedImage{
 							{
@@ -392,8 +392,8 @@ func TestRender(t *testing.T) {
 							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
 							property.MustBuildPackage("foo", "0.1.0"),
 							property.MustBuildPackageRequired("bar", "<0.1.0"),
-							property.MustBuildBundleObjectData(foov1csv),
-							property.MustBuildBundleObjectData(foov1crd),
+							property.MustBuildBundleObject(foov1csv),
+							property.MustBuildBundleObject(foov1crd),
 						},
 						RelatedImages: []declcfg.RelatedImage{
 							{
@@ -417,8 +417,8 @@ func TestRender(t *testing.T) {
 							property.MustBuildGVKRequired("test.bar", "v1alpha1", "Bar"),
 							property.MustBuildPackage("foo", "0.2.0"),
 							property.MustBuildPackageRequired("bar", "<0.1.0"),
-							property.MustBuildBundleObjectData(foov2csv),
-							property.MustBuildBundleObjectData(foov2crd),
+							property.MustBuildBundleObject(foov2csv),
+							property.MustBuildBundleObject(foov2crd),
 						},
 						RelatedImages: []declcfg.RelatedImage{
 							{

--- a/alpha/declcfg/helpers_test.go
+++ b/alpha/declcfg/helpers_test.go
@@ -3,7 +3,6 @@ package declcfg
 import (
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"sort"
 	"testing"
 
@@ -116,8 +115,8 @@ func newTestBundle(packageName, version string, opts ...bundleOpt) Bundle {
 		Image:   testBundleImage(packageName, version),
 		Properties: []property.Property{
 			property.MustBuildPackage(packageName, version),
-			property.MustBuildBundleObjectRef(filepath.Join("objects", testBundleName(packageName, version)+".csv.yaml")),
-			property.MustBuildBundleObjectData([]byte(`{"kind": "CustomResourceDefinition", "apiVersion": "apiextensions.k8s.io/v1"}`)),
+			property.MustBuildBundleObject([]byte(csvJson)),
+			property.MustBuildBundleObject([]byte(`{"kind": "CustomResourceDefinition", "apiVersion": "apiextensions.k8s.io/v1"}`)),
 		},
 		RelatedImages: []RelatedImage{
 			{
@@ -193,8 +192,8 @@ func getBundle(pkg *model.Package, ch *model.Channel, version, replaces string, 
 		Image:   testBundleImage(pkg.Name, version),
 		Properties: []property.Property{
 			property.MustBuildPackage(pkg.Name, version),
-			property.MustBuildBundleObjectRef(filepath.Join("objects", testBundleName(pkg.Name, version)+".csv.yaml")),
-			property.MustBuildBundleObjectData([]byte(getCRDJSON())),
+			property.MustBuildBundleObject([]byte(getCSVJson(pkg.Name, version))),
+			property.MustBuildBundleObject([]byte(getCRDJSON())),
 		},
 		Replaces: replaces,
 		Skips:    skips,

--- a/alpha/declcfg/load_test.go
+++ b/alpha/declcfg/load_test.go
@@ -2,7 +2,9 @@ package declcfg
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io/fs"
 	"os"
 	"testing"
@@ -254,7 +256,7 @@ func TestLoadFS(t *testing.T) {
 							{Type: "olm.gvk", Value: json.RawMessage(`{"group":"etcd.database.coreos.com","kind":"EtcdCluster","version":"v1beta2"}`)},
 							{Type: "olm.channel", Value: json.RawMessage(`{"name":"alpha"}`)},
 							{Type: "olm.skipRange", Value: json.RawMessage(`"<0.6.1"`)},
-							{Type: "olm.bundle.object", Value: json.RawMessage(`{"ref":"etcdoperator.v0.6.1.clusterserviceversion.yaml"}`)},
+							{Type: "olm.bundle.object", Value: json.RawMessage(fmt.Sprintf(`{"data": %q}`, base64.StdEncoding.EncodeToString(etcdCSV.Data)))},
 						},
 						RelatedImages: []RelatedImage{{Name: "etcdv0.6.1", Image: "quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943"}},
 						Objects:       []string{toJSON(t, etcdCSV.Data)},
@@ -508,7 +510,7 @@ var (
 }`),
 	}
 	etcd = &fstest.MapFile{
-		Data: []byte(`---
+		Data: []byte(fmt.Sprintf(`---
 schema: olm.package
 name: etcd
 defaultChannel: singlenamespace-alpha
@@ -539,7 +541,7 @@ properties:
     value: <0.6.1
   - type: olm.bundle.object
     value:
-      ref: etcdoperator.v0.6.1.clusterserviceversion.yaml
+      data: %q
 relatedImages:
   - image: quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943
     name: etcdv0.6.1
@@ -674,7 +676,7 @@ properties:
       replaces: etcdoperator.v0.9.2-clusterwide
 relatedImages:
   - image: quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b
-    name: etcdv0.9.2`),
+    name: etcdv0.9.2`, base64.StdEncoding.EncodeToString(etcdCSV.Data))),
 	}
 	etcdCSV = &fstest.MapFile{
 		Data: []byte(`apiVersion: operators.coreos.com/v1alpha1

--- a/alpha/declcfg/write_test.go
+++ b/alpha/declcfg/write_test.go
@@ -78,7 +78,7 @@ func TestWriteJSON(t *testing.T) {
         {
             "type": "olm.bundle.object",
             "value": {
-                "ref": "objects/anakin.v0.0.1.csv.yaml"
+                "data": "eyJraW5kIjogIkNsdXN0ZXJTZXJ2aWNlVmVyc2lvbiIsICJhcGlWZXJzaW9uIjogIm9wZXJhdG9ycy5jb3Jlb3MuY29tL3YxYWxwaGExIiwgIm1ldGFkYXRhIjp7Im5hbWUiOiJhbmFraW4udjAuMC4xIn19"
             }
         },
         {
@@ -111,7 +111,7 @@ func TestWriteJSON(t *testing.T) {
         {
             "type": "olm.bundle.object",
             "value": {
-                "ref": "objects/anakin.v0.1.0.csv.yaml"
+                "data": "eyJraW5kIjogIkNsdXN0ZXJTZXJ2aWNlVmVyc2lvbiIsICJhcGlWZXJzaW9uIjogIm9wZXJhdG9ycy5jb3Jlb3MuY29tL3YxYWxwaGExIiwgIm1ldGFkYXRhIjp7Im5hbWUiOiJhbmFraW4udjAuMS4wIn19"
             }
         },
         {
@@ -144,7 +144,7 @@ func TestWriteJSON(t *testing.T) {
         {
             "type": "olm.bundle.object",
             "value": {
-                "ref": "objects/anakin.v0.1.1.csv.yaml"
+                "data": "eyJraW5kIjogIkNsdXN0ZXJTZXJ2aWNlVmVyc2lvbiIsICJhcGlWZXJzaW9uIjogIm9wZXJhdG9ycy5jb3Jlb3MuY29tL3YxYWxwaGExIiwgIm1ldGFkYXRhIjp7Im5hbWUiOiJhbmFraW4udjAuMS4xIn19"
             }
         },
         {
@@ -206,7 +206,7 @@ func TestWriteJSON(t *testing.T) {
         {
             "type": "olm.bundle.object",
             "value": {
-                "ref": "objects/boba-fett.v1.0.0.csv.yaml"
+                "data": "eyJraW5kIjogIkNsdXN0ZXJTZXJ2aWNlVmVyc2lvbiIsICJhcGlWZXJzaW9uIjogIm9wZXJhdG9ycy5jb3Jlb3MuY29tL3YxYWxwaGExIiwgIm1ldGFkYXRhIjp7Im5hbWUiOiJib2JhLWZldHQudjEuMC4wIn19"
             }
         },
         {
@@ -239,7 +239,7 @@ func TestWriteJSON(t *testing.T) {
         {
             "type": "olm.bundle.object",
             "value": {
-                "ref": "objects/boba-fett.v2.0.0.csv.yaml"
+                "data": "eyJraW5kIjogIkNsdXN0ZXJTZXJ2aWNlVmVyc2lvbiIsICJhcGlWZXJzaW9uIjogIm9wZXJhdG9ycy5jb3Jlb3MuY29tL3YxYWxwaGExIiwgIm1ldGFkYXRhIjp7Im5hbWUiOiJib2JhLWZldHQudjIuMC4wIn19"
             }
         },
         {
@@ -329,7 +329,7 @@ properties:
     data: eyJraW5kIjogIkN1c3RvbVJlc291cmNlRGVmaW5pdGlvbiIsICJhcGlWZXJzaW9uIjogImFwaWV4dGVuc2lvbnMuazhzLmlvL3YxIn0=
 - type: olm.bundle.object
   value:
-    ref: objects/anakin.v0.0.1.csv.yaml
+    data: eyJraW5kIjogIkNsdXN0ZXJTZXJ2aWNlVmVyc2lvbiIsICJhcGlWZXJzaW9uIjogIm9wZXJhdG9ycy5jb3Jlb3MuY29tL3YxYWxwaGExIiwgIm1ldGFkYXRhIjp7Im5hbWUiOiJhbmFraW4udjAuMC4xIn19
 - type: olm.package
   value:
     packageName: anakin
@@ -348,7 +348,7 @@ properties:
     data: eyJraW5kIjogIkN1c3RvbVJlc291cmNlRGVmaW5pdGlvbiIsICJhcGlWZXJzaW9uIjogImFwaWV4dGVuc2lvbnMuazhzLmlvL3YxIn0=
 - type: olm.bundle.object
   value:
-    ref: objects/anakin.v0.1.0.csv.yaml
+    data: eyJraW5kIjogIkNsdXN0ZXJTZXJ2aWNlVmVyc2lvbiIsICJhcGlWZXJzaW9uIjogIm9wZXJhdG9ycy5jb3Jlb3MuY29tL3YxYWxwaGExIiwgIm1ldGFkYXRhIjp7Im5hbWUiOiJhbmFraW4udjAuMS4wIn19
 - type: olm.package
   value:
     packageName: anakin
@@ -367,7 +367,7 @@ properties:
     data: eyJraW5kIjogIkN1c3RvbVJlc291cmNlRGVmaW5pdGlvbiIsICJhcGlWZXJzaW9uIjogImFwaWV4dGVuc2lvbnMuazhzLmlvL3YxIn0=
 - type: olm.bundle.object
   value:
-    ref: objects/anakin.v0.1.1.csv.yaml
+    data: eyJraW5kIjogIkNsdXN0ZXJTZXJ2aWNlVmVyc2lvbiIsICJhcGlWZXJzaW9uIjogIm9wZXJhdG9ycy5jb3Jlb3MuY29tL3YxYWxwaGExIiwgIm1ldGFkYXRhIjp7Im5hbWUiOiJhbmFraW4udjAuMS4xIn19
 - type: olm.package
   value:
     packageName: anakin
@@ -406,7 +406,7 @@ properties:
     data: eyJraW5kIjogIkN1c3RvbVJlc291cmNlRGVmaW5pdGlvbiIsICJhcGlWZXJzaW9uIjogImFwaWV4dGVuc2lvbnMuazhzLmlvL3YxIn0=
 - type: olm.bundle.object
   value:
-    ref: objects/boba-fett.v1.0.0.csv.yaml
+    data: eyJraW5kIjogIkNsdXN0ZXJTZXJ2aWNlVmVyc2lvbiIsICJhcGlWZXJzaW9uIjogIm9wZXJhdG9ycy5jb3Jlb3MuY29tL3YxYWxwaGExIiwgIm1ldGFkYXRhIjp7Im5hbWUiOiJib2JhLWZldHQudjEuMC4wIn19
 - type: olm.package
   value:
     packageName: boba-fett
@@ -425,7 +425,7 @@ properties:
     data: eyJraW5kIjogIkN1c3RvbVJlc291cmNlRGVmaW5pdGlvbiIsICJhcGlWZXJzaW9uIjogImFwaWV4dGVuc2lvbnMuazhzLmlvL3YxIn0=
 - type: olm.bundle.object
   value:
-    ref: objects/boba-fett.v2.0.0.csv.yaml
+    data: eyJraW5kIjogIkNsdXN0ZXJTZXJ2aWNlVmVyc2lvbiIsICJhcGlWZXJzaW9uIjogIm9wZXJhdG9ycy5jb3Jlb3MuY29tL3YxYWxwaGExIiwgIm1ldGFkYXRhIjp7Im5hbWUiOiJib2JhLWZldHQudjIuMC4wIn19
 - type: olm.package
   value:
     packageName: boba-fett

--- a/alpha/model/model_test.go
+++ b/alpha/model/model_test.go
@@ -478,7 +478,7 @@ func TestValidators(t *testing.T) {
 				Properties: []property.Property{
 					property.MustBuildPackage("anakin", "0.1.0"),
 					property.MustBuildGVK("skywalker.me", "v1alpha1", "PodRacer"),
-					property.MustBuildBundleObjectRef("path/to/data"),
+					property.MustBuildBundleObject([]byte("testdata")),
 				},
 				Objects: []string{"testdata"},
 				CsvJSON: "CSVjson",

--- a/alpha/property/property.go
+++ b/alpha/property/property.go
@@ -5,9 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/fs"
-	"io/ioutil"
-	"path/filepath"
 	"reflect"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -70,7 +67,7 @@ type GVKRequired struct {
 }
 
 type BundleObject struct {
-	File `json:",inline"`
+	Data []byte `json:"data"`
 }
 
 type CSVMetadata struct {
@@ -88,58 +85,6 @@ type CSVMetadata struct {
 	MinKubeVersion            string                             `json:"minKubeVersion,omitempty"`
 	NativeAPIs                []metav1.GroupVersionKind          `json:"nativeAPIs,omitempty"`
 	Provider                  v1alpha1.AppLink                   `json:"provider,omitempty"`
-}
-
-type File struct {
-	ref  string
-	data []byte
-}
-
-type fileJSON struct {
-	Ref  string `json:"ref,omitempty"`
-	Data []byte `json:"data,omitempty"`
-}
-
-func (f *File) UnmarshalJSON(data []byte) error {
-	var t fileJSON
-	if err := json.Unmarshal(data, &t); err != nil {
-		return err
-	}
-	if len(t.Ref) > 0 && len(t.Data) > 0 {
-		return errors.New("fields 'ref' and 'data' are mutually exclusive")
-	}
-	f.ref = t.Ref
-	f.data = t.Data
-	return nil
-}
-
-func (f File) MarshalJSON() ([]byte, error) {
-	return json.Marshal(fileJSON{
-		Ref:  f.ref,
-		Data: f.data,
-	})
-}
-
-func (f File) IsRef() bool {
-	return len(f.ref) > 0
-}
-
-func (f File) GetRef() string {
-	return f.ref
-}
-
-func (f File) GetData(root fs.FS, cwd string) ([]byte, error) {
-	if !f.IsRef() {
-		return f.data, nil
-	}
-	if filepath.IsAbs(f.ref) {
-		return nil, fmt.Errorf("reference must be a relative path")
-	}
-	file, err := root.Open(filepath.Join(cwd, f.ref))
-	if err != nil {
-		return nil, err
-	}
-	return ioutil.ReadAll(file)
 }
 
 type Properties struct {
@@ -308,11 +253,8 @@ func MustBuildGVK(group, version, kind string) Property {
 func MustBuildGVKRequired(group, version, kind string) Property {
 	return MustBuild(&GVKRequired{group, kind, version})
 }
-func MustBuildBundleObjectRef(ref string) Property {
-	return MustBuild(&BundleObject{File: File{ref: ref}})
-}
-func MustBuildBundleObjectData(data []byte) Property {
-	return MustBuild(&BundleObject{File: File{data: data}})
+func MustBuildBundleObject(data []byte) Property {
+	return MustBuild(&BundleObject{Data: data})
 }
 
 func MustBuildCSVMetadata(csv v1alpha1.ClusterServiceVersion) Property {

--- a/cmd/opm/migrate/cmd.go
+++ b/cmd/opm/migrate/cmd.go
@@ -27,9 +27,6 @@ parsers that assume that a file contains exactly one valid JSON object.
 
 ` + sqlite.DeprecationMessage,
 		Args: cobra.ExactArgs(2),
-		PersistentPreRun: func(_ *cobra.Command, _ []string) {
-			sqlite.LogSqliteDeprecation()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			migrate.CatalogRef = args[0]
 			migrate.OutputDir = args[1]

--- a/cmd/opm/render/cmd.go
+++ b/cmd/opm/render/cmd.go
@@ -66,6 +66,7 @@ database files.
 		},
 	}
 	cmd.Flags().StringVarP(&output, "output", "o", "json", "Output format of the streamed file-based catalog objects (json|yaml)")
+	cmd.Flags().BoolVar(&render.Migrate, "migrate", false, "Perform migrations on the rendered FBC")
 	return cmd
 }
 

--- a/pkg/api/api_to_model.go
+++ b/pkg/api/api_to_model.go
@@ -117,7 +117,7 @@ func convertAPIBundleToModelProperties(b *Bundle) ([]property.Property, error) {
 		out = append(out, property.MustBuildCSVMetadata(csv))
 	} else {
 		for _, obj := range b.Object {
-			out = append(out, property.MustBuildBundleObjectData([]byte(obj)))
+			out = append(out, property.MustBuildBundleObject([]byte(obj)))
 		}
 	}
 

--- a/pkg/registry/registry_to_model.go
+++ b/pkg/registry/registry_to_model.go
@@ -108,11 +108,11 @@ func ObjectsAndPropertiesFromBundle(b *Bundle) ([]string, []property.Property, e
 		// Otherwise, make a olm.csv.metadata property if the object is a CSV
 		// (and fallback to olm.bundle.object if parsing the CSV fails).
 		if b.BundleImage == "" {
-			props = append(props, property.MustBuildBundleObjectData(objData))
+			props = append(props, property.MustBuildBundleObject(objData))
 		} else if obj.GetKind() == operators.ClusterServiceVersionKind {
 			var csv v1alpha1.ClusterServiceVersion
 			if err := json.Unmarshal(objData, &csv); err != nil {
-				props = append(props, property.MustBuildBundleObjectData(objData))
+				props = append(props, property.MustBuildBundleObject(objData))
 			} else {
 				props = append(props, property.MustBuildCSVMetadata(csv))
 			}


### PR DESCRIPTION
This commit adds support for migrating FBC to the latest preferred FBC
contents. Note that sqlite and bundle inputs are always rendered using
the latest preferred FBC contents.

The migrate command is updated to now support FBC images and directories
as input (only sqlite was supported prior), such that the written output
will always be migrated.

The render command is updated with a `--migrate` flag that allows a
caller to opt into migration during rendering.

Under the hood, both of these subcommands use the action.Render struct,
which has a new `Migrate` boolean field that callers can use to
enable/disable the migration behavior.

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>

---

This is specifically useful right now to convert existing FBCs using `olm.bundle.object` to use of `olm.csv.metadata`, which can reduce catalog size significantly. At the time of the PR being opened, it reduces the operatorhub catalog from 98M to 23M (~76% reduction in size)


NOTE: This builds upon #1143, which is necessary to align on the tenet that FBC directory structure can change without changing the validity or meaning of the catalog.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
