### PR TITLE
Fix upstream-builder image build

### DIFF
--- a/upstream-builder.Dockerfile
+++ b/upstream-builder.Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.23-alpine as builder
 
-RUN apk update && apk add sqlite build-base git mercurial bash
+RUN apk update && apk add sqlite build-base git mercurial bash linux-headers
 WORKDIR /build
 
 COPY . .


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This PR adds the installation of the `linux-headers` package in the upstream-builder image to fix the build error-`linux/limits.h: No such file or directory`

**Motivation for the change:**

This PR fixes #1466 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

