### PR TITLE
add macos codesigning of opm binary for apple silicon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,10 @@ $(CMDS):
 $(OPM): opm_version_flags=-ldflags "-X '$(PKG)/cmd/opm/version.gitCommit=$(GIT_COMMIT)' -X '$(PKG)/cmd/opm/version.opmVersion=$(OPM_VERSION)' -X '$(PKG)/cmd/opm/version.buildDate=$(BUILD_DATE)'"
 $(OPM):
 	$(extra_env) $(GO) build $(opm_version_flags) $(extra_flags) $(TAGS) -o $@ ./cmd/$(notdir $@)
+ifeq ($(shell go env GOARCH),arm64)
+	codesign --sign - --force --preserve-metadata=entitlements,requirements,flags,runtime $(OPM)
+endif
+
 
 .PHONY: build
 build: clean $(CMDS) $(OPM)


### PR DESCRIPTION
Due to apple's requirement that all apple silicon apps must be signed, the app make targets here will not be able to be executed unless they are signed in macos sequoia and later.

For example, if this generates the `opm` binary at $HOME/devel/operator-registry/bin/opm and we invoke it, without being signed the result will be `Killed: 9` messages for each attempted invocation of the compiled unsigned app, for e.g.:

```sh
╰$ ./bin/opm --help
[1]    14243 killed     ./bin/opm --help
```

This is a completely naive approach to rectifying this, and we probably need some more thought on the subject, but this approach at least lets me execute locally-built binaries to examine catalog content.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
