### PR TITLE
(bugfix) Update to handle mermaid visualization for deprecation of multiple packages

### DIFF
--- a/alpha/declcfg/write.go
+++ b/alpha/declcfg/write.go
@@ -202,16 +202,12 @@ func (writer *MermaidWriter) WriteChannels(cfg DeclarativeConfig, out io.Writer)
 		out.Write([]byte("  end\n"))
 	}
 
-	if len(deprecatedPackages) > 0 {
-		for _, deprecatedPackage := range deprecatedPackages {
-			out.Write([]byte(fmt.Sprintf("style %s fill:#989695\n", deprecatedPackage)))
-		}
+	for _, deprecatedPackage := range deprecatedPackages {
+		out.Write([]byte(fmt.Sprintf("style %s fill:#989695\n", deprecatedPackage)))
 	}
 
-	if len(deprecatedChannels) > 0 {
-		for _, deprecatedChannel := range deprecatedChannels {
-			out.Write([]byte(fmt.Sprintf("style %s fill:#DCD0FF\n", deprecatedChannel)))
-		}
+	for _, deprecatedChannel := range deprecatedChannels {
+		out.Write([]byte(fmt.Sprintf("style %s fill:#DCD0FF\n", deprecatedChannel)))
 	}
 
 	return nil

--- a/alpha/declcfg/write.go
+++ b/alpha/declcfg/write.go
@@ -123,7 +123,7 @@ func (writer *MermaidWriter) WriteChannels(cfg DeclarativeConfig, out io.Writer)
 		}
 	}
 
-	var deprecatedPackage string
+	deprecatedPackages := []string{}
 	deprecatedChannels := []string{}
 
 	for _, c := range cfg.Channels {
@@ -140,7 +140,7 @@ func (writer *MermaidWriter) WriteChannels(cfg DeclarativeConfig, out io.Writer)
 			pkgBuilder.WriteString(fmt.Sprintf("    subgraph %s[%q]\n", channelID, filteredChannel.Name))
 
 			if depByPackage.Has(filteredChannel.Package) {
-				deprecatedPackage = filteredChannel.Package
+				deprecatedPackages = append(deprecatedPackages, filteredChannel.Package)
 			}
 
 			if depByChannel.Has(filteredChannel.Name) {
@@ -202,8 +202,10 @@ func (writer *MermaidWriter) WriteChannels(cfg DeclarativeConfig, out io.Writer)
 		out.Write([]byte("  end\n"))
 	}
 
-	if deprecatedPackage != "" {
-		out.Write([]byte(fmt.Sprintf("style %s fill:#989695\n", deprecatedPackage)))
+	if len(deprecatedPackages) > 0 {
+		for _, deprecatedPackage := range deprecatedPackages {
+			out.Write([]byte(fmt.Sprintf("style %s fill:#989695\n", deprecatedPackage)))
+		}
 	}
 
 	if len(deprecatedChannels) > 0 {


### PR DESCRIPTION
[PR](https://github.com/operator-framework/operator-registry/pull/1172) to add colorblind-friendly color indicators for deprecation of each scope (bundle, package and channel) was merged last week. Based on this [review comment](https://github.com/operator-framework/operator-registry/pull/1172#discussion_r1423996999), previously merged PR presumes that we will only ever have at most one deprecated package.  This PR fixes that by handling the case of a declarative config includes multiple deprecated packages.