### PR TITLE
Address goreleaser deprecations

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -61,7 +61,7 @@ jobs:
         run: make release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_ARGS: release --rm-dist -f release/goreleaser.windows.yaml --skip-validate ${{ github.event_name == 'pull_request' && '--snapshot' || '' }}
+          RELEASE_ARGS: release --skip=validate --clean -f release/goreleaser.windows.yaml ${{ github.event_name == 'pull_request' && '--snapshot' || '' }}
 
       - run: tar -cvf dist-windows.tar dist
       - uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ export LATEST_IMAGE_OR_EMPTY := $(shell \
 	&& [ "$(shell echo -e "$(OPM_VERSION)\n$(LATEST_TAG)" | sort -rV | head -n1)" == "$(OPM_VERSION)" ] \
 	&& echo "$(OPM_IMAGE_REPO):latest" || echo "")
 RELEASE_GOOS := $(shell go env GOOS)
-RELEASE_ARGS ?= release --rm-dist --snapshot -f release/goreleaser.$(RELEASE_GOOS).yaml
+RELEASE_ARGS ?= release --clean --snapshot -f release/goreleaser.$(RELEASE_GOOS).yaml
 
 # Note: bingo does not yet support windows (https://github.com/bwplotka/bingo/issues/26)
 # so GOOS=windows gets its own way to install goreleaser


### PR DESCRIPTION
**Description of the change:**

Address goreleaser deprecations:

```
  • DEPRECATED: --skip-validate was deprecated in favor of --skip=validate, check https://goreleaser.com/deprecations#-skip for more details
  • DEPRECATED: --rm-dist was deprecated in favor of --clean, check https://goreleaser.com/deprecations#-rm-dist for more details
  • skipping announce, publish and validate...
```



**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
