### PR TITLE
Update api dependency to 0.19.0

### DIFF
--- a/cmd/opm/alpha/bundle/validate.go
+++ b/cmd/opm/alpha/bundle/validate.go
@@ -35,10 +35,13 @@ Optional validators. These validators are disabled by default and can be enabled
  * Operatorhub validator - performs operatorhub.io validation. To validate a bundle using custom categories use with the OPERATOR_BUNDLE_CATEGORIES environmental variable to point to a json-encoded categories file.
  * Bundle objects validator - performs validation on resources like PodDisruptionBudgets and PriorityClasses. 
 
-See https://olm.operatorframework.io/docs/tasks/validate-package/#validation for more info.`,
-		Example: `$ opm alpha bundle validate --tag quay.io/test/test-operator:latest --image-builder docker`,
-		RunE:    validateFunc,
-		Args:    cobra.NoArgs,
+See https://olm.operatorframework.io/docs/tasks/validate-package/#validation for more info.
+
+Note that this subcommand is deprecated and will be removed in a future release. Migrate to operator-sdk bundle validate.`,
+		Example:    `$ opm alpha bundle validate --tag quay.io/test/test-operator:latest --image-builder docker`,
+		RunE:       validateFunc,
+		Args:       cobra.NoArgs,
+		Deprecated: "This subcommand is deprecated and will be removed in a future release. Migrate to operator-sdk bundle validate",
 	}
 
 	bundleValidateCmd.Flags().StringVarP(&tag, "tag", "t", "",

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/onsi/gomega v1.27.7
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b
-	github.com/operator-framework/api v0.18.0
+	github.com/operator-framework/api v0.19.0
 	github.com/otiai10/copy v1.2.0
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -725,8 +725,8 @@ github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mo
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
-github.com/operator-framework/api v0.18.0 h1:6EdSNeAjin4LRu2YQnQWMJMc6HXS0AQDG+CfaEvFrAo=
-github.com/operator-framework/api v0.18.0/go.mod h1:SCCslqke6AVOJ5JM+NqNE1CHuAgJLScsL66pnPaSMXs=
+github.com/operator-framework/api v0.19.0 h1:QU1CTJU+CufoeneA5rsNlP/uP96s8vDHWUYDFZTauzA=
+github.com/operator-framework/api v0.19.0/go.mod h1:SCCslqke6AVOJ5JM+NqNE1CHuAgJLScsL66pnPaSMXs=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=


### PR DESCRIPTION
Bump api dependency.

Since that api change is related to validation types, rather than ingest the validation data this change does the first step of https://github.com/operator-framework/operator-registry/issues/1158 and marks `opm alpha bundle validate` as deprecated.