### PR TITLE
pkg/cache: configurable backend preference

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -222,9 +222,11 @@ func TestCache_ListPackages(t *testing.T) {
 func genTestCaches(t *testing.T, fbcFS fs.FS) map[string]Cache {
 	t.Helper()
 
-	caches := map[string]Cache{
-		"json":      &cache{backend: newJSONBackend(t.TempDir()), log: log.Null()},
-		"pogreb.v1": &cache{backend: newPogrebV1Backend(t.TempDir()), log: log.Null()},
+	caches := make(map[string]Cache)
+	for _, format := range []string{FormatJSON, FormatPogrebV1} {
+		c, err := New(t.TempDir(), WithFormat(format), WithLog(log.Null()))
+		require.NoError(t, err)
+		caches[format] = c
 	}
 
 	for _, c := range caches {

--- a/pkg/cache/json.go
+++ b/pkg/cache/json.go
@@ -40,8 +40,10 @@ type jsonBackend struct {
 	bundles bundleKeys
 }
 
+const FormatJSON = "json"
+
 func (q *jsonBackend) Name() string {
-	return "json"
+	return FormatJSON
 }
 
 func (q *jsonBackend) IsCachePresent() bool {

--- a/pkg/cache/pogrebv1.go
+++ b/pkg/cache/pogrebv1.go
@@ -31,10 +31,12 @@ func newPogrebV1Backend(baseDir string) *pogrebV1Backend {
 }
 
 const (
+	FormatPogrebV1 = "pogreb.v1"
+
 	pogrebV1CacheModeDir  = 0770
 	pogrebV1CacheModeFile = 0660
 
-	pograbV1CacheDir = "pogreb.v1"
+	pograbV1CacheDir = FormatPogrebV1
 	pogrebDigestFile = pograbV1CacheDir + "/digest"
 	pogrebDbDir      = pograbV1CacheDir + "/db"
 )
@@ -46,7 +48,7 @@ type pogrebV1Backend struct {
 }
 
 func (q *pogrebV1Backend) Name() string {
-	return pograbV1CacheDir
+	return FormatPogrebV1
 }
 
 func (q *pogrebV1Backend) IsCachePresent() bool {


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Update the FBC cache library to accept a preferred backend.

NOTE: this does not (yet) change `opm serve` to expose this configuration knob in the CLI.

**Motivation for the change:**
Allow importers of `operator-registry` to construct a cache with a specific backend. This is a necessary step to enable catalog mutator tools to be able to use the input catalog's cache format when it writes the output catalog.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
