### PR TITLE
enforce rfc1123 label compatibility for olm.package.name

### DIFF
--- a/alpha/declcfg/declcfg_to_model.go
+++ b/alpha/declcfg/declcfg_to_model.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/blang/semver/v4"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/operator-framework/operator-registry/alpha/model"
 	"github.com/operator-framework/operator-registry/alpha/property"
@@ -20,6 +21,10 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 
 		if _, ok := mpkgs[p.Name]; ok {
 			return nil, fmt.Errorf("duplicate package %q", p.Name)
+		}
+
+		if errs := validation.IsDNS1123Label(p.Name); len(errs) > 0 {
+			return nil, fmt.Errorf("invalid package name %q: %v", p.Name, errs)
 		}
 
 		mpkg := &model.Package{

--- a/alpha/declcfg/declcfg_to_model_test.go
+++ b/alpha/declcfg/declcfg_to_model_test.go
@@ -216,6 +216,17 @@ func TestConvertToModel(t *testing.T) {
 			},
 		},
 		{
+			name:      "Error/PackageBreaksRFC1123",
+			assertion: hasError(`invalid package name "foo.bar": [must not contain dots]`),
+			cfg: DeclarativeConfig{
+				Packages: []Package{
+					newTestPackage("foo.bar", "alpha", svgSmallCircle),
+				},
+				Channels: []Channel{newTestChannel("foo", "alpha", ChannelEntry{Name: "foo.v0.1.0"})},
+				Bundles:  []Bundle{newTestBundle("foo", "0.1.0")},
+			},
+		},
+		{
 			name:      "Error/DuplicateChannel",
 			assertion: hasError(`package "foo" has duplicate channel "alpha"`),
 			cfg: DeclarativeConfig{


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**
in the interest of facilitating package name uniqueness with FBC catalogs, it's in our best interests to have the key attribute able to satisfy the requirements of `metadata.name` which some storage requires.  There is already prior art which prevents compliance with the more stringent RFC1035 (https://dev.operatorhub.io/operator/3scale-community-operator) but there is no currently published operator in public catalogs which fails RFC1123 label compliance in `olm.package.name`, so this PR would make that a requirement going forward.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
