### PR TITLE
Add verify (tidy/lint) target

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -20,5 +20,5 @@ jobs:
           go-version-file: "go.mod"
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports@latest
-      - name: Run sanity checks
-        run: make lint && git diff --exit-code
+      - name: Run verify checks
+        run: make verify

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,15 @@ static: build
 unit:
 	$(GO) test -coverprofile=coverage.out $(SPECIFIC_UNIT_TEST) $(SPECIFIC_SKIP_UNIT_TEST) $(TAGS) $(TEST_RACE) -count=1 ./pkg/... ./alpha/...
 
+.PHONY: tidy
+tidy:
+	go mod tidy
+	go mod verify
+
+.PHONY: verify
+verify: tidy lint
+	git diff --exit-code
+
 .PHONY: sanity-check
 sanity-check:
 	# Build a container with the most recent binaries for this project.


### PR DESCRIPTION
Added a verify target, to which other checks can be added. Added lint and tidy to the verify target.
This will be used during github workflows/CI to make sure everything is "tidied".
Updated the `sanity` check to use this verify target.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
