### PR TITLE
template/*: allow passing custom bundle renderer

### DIFF
--- a/alpha/action/list_test.go
+++ b/alpha/action/list_test.go
@@ -28,7 +28,7 @@ foo   Foo Operator  beta
 		{
 			name:        "Error/UnknownIndex",
 			list:        ListPackages{IndexReference: "unknown-index"},
-			expectedErr: `render reference "unknown-index": repository name must be canonical`,
+			expectedErr: `render reference "unknown-index": failed to pull image "unknown-index": repository name must be canonical`,
 		},
 	}
 	for _, s := range specs {
@@ -79,7 +79,7 @@ foo      stable   foo.v0.2.0
 		{
 			name:        "Error/UnknownIndex",
 			list:        ListChannels{IndexReference: "unknown-index"},
-			expectedErr: `render reference "unknown-index": repository name must be canonical`,
+			expectedErr: `render reference "unknown-index": failed to pull image "unknown-index": repository name must be canonical`,
 		},
 		{
 			name:        "Error/UnknownPackage",
@@ -138,7 +138,7 @@ foo      stable   foo.v0.2.0  foo.v0.1.0  foo.v0.1.1,foo.v0.1.2  <0.2.0      tes
 		{
 			name:        "Error/UnknownIndex",
 			list:        ListBundles{IndexReference: "unknown-index"},
-			expectedErr: `render reference "unknown-index": repository name must be canonical`,
+			expectedErr: `render reference "unknown-index": failed to pull image "unknown-index": repository name must be canonical`,
 		},
 		{
 			name:        "Error/UnknownPackage",

--- a/alpha/action/render.go
+++ b/alpha/action/render.go
@@ -162,19 +162,19 @@ func (r Render) renderReference(ctx context.Context, ref string) (*declcfg.Decla
 func (r Render) imageToDeclcfg(ctx context.Context, imageRef string) (*declcfg.DeclarativeConfig, error) {
 	ref := image.SimpleReference(imageRef)
 	if err := r.Registry.Pull(ctx, ref); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to pull image %q: %v", ref, err)
 	}
 	labels, err := r.Registry.Labels(ctx, ref)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get labels for image %q: %v", ref, err)
 	}
 	tmpDir, err := os.MkdirTemp("", "render-unpack-")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("create tempdir: %v", err)
 	}
 	defer os.RemoveAll(tmpDir)
 	if err := r.Registry.Unpack(ctx, ref, tmpDir); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unpack image %q: %v", ref, err)
 	}
 
 	var cfg *declcfg.DeclarativeConfig

--- a/alpha/template/semver/semver_test.go
+++ b/alpha/template/semver/semver_test.go
@@ -538,7 +538,7 @@ func TestGetVersionsFromStandardChannel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			iosv := tt.sv
-			versions, err := iosv.getVersionsFromStandardChannels(&tt.dc)
+			versions, err := iosv.getVersionsFromStandardChannels(&tt.dc, buildBundleList(tt.sv))
 			require.NoError(t, err)
 			require.EqualValues(t, tt.outVersions, *versions)
 			require.EqualValues(t, "a", iosv.pkg) // verify that we learned the package name and stashed it in the receiver
@@ -591,7 +591,7 @@ func TestBailOnVersionBuildMetadata(t *testing.T) {
 	}
 
 	t.Run("Abort on unorderable build metadata version data", func(t *testing.T) {
-		_, err := sv.getVersionsFromStandardChannels(&dc)
+		_, err := sv.getVersionsFromStandardChannels(&dc, buildBundleList(sv))
 		require.Error(t, err)
 	})
 }

--- a/alpha/template/semver/types.go
+++ b/alpha/template/semver/types.go
@@ -1,19 +1,18 @@
 package semver
 
 import (
+	"context"
 	"io"
 
 	"github.com/blang/semver/v4"
 
-	"github.com/operator-framework/operator-registry/alpha/action/migrations"
-	"github.com/operator-framework/operator-registry/pkg/image"
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
 )
 
 // data passed into this module externally
 type Template struct {
-	Data       io.Reader
-	Registry   image.Registry
-	Migrations *migrations.Migrations
+	Data         io.Reader
+	RenderBundle func(context.Context, string) (*declcfg.DeclarativeConfig, error)
 }
 
 // IO structs -- BEGIN


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Make the template rendering libraries accept a bundle renderer function.

**Motivation for the change:**
This allows importers of operator-registry to provide custom rendering logic for bundle references that appear in template configuration files.

This would enable third-parties to build experimental bundle transport formats and continue using the standard operator-registry template tooling with them.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
