### PR TITLE
model: validate unique bundle versions

### DIFF
--- a/alpha/declcfg/helpers_test.go
+++ b/alpha/declcfg/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -244,6 +245,7 @@ func getBundle(pkg *model.Package, ch *model.Channel, version, replaces string, 
 			getCSVJson(pkg.Name, version),
 			getCRDJSON(),
 		},
+		Version: semver.MustParse(version),
 	}
 }
 

--- a/alpha/model/model_test.go
+++ b/alpha/model/model_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -257,6 +258,25 @@ func TestValidators(t *testing.T) {
 				Icon: &Icon{Data: mustBase64Decode(svgData), MediaType: "image/svg+xml"},
 			},
 			assertion: hasError("package must contain at least one channel"),
+		},
+		{
+			name: "Package/Error/DuplicateBundleVersions",
+			v: &Package{
+				Name: "anakin",
+				Channels: map[string]*Channel{
+					"light": {
+						Package: pkg,
+						Name:    "light",
+						Bundles: map[string]*Bundle{
+							"anakin.v0.0.1": {Name: "anakin.v0.0.1", Version: semver.MustParse("0.0.1")},
+							"anakin.v0.0.2": {Name: "anakin.v0.0.2", Version: semver.MustParse("0.0.1")},
+							"anakin.v1.0.1": {Name: "anakin.v1.0.1", Version: semver.MustParse("1.0.1")},
+							"anakin.v1.0.2": {Name: "anakin.v1.0.2", Version: semver.MustParse("1.0.1")},
+						},
+					},
+				},
+			},
+			assertion: hasError(`duplicate versions found in bundles: [{0.0.1: [anakin.v0.0.1, anakin.v0.0.2]} {1.0.1: [anakin.v1.0.1, anakin.v1.0.2]}]`),
 		},
 		{
 			name: "Package/Error/NoDefaultChannel",
@@ -612,6 +632,7 @@ func makePackageChannelBundle() (*Package, *Channel) {
 			property.MustBuildPackage("anakin", "0.0.1"),
 			property.MustBuildGVK("skywalker.me", "v1alpha1", "PodRacer"),
 		},
+		Version: semver.MustParse("0.0.1"),
 	}
 	bundle2 := &Bundle{
 		Name:     "anakin.v0.0.2",
@@ -621,6 +642,7 @@ func makePackageChannelBundle() (*Package, *Channel) {
 			property.MustBuildPackage("anakin", "0.0.2"),
 			property.MustBuildGVK("skywalker.me", "v1alpha1", "PodRacer"),
 		},
+		Version: semver.MustParse("0.0.2"),
 	}
 	ch := &Channel{
 		Name: "light",

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/tidwall/btree v1.7.0
 	go.etcd.io/bbolt v1.3.10
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/mod v0.20.0
 	golang.org/x/net v0.28.0
 	golang.org/x/sync v0.8.0
@@ -174,7 +175,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.1.0 // indirect
 	golang.org/x/crypto v0.26.0 // indirect
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/oauth2 v0.22.0 // indirect
 	golang.org/x/term v0.23.0 // indirect
 	golang.org/x/time v0.5.0 // indirect

--- a/pkg/api/api_to_model.go
+++ b/pkg/api/api_to_model.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/blang/semver/v4"
+
 	"github.com/operator-framework/operator-registry/alpha/model"
 	"github.com/operator-framework/operator-registry/alpha/property"
 )
@@ -20,6 +22,11 @@ func ConvertAPIBundleToModelBundle(b *Bundle) (*model.Bundle, error) {
 		return nil, fmt.Errorf("get related iamges: %v", err)
 	}
 
+	vers, err := semver.Parse(b.Version)
+	if err != nil {
+		return nil, fmt.Errorf("parse version %q: %v", b.Version, err)
+	}
+
 	return &model.Bundle{
 		Name:          b.CsvName,
 		Image:         b.BundlePath,
@@ -30,6 +37,7 @@ func ConvertAPIBundleToModelBundle(b *Bundle) (*model.Bundle, error) {
 		Objects:       b.Object,
 		Properties:    bundleProps,
 		RelatedImages: relatedImages,
+		Version:       vers,
 	}, nil
 }
 

--- a/pkg/api/conversion_test.go
+++ b/pkg/api/conversion_test.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 
 	"github.com/operator-framework/operator-registry/alpha/model"
 	"github.com/operator-framework/operator-registry/alpha/property"
@@ -77,6 +79,7 @@ func testModelBundle(t *testing.T) model.Bundle {
 				Image: "quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b",
 			},
 		},
+		Version: semver.MustParse("0.9.4"),
 	}
 	return b
 }


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Validate that bundles within a package use unique semver versions.

**Motivation for the change:**
This has always been assumed. Now we are explicitly checking.

I verified that the operatorhubio catalog and all of Red Hat's catalogs for OCP 4.15 and 4.16 continue to pass with this new validation.

Are there any other catalogs that should be checked?

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
