### PR TITLE
use composite template's contributions path as fallback search for template inputs

### DIFF
--- a/alpha/template/composite/builder_test.go
+++ b/alpha/template/composite/builder_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -208,6 +209,38 @@ func TestBasicBuilder(t *testing.T) {
 				require.Equal(t,
 					buildErr.Error(),
 					"basic template configuration is invalid: basic template config must have a non-empty input (templateDefinition.config.input),basic template config must have a non-empty output (templateDefinition.config.output)")
+			},
+		},
+		{
+			name:     "successful basic build yaml output using contribution cwd to find inputs",
+			validate: true,
+			basicBuilder: NewBasicBuilder(BuilderConfig{
+				WorkingDir:       testDir,
+				OutputType:       "yaml",
+				ContributionPath: filepath.Join(testDir, "components"),
+			}),
+			templateDefinition: TemplateDefinition{
+				Schema: BasicBuilderSchema,
+				Config: []byte(fmt.Sprintf(validConfigTemplate, "basic.yaml", "catalog.yaml")),
+			},
+			files: map[string]string{
+				"components/basic.yaml": basicYaml,
+			},
+			buildAssertions: func(t *testing.T, dir string, buildErr error) {
+				require.NoError(t, buildErr)
+				// check if the catalog.yaml file exists in the correct place
+				filePath := path.Join(dir, "catalog.yaml")
+				_, err := os.Stat(filePath)
+				require.NoError(t, err)
+				file, err := os.Open(filePath)
+				require.NoError(t, err)
+				defer file.Close()
+				fileData, err := io.ReadAll(file)
+				require.NoError(t, err)
+				require.Equal(t, string(fileData), basicBuiltFbcYaml)
+			},
+			validateAssertions: func(t *testing.T, validateErr error) {
+				require.NoError(t, validateErr)
 			},
 		},
 	}
@@ -671,6 +704,38 @@ func TestSemverBuilder(t *testing.T) {
 					"semver template configuration is invalid: semver template config must have a non-empty input (templateDefinition.config.input),semver template config must have a non-empty output (templateDefinition.config.output)",
 					buildErr.Error(),
 				)
+			},
+		},
+		{
+			name:     "successful semver build json output using contribution cwd to find inputs",
+			validate: true,
+			semverBuilder: NewSemverBuilder(BuilderConfig{
+				WorkingDir:       testDir,
+				OutputType:       "json",
+				ContributionPath: filepath.Join(testDir, "components"),
+			}),
+			templateDefinition: TemplateDefinition{
+				Schema: SemverBuilderSchema,
+				Config: []byte(fmt.Sprintf(validConfigTemplate, "semver.yaml", "catalog.json")),
+			},
+			files: map[string]string{
+				"components/semver.yaml": semverYaml,
+			},
+			buildAssertions: func(t *testing.T, dir string, buildErr error) {
+				require.NoError(t, buildErr)
+				// check if the catalog.yaml file exists in the correct place
+				filePath := path.Join(dir, "catalog.json")
+				_, err := os.Stat(filePath)
+				require.NoError(t, err)
+				file, err := os.Open(filePath)
+				require.NoError(t, err)
+				defer file.Close()
+				fileData, err := io.ReadAll(file)
+				require.NoError(t, err)
+				require.Equal(t, semverBuiltFbcJson, string(fileData))
+			},
+			validateAssertions: func(t *testing.T, validateErr error) {
+				require.NoError(t, validateErr)
 			},
 		},
 	}
@@ -1142,6 +1207,38 @@ func TestRawBuilder(t *testing.T) {
 				require.Equal(t,
 					buildErr.Error(),
 					"raw template configuration is invalid: raw template config must have a non-empty input (templateDefinition.config.input),raw template config must have a non-empty output (templateDefinition.config.output)")
+			},
+		},
+		{
+			name:     "successful raw build json output using contribution cwd to find inputs",
+			validate: true,
+			rawBuilder: NewRawBuilder(BuilderConfig{
+				WorkingDir:       testDir,
+				OutputType:       "json",
+				ContributionPath: filepath.Join(testDir, "components"),
+			}),
+			templateDefinition: TemplateDefinition{
+				Schema: RawBuilderSchema,
+				Config: []byte(fmt.Sprintf(validConfigTemplate, "raw.yaml", "catalog.json")),
+			},
+			files: map[string]string{
+				"components/raw.yaml": rawYaml,
+			},
+			buildAssertions: func(t *testing.T, dir string, buildErr error) {
+				require.NoError(t, buildErr)
+				// check if the catalog.yaml file exists in the correct place
+				filePath := path.Join(dir, "catalog.json")
+				_, err := os.Stat(filePath)
+				require.NoError(t, err)
+				file, err := os.Open(filePath)
+				require.NoError(t, err)
+				defer file.Close()
+				fileData, err := io.ReadAll(file)
+				require.NoError(t, err)
+				require.Equal(t, string(fileData), rawBuiltFbcJson)
+			},
+			validateAssertions: func(t *testing.T, validateErr error) {
+				require.NoError(t, validateErr)
 			},
 		},
 	}

