### PR TITLE
:seedling: Bump ghcr.io/grpc-ecosystem/grpc-health-probe docker tag to v0.4.29

### DIFF
--- a/release/goreleaser.opm.Dockerfile
+++ b/release/goreleaser.opm.Dockerfile
@@ -2,7 +2,7 @@
 #   build opm images. See the configurations in .goreleaser.yaml
 #   and .github/workflows/release.yaml.
 
-FROM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.28 as grpc_health_probe
+FROM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.29 as grpc_health_probe
 FROM gcr.io/distroless/static:debug
 COPY --from=grpc_health_probe /ko-app/grpc-health-probe /bin/grpc_health_probe
 COPY ["nsswitch.conf", "/etc/nsswitch.conf"]


### PR DESCRIPTION
**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
