### PR TITLE
set default goal since bingo disrupts it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ export GIT_COMMIT := $(or $(SOURCE_GIT_COMMIT),$(shell git rev-parse --short HEA
 export OPM_VERSION := $(or $(SOURCE_GIT_TAG),$(shell git describe --always --tags HEAD))
 export BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 
+.DEFAULT_GOAL := all
+
 # bingo manages consistent tooling versions for things like kind, kustomize, etc.
 include .bingo/Variables.mk
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
set a default goal of `all` for the Makefile

**Motivation for the change:**
since https://github.com/operator-framework/operator-registry/commit/7a1b8ec63f4bd6d88d9b9380fd812a7d6ec0097c the `all` goal is no longer the first (and therefore default-by-default) goal.  This explicitly makes it the default target again.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