--- a/alpha/template/composite/composite.go
+++ b/alpha/template/composite/composite.go
@@ -19,9 +19,10 @@ func WithCatalogFile(catalogFile io.Reader) TemplateOption {
 	}
 }
 
-func WithContributionFile(contribFile io.Reader) TemplateOption {
+func WithContributionFile(contribFile io.Reader, contribPath string) TemplateOption {
 	return func(t *Template) {
 		t.contributionFile = contribFile
+		t.contributionPath = contribPath
 	}
 }
 
@@ -230,8 +231,9 @@ func (t *Template) newCatalogBuilderMap(catalogs []Catalog, outputType string) (
 			builderMap := make(BuilderMap)
 			for _, schema := range catalog.Builders {
 				builder, err := t.builderForSchema(schema, BuilderConfig{
-					WorkingDir: catalog.Destination.WorkingDir,
-					OutputType: outputType,
+					WorkingDir:       catalog.Destination.WorkingDir,
+					OutputType:       outputType,
+					ContributionPath: t.contributionPath,
 				})
 				if err != nil {
 					return nil, fmt.Errorf("getting builder %q for catalog %q: %v", schema, catalog.Name, err)

--- a/alpha/template/composite/composite_test.go
+++ b/alpha/template/composite/composite_test.go
@@ -436,7 +436,7 @@ func TestParseContributionSpec(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			template := NewTemplate(WithContributionFile(strings.NewReader(tc.composite)))
+			template := NewTemplate(WithContributionFile(strings.NewReader(tc.composite), ""))
 			contrib, err := template.parseContributionSpec()
 			tc.assertions(t, contrib, err)
 		})

--- a/alpha/template/composite/types.go
+++ b/alpha/template/composite/types.go
@@ -43,6 +43,7 @@ type builderFunc func(BuilderConfig) Builder
 type Template struct {
 	catalogFile        io.Reader
 	contributionFile   io.Reader
+	contributionPath   string
 	validate           bool
 	outputType         string
 	registry           image.Registry

--- a/cmd/opm/alpha/template/composite.go
+++ b/cmd/opm/alpha/template/composite.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -49,6 +50,11 @@ and a 'composite template' file`,
 			}
 			defer compositeReader.Close()
 
+			compositePath, err := filepath.Abs(filepath.Dir(compositeFile))
+			if err != nil {
+				log.Fatalf("getting absolute path of composite config file %q: %v", compositeFile, err)
+			}
+
 			// catalog maintainer's 'catalogs.yaml' file
 			tempCatalog, err := composite.FetchCatalogConfig(catalogFile, http.DefaultClient)
 			if err != nil {
@@ -58,7 +64,7 @@ and a 'composite template' file`,
 
 			template := composite.NewTemplate(
 				composite.WithCatalogFile(tempCatalog),
-				composite.WithContributionFile(compositeReader),
+				composite.WithContributionFile(compositeReader, compositePath),
 				composite.WithOutputType(output),
 				composite.WithRegistry(reg),
 			)


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

since using the composite template means the union of requirements from two parties, it can be confusing sometimes to understand the context of resource references.  

For example, in the contribution schema `olm.composite` there are references to input filesystem elements in `Components[].Strategy.Template.Config.Input` ([ref](https://github.com/operator-framework/operator-registry/blob/4c69b4af4437039212dd83fbe049fa30efb0b2cc/alpha/template/composite/types.go#L22-L23)) but these may be relative or absolute references.  And if relative... then relative to what?  

This PR attempts to address this by fallback searching for input references relative to the cwd of the contribution file (if driven by CLI) or the `Components[].Strategy.Template.Config.ContributionPath` (if provided). 

For example, given a contribution of the format
```yaml
schema: olm.composite
components:
  - name: catalog-of-wonders
    destination:
      path: my-operator
    strategy:
      name: semver
      template:
        schema: olm.builder.semver
        config:
          input: semver-catalog-template.yaml
          output: catalog.yaml
```

the template expansion will look for `semver-catalog-template.yaml` in the CWD of the executed command.  But if the file is actually in a `catalog-data` subdirectory but the command is executed in the parent, then it won't be solved, for e.g. 
```tree
catalog-data
├── basic-catalog-template.yaml
└── contributions.yaml
```

The catalogs.yaml file which fulfills the `olm.composite.catalogs` spec may be local or remote, so it is unsuitable as a search location, but the `olm.composite` source is always local, which allows us to infer a possible anchor point for relative references. 

In case a naiive access attempt for the specified contribution input file fails, we use the resulting anchor in a fallback attempt to resolve input references.


**Motivation for the change:**

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage 
- [x] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
