### PR TITLE
providing a constraint property constant for dependency consistency

### DIFF
--- a/alpha/property/property.go
+++ b/alpha/property/property.go
@@ -106,6 +106,7 @@ const (
 	TypeGVKRequired     = "olm.gvk.required"
 	TypeBundleObject    = "olm.bundle.object"
 	TypeCSVMetadata     = "olm.csv.metadata"
+	TypeConstraint      = "olm.constraint"
 	TypeChannel         = "olm.channel"
 )
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
add a convenience type for `olm.constraint` family of dependencies for consistent approach to dependency detection


**Motivation for the change:**
working in pursuit of https://github.com/operator-framework/operator-controller/issues/779 identified that there are not constant types to represent all the dependency types in one place.  This should help make https://github.com/operator-framework/operator-controller/pull/781 cleaner.

They are currently divided across
1. [alpha/property/property.go](https://github.com/operator-framework/operator-registry/blob/master/alpha/property/property.go#L102-L110) (for package/gvk); and
2. [pkg/registry/types.go](https://github.com/operator-framework/operator-registry/blob/master/pkg/registry/types.go#L59) (for constraint)

This appears to be for a few reasons:
1. operator-registry doesn't enforce/convert olm.constraint; it's deferred until olm's resolver
2. operator-lifecycle-manager uses bare "olm.constraint" strings instead of using a const type
3. in [alpha/property/property.go Parse()](https://github.com/operator-framework/operator-registry/blob/master/alpha/property/property.go#L161-L166) this property passes as opaque `json.RawMessage` type via the default case since it has no dedicated storage type in this context. 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
