### PR TITLE
cleanup produced utest/dockerfile artifacts on test conclusion

### DIFF
--- a/pkg/lib/indexer/indexer_test.go
+++ b/pkg/lib/indexer/indexer_test.go
@@ -127,6 +127,7 @@ func TestBuildContext(t *testing.T) {
 			// prevent regression - cleanup should never be nil
 			t.Fatal("buildContext returned nil cleanup function")
 		}
+		defer actualCleanup()
 
 		if testCase.expectedOutDockerfile != nil && actualOutDockerfile != *testCase.expectedOutDockerfile {
 			t.Fatalf("comparing outDockerfile: expected %v actual %v",


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
clean up ephemeral utest artifacts

**Motivation for the change:**

utest runs in this repo generate temp build directories and dockerfiles but the cleanup routines are never run so the repo fills up with (git-ignored) test artifacts.  

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
