### PR TITLE
pkg/cache: set explicit mode to handle upcoming go1.22 defaulting in fstest.MapFS

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -215,6 +215,9 @@ func genTestCaches(t *testing.T, fbcFS fs.FS) []Cache {
 }
 
 var validFS = fstest.MapFS{
+	".": &fstest.MapFile{
+		Mode: fs.ModeDir,
+	},
 	"cockroachdb.json": &fstest.MapFile{
 		Data: []byte(`{
     "schema": "olm.package",


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Add a directory entry for "." in the `validFS` with permissions explicitly zero'd.

**Motivation for the change:**
This is a pre-emptive change that we should make prior to bumping `opm` to go1.22, because in go1.22 `fstest.MapFS` now [sets `0555` permissions on synthesized directories](https://cs.opensource.google/go/go/+/09aada24aa156e0f754688487088badd969caad8).

This aligns with the existing assumptions and ensures that our expected digest remains stable.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
