### PR TITLE
graph deprecation mermaid visualization update

### DIFF
--- a/alpha/declcfg/write_test.go
+++ b/alpha/declcfg/write_test.go
@@ -526,11 +526,12 @@ func TestWriteMermaidChannels(t *testing.T) {
 			startEdge:     "",
 			packageFilter: "",
 			expected: `graph LR
+  classDef deprecated fill:#E8960F
   %% package "anakin"
   subgraph "anakin"
     %% channel "dark"
     subgraph anakin-dark["dark"]
-      anakin-dark-anakin.v0.0.1["anakin.v0.0.1"]
+      anakin-dark-anakin.v0.0.1["anakin.v0.0.1"]:::deprecated
       anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]
       anakin-dark-anakin.v0.0.1["anakin.v0.0.1"]-- replace --> anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]
       anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]
@@ -539,7 +540,7 @@ func TestWriteMermaidChannels(t *testing.T) {
     end
     %% channel "light"
     subgraph anakin-light["light"]
-      anakin-light-anakin.v0.0.1["anakin.v0.0.1"]
+      anakin-light-anakin.v0.0.1["anakin.v0.0.1"]:::deprecated
       anakin-light-anakin.v0.1.0["anakin.v0.1.0"]
       anakin-light-anakin.v0.0.1["anakin.v0.0.1"]-- replace --> anakin-light-anakin.v0.1.0["anakin.v0.1.0"]
     end
@@ -553,6 +554,8 @@ func TestWriteMermaidChannels(t *testing.T) {
       boba-fett-mando-boba-fett.v1.0.0["boba-fett.v1.0.0"]-- replace --> boba-fett-mando-boba-fett.v2.0.0["boba-fett.v2.0.0"]
     end
   end
+style anakin fill:#989695
+style anakin-light fill:#DCD0FF
 `,
 		},
 		{
@@ -561,6 +564,7 @@ func TestWriteMermaidChannels(t *testing.T) {
 			startEdge:     "anakin.v0.1.0",
 			packageFilter: "",
 			expected: `graph LR
+  classDef deprecated fill:#E8960F
   %% package "anakin"
   subgraph "anakin"
     %% channel "dark"
@@ -574,6 +578,8 @@ func TestWriteMermaidChannels(t *testing.T) {
       anakin-light-anakin.v0.1.0["anakin.v0.1.0"]
     end
   end
+style anakin fill:#989695
+style anakin-light fill:#DCD0FF
 `,
 		},
 		{
@@ -582,6 +588,7 @@ func TestWriteMermaidChannels(t *testing.T) {
 			startEdge:     "",
 			packageFilter: "boba-fett",
 			expected: `graph LR
+  classDef deprecated fill:#E8960F
   %% package "boba-fett"
   subgraph "boba-fett"
     %% channel "mando"


### PR DESCRIPTION
**Description of the change:**
Add colorblind-friendly color indicators for deprecation of each scope (bundle, package and channel)

**Motivation for the change:**
Make it easy to visually identify the deprecated packages, bundles and channels from the mermaid graphs

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

Closes [1160](https://github.com/operator-framework/operator-registry/issues/1160)


Previous mermaid graph output without the color indications for deprecations of each scope: 


<img width="1791" alt="original-mermaid-graph" src="https://github.com/operator-framework/operator-registry/assets/3925702/9883b326-9b64-4445-99b7-2a4f514571c3">


With the changes in this PR, example mermaid graph output showcasing a deprecated channel `kiali-alpha`, bundle `kiali-operator.v1.68.0`, package `kiali`:


<img width="1788" alt="new-mermaid-graph" src="https://github.com/operator-framework/operator-registry/assets/3925702/e2c25083-bc0b-417b-a392-9f9d1d542def">

