### PR TITLE
generate binary-less dockerfiles

### DIFF
--- a/alpha/action/generate_dockerfile.go
+++ b/alpha/action/generate_dockerfile.go
@@ -9,11 +9,11 @@ import (
 )
 
 type GenerateDockerfile struct {
-	BaseImage   string
-	IndexDir    string
-	ExtraLabels map[string]string
-	Writer      io.Writer
-	Lite        bool
+	BaseImage    string
+	BuilderImage string
+	IndexDir     string
+	ExtraLabels  map[string]string
+	Writer       io.Writer
 }
 
 func (i GenerateDockerfile) Run() error {
@@ -21,14 +21,7 @@ func (i GenerateDockerfile) Run() error {
 		return err
 	}
 
-	var dockerfileTemplate string
-	if i.Lite {
-		dockerfileTemplate = binlessDockerfileTmpl
-	} else {
-		dockerfileTemplate = dockerfileTmpl
-	}
-
-	t, err := template.New("dockerfile").Parse(dockerfileTemplate)
+	t, err := template.New("dockerfile").Parse(dockerfileTmpl)
 	if err != nil {
 		// The template is hardcoded in the binary, so if
 		// there is a parse error, it was a programmer error.
@@ -47,44 +40,36 @@ func (i GenerateDockerfile) validate() error {
 	return nil
 }
 
-const binlessDockerfileTmpl = `# The builder image is expected to contain
+const dockerfileTmpl = `# The builder image is expected to contain
 # /bin/opm (with serve subcommand)
-FROM {{.BaseImage}} as builder
+FROM {{.BuilderImage}} as builder
 
 # Copy FBC root into image at /configs and pre-populate serve cache
 ADD {{.IndexDir}} /configs
 RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
 
-FROM scratch
+FROM {{.BaseImage}}
+
+{{- if ne .BaseImage "scratch" }}
+# The base image is expected to contain
+# /bin/opm (with serve subcommand) and /bin/grpc_health_probe
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+{{- else }}
+# OLMv0 CatalogSources that use binary-less images must set:
+# spec:
+#   grpcPodConfig:
+#     extractContent:
+#       catalogDir: /configs
+#       cacheDir: /tmp/cache
+{{- end }}
 
 COPY --from=builder /configs /configs
 COPY --from=builder /tmp/cache /tmp/cache
 
 # Set FBC-specific label for the location of the FBC root directory
-# in the image
-LABEL ` + containertools.ConfigsLocationLabel + `=/configs
-{{- if .ExtraLabels }}
-
-# Set other custom labels
-{{- range $key, $value := .ExtraLabels }}
-LABEL "{{ $key }}"="{{ $value }}"
-{{- end }}
-{{- end }}
-`
-
-const dockerfileTmpl = `# The base image is expected to contain
-# /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM {{.BaseImage}}
-
-# Configure the entrypoint and command
-ENTRYPOINT ["/bin/opm"]
-CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
-
-# Copy declarative config root into image at /configs and pre-populate serve cache
-ADD {{.IndexDir}} /configs
-RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
-
-# Set DC-specific label for the location of the DC root directory
 # in the image
 LABEL ` + containertools.ConfigsLocationLabel + `=/configs
 {{- if .ExtraLabels }}

--- a/alpha/action/generate_dockerfile_test.go
+++ b/alpha/action/generate_dockerfile_test.go
@@ -41,88 +41,9 @@ func TestGenerateDockerfile(t *testing.T) {
 		{
 			name: "Success/WithoutExtraLabels",
 			gen: GenerateDockerfile{
-				BaseImage: "foo",
-				IndexDir:  "bar",
-			},
-			expectedDockerfile: `# The base image is expected to contain
-# /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM foo
-
-# Configure the entrypoint and command
-ENTRYPOINT ["/bin/opm"]
-CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
-
-# Copy declarative config root into image at /configs and pre-populate serve cache
-ADD bar /configs
-RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
-
-# Set DC-specific label for the location of the DC root directory
-# in the image
-LABEL operators.operatorframework.io.index.configs.v1=/configs
-`,
-		},
-		{
-			name: "Success/WithExtraLabels",
-			gen: GenerateDockerfile{
-				BaseImage: "foo",
-				IndexDir:  "bar",
-				ExtraLabels: map[string]string{
-					"key1": "value1",
-					"key2": "value2",
-				},
-			},
-			expectedDockerfile: `# The base image is expected to contain
-# /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM foo
-
-# Configure the entrypoint and command
-ENTRYPOINT ["/bin/opm"]
-CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
-
-# Copy declarative config root into image at /configs and pre-populate serve cache
-ADD bar /configs
-RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
-
-# Set DC-specific label for the location of the DC root directory
-# in the image
-LABEL operators.operatorframework.io.index.configs.v1=/configs
-
-# Set other custom labels
-LABEL "key1"="value1"
-LABEL "key2"="value2"
-`,
-		},
-
-		{
-			name: "Lite/Fail/EmptyBaseImage",
-			gen: GenerateDockerfile{
-				IndexDir: "bar",
-				ExtraLabels: map[string]string{
-					"key1": "value1",
-					"key2": "value2",
-				},
-				Lite: true,
-			},
-			expectedErr: "base image is unset",
-		},
-		{
-			name: "Lite/Fail/EmptyFromDir",
-			gen: GenerateDockerfile{
-				BaseImage: "foo",
-				ExtraLabels: map[string]string{
-					"key1": "value1",
-					"key2": "value2",
-				},
-				Lite: true,
-			},
-			expectedErr: "index directory is unset",
-		},
-		{
-			name: "Lite/Success/WithoutExtraLabels",
-			gen: GenerateDockerfile{
-				BaseImage: "foo",
-				IndexDir:  "bar",
-				Lite:      true,
+				BuilderImage: "foo",
+				BaseImage:    "foo",
+				IndexDir:     "bar",
 			},
 			expectedDockerfile: `# The builder image is expected to contain
 # /bin/opm (with serve subcommand)
@@ -132,7 +53,13 @@ FROM foo as builder
 ADD bar /configs
 RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
 
-FROM scratch
+FROM foo
+# The base image is expected to contain
+# /bin/opm (with serve subcommand) and /bin/grpc_health_probe
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
 
 COPY --from=builder /configs /configs
 COPY --from=builder /tmp/cache /tmp/cache
@@ -143,15 +70,75 @@ LABEL operators.operatorframework.io.index.configs.v1=/configs
 `,
 		},
 		{
-			name: "Lite/Success/WithExtraLabels",
+			name: "Success/WithExtraLabels",
 			gen: GenerateDockerfile{
-				BaseImage: "foo",
-				IndexDir:  "bar",
+				BuilderImage: "foo",
+				BaseImage:    "foo",
+				IndexDir:     "bar",
 				ExtraLabels: map[string]string{
 					"key1": "value1",
 					"key2": "value2",
 				},
-				Lite: true,
+			},
+			expectedDockerfile: `# The builder image is expected to contain
+# /bin/opm (with serve subcommand)
+FROM foo as builder
+
+# Copy FBC root into image at /configs and pre-populate serve cache
+ADD bar /configs
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+FROM foo
+# The base image is expected to contain
+# /bin/opm (with serve subcommand) and /bin/grpc_health_probe
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+
+COPY --from=builder /configs /configs
+COPY --from=builder /tmp/cache /tmp/cache
+
+# Set FBC-specific label for the location of the FBC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs
+
+# Set other custom labels
+LABEL "key1"="value1"
+LABEL "key2"="value2"
+`,
+		},
+
+		{
+			name: "Scratch/Fail/EmptyBaseImage",
+			gen: GenerateDockerfile{
+				BuilderImage: "foo",
+				IndexDir:     "bar",
+				ExtraLabels: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			expectedErr: "base image is unset",
+		},
+		{
+			name: "Scratch/Fail/EmptyFromDir",
+			gen: GenerateDockerfile{
+				BuilderImage: "foo",
+				BaseImage:    "scratch",
+				ExtraLabels: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			expectedErr: "index directory is unset",
+		},
+		{
+			name: "Scratch/Success/WithoutExtraLabels",
+			gen: GenerateDockerfile{
+				BuilderImage: "foo",
+				BaseImage:    "scratch",
+				IndexDir:     "bar",
 			},
 			expectedDockerfile: `# The builder image is expected to contain
 # /bin/opm (with serve subcommand)
@@ -162,6 +149,47 @@ ADD bar /configs
 RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
 
 FROM scratch
+# OLMv0 CatalogSources that use binary-less images must set:
+# spec:
+#   grpcPodConfig:
+#     extractContent:
+#       catalogDir: /configs
+#       cacheDir: /tmp/cache
+
+COPY --from=builder /configs /configs
+COPY --from=builder /tmp/cache /tmp/cache
+
+# Set FBC-specific label for the location of the FBC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs
+`,
+		},
+		{
+			name: "Scratch/Success/WithExtraLabels",
+			gen: GenerateDockerfile{
+				BuilderImage: "foo",
+				BaseImage:    "scratch",
+				IndexDir:     "bar",
+				ExtraLabels: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			expectedDockerfile: `# The builder image is expected to contain
+# /bin/opm (with serve subcommand)
+FROM foo as builder
+
+# Copy FBC root into image at /configs and pre-populate serve cache
+ADD bar /configs
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+FROM scratch
+# OLMv0 CatalogSources that use binary-less images must set:
+# spec:
+#   grpcPodConfig:
+#     extractContent:
+#       catalogDir: /configs
+#       cacheDir: /tmp/cache
 
 COPY --from=builder /configs /configs
 COPY --from=builder /tmp/cache /tmp/cache

--- a/alpha/action/generate_dockerfile_test.go
+++ b/alpha/action/generate_dockerfile_test.go
@@ -92,6 +92,89 @@ LABEL "key1"="value1"
 LABEL "key2"="value2"
 `,
 		},
+
+		{
+			name: "Lite/Fail/EmptyBaseImage",
+			gen: GenerateDockerfile{
+				IndexDir: "bar",
+				ExtraLabels: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+				Lite: true,
+			},
+			expectedErr: "base image is unset",
+		},
+		{
+			name: "Lite/Fail/EmptyFromDir",
+			gen: GenerateDockerfile{
+				BaseImage: "foo",
+				ExtraLabels: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+				Lite: true,
+			},
+			expectedErr: "index directory is unset",
+		},
+		{
+			name: "Lite/Success/WithoutExtraLabels",
+			gen: GenerateDockerfile{
+				BaseImage: "foo",
+				IndexDir:  "bar",
+				Lite:      true,
+			},
+			expectedDockerfile: `# The builder image is expected to contain
+# /bin/opm (with serve subcommand)
+FROM foo as builder
+
+# Copy FBC root into image at /configs and pre-populate serve cache
+ADD bar /configs
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+FROM scratch
+
+COPY --from=builder /configs /configs
+COPY --from=builder /tmp/cache /tmp/cache
+
+# Set FBC-specific label for the location of the FBC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs
+`,
+		},
+		{
+			name: "Lite/Success/WithExtraLabels",
+			gen: GenerateDockerfile{
+				BaseImage: "foo",
+				IndexDir:  "bar",
+				ExtraLabels: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+				Lite: true,
+			},
+			expectedDockerfile: `# The builder image is expected to contain
+# /bin/opm (with serve subcommand)
+FROM foo as builder
+
+# Copy FBC root into image at /configs and pre-populate serve cache
+ADD bar /configs
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+FROM scratch
+
+COPY --from=builder /configs /configs
+COPY --from=builder /tmp/cache /tmp/cache
+
+# Set FBC-specific label for the location of the FBC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs
+
+# Set other custom labels
+LABEL "key1"="value1"
+LABEL "key2"="value2"
+`,
+		},
 	}
 
 	for _, s := range specs {

--- a/cmd/opm/generate/cmd.go
+++ b/cmd/opm/generate/cmd.go
@@ -29,6 +29,7 @@ func newDockerfileCmd() *cobra.Command {
 	var (
 		baseImage      string
 		extraLabelStrs []string
+		lite           bool
 	)
 	cmd := &cobra.Command{
 		Use:   "dockerfile <dcRootDir>",
@@ -75,6 +76,7 @@ value of each duplicate key will be added to the generated Dockerfile.
 				IndexDir:    indexName,
 				ExtraLabels: extraLabels,
 				Writer:      f,
+				Lite:        lite,
 			}
 			if err := gen.Run(); err != nil {
 				log.Fatal(err)
@@ -83,6 +85,7 @@ value of each duplicate key will be added to the generated Dockerfile.
 		},
 	}
 	cmd.Flags().StringVarP(&baseImage, "binary-image", "i", containertools.DefaultBinarySourceImage, "Image in which to build catalog.")
+	cmd.Flags().BoolVarP(&lite, "lite", "t", false, "Generate a smaller, binary-less Dockerfile.")
 	cmd.Flags().StringSliceVarP(&extraLabelStrs, "extra-labels", "l", []string{}, "Extra labels to include in the generated Dockerfile. Labels should be of the form 'key=value'.")
 	return cmd
 }

--- a/cmd/opm/generate/cmd.go
+++ b/cmd/opm/generate/cmd.go
@@ -17,7 +17,7 @@ import (
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "generate",
-		Short: "Generate various artifacts for declarative config indexes",
+		Short: "Generate various artifacts for file-based catalogs",
 	}
 	cmd.AddCommand(
 		newDockerfileCmd(),
@@ -28,24 +28,35 @@ func NewCmd() *cobra.Command {
 func newDockerfileCmd() *cobra.Command {
 	var (
 		baseImage      string
+		builderImage   string
 		extraLabelStrs []string
-		lite           bool
 	)
 	cmd := &cobra.Command{
-		Use:   "dockerfile <dcRootDir>",
+		Use:   "dockerfile <fbcRootDir>",
 		Args:  cobra.ExactArgs(1),
-		Short: "Generate a Dockerfile for a declarative config index",
-		Long: `Generate a Dockerfile for a declarative config index.
+		Short: "Generate a Dockerfile for a file-based catalog",
+		Long: `Generate a Dockerfile for a file-based catalog.
 
-This command creates a Dockerfile in the same directory as the <dcRootDir>
-(named <dcDirName>.Dockerfile) that can be used to build the index. If a
+This command creates a Dockerfile in the same directory as the <fbcRootDir>
+(named <fbcRootDir>.Dockerfile) that can be used to build the index. If a
 Dockerfile with the same name already exists, this command will fail.
 
 When specifying extra labels, note that if duplicate keys exist, only the last
 value of each duplicate key will be added to the generated Dockerfile.
+
+A separate builder and base image can be specified. The builder image may not be "scratch".
 `,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(inCmd *cobra.Command, args []string) error {
 			fromDir := filepath.Clean(args[0])
+
+			if builderImage == "scratch" {
+				return fmt.Errorf("invalid builder image: %q", builderImage)
+			}
+
+			// preserving old behavior, if binary-image is set but not builder-image, set builder-image to binary-image
+			if inCmd.Flags().Changed("binary-image") && !inCmd.Flags().Changed("builder-image") {
+				builderImage = baseImage
+			}
 
 			extraLabels, err := parseLabels(extraLabelStrs)
 			if err != nil {
@@ -72,11 +83,11 @@ value of each duplicate key will be added to the generated Dockerfile.
 			defer f.Close()
 
 			gen := action.GenerateDockerfile{
-				BaseImage:   baseImage,
-				IndexDir:    indexName,
-				ExtraLabels: extraLabels,
-				Writer:      f,
-				Lite:        lite,
+				BaseImage:    baseImage,
+				BuilderImage: builderImage,
+				IndexDir:     indexName,
+				ExtraLabels:  extraLabels,
+				Writer:       f,
 			}
 			if err := gen.Run(); err != nil {
 				log.Fatal(err)
@@ -84,9 +95,12 @@ value of each duplicate key will be added to the generated Dockerfile.
 			return nil
 		},
 	}
-	cmd.Flags().StringVarP(&baseImage, "binary-image", "i", containertools.DefaultBinarySourceImage, "Image in which to build catalog.")
-	cmd.Flags().BoolVarP(&lite, "lite", "t", false, "Generate a smaller, binary-less Dockerfile.")
+	cmd.Flags().StringVar(&baseImage, "binary-image", containertools.DefaultBinarySourceImage, "Image in which to build catalog.")
+	cmd.Flags().StringVarP(&baseImage, "base-image", "i", containertools.DefaultBinarySourceImage, "Image base to use to build catalog.")
+	cmd.Flags().StringVarP(&builderImage, "builder-image", "b", containertools.DefaultBinarySourceImage, "Image to use as a build stage.")
 	cmd.Flags().StringSliceVarP(&extraLabelStrs, "extra-labels", "l", []string{}, "Extra labels to include in the generated Dockerfile. Labels should be of the form 'key=value'.")
+	cmd.Flags().MarkDeprecated("binary-image", "use --base-image instead")
+	cmd.MarkFlagsMutuallyExclusive("binary-image", "base-image")
 	return cmd
 }
 

--- a/ohio.Dockerfile
+++ b/ohio.Dockerfile
@@ -1,6 +1,0 @@
-FROM quay.io/operatorhubio/catalog:latest
-
-COPY opm /bin/opm
-
-ENTRYPOINT ["/bin/opm"]
-CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
provide the capability for `opm generate dockerfiles` to generate Dockerfiles which build a binary-less catalog image based on scratch.  

We expose a new `builder-image` flag, allowing users to specify a new image to be used as a builder in the multi-stage dockerfile generated.  This may not be `scratch`. 
`builder-image` and `binary-image` flags both default to `quay.io/operator-framework/opm:latest`
In order to generate a binary-less catalog image dockerfile, users just need to specify `binary-image` of `scratch`. 

***Users who previously set `binary-image` may need to check if they need to also specify `builder-image` to preserve existing behavior***

**Motivation for the change:**
binary-less catalogs can be built on scratch to make tiny, platform-less catalog sources which can leverage the `.spec.grpcPodConfig.extractContent` fields to allow for on-cluster unpacking.


**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
