### PR TITLE
provide an optional base image flag for generated dockerfiles from alpha bundle build commands

### DIFF
--- a/cmd/opm/alpha/bundle/build.go
+++ b/cmd/opm/alpha/bundle/build.go
@@ -15,6 +15,7 @@ var (
 	defaultChannel string
 	outputDir      string
 	overwrite      bool
+	baseImage      string
 )
 
 // newBundleBuildCmd returns a command that will build operator bundle image.
@@ -76,6 +77,9 @@ Note:
 	bundleBuildCmd.Flags().StringVarP(&outputDir, "output-dir", "u", "",
 		"Optional output directory for operator manifests")
 
+	bundleBuildCmd.Flags().StringVar(&baseImage, "base-image", "scratch",
+		"Use a custom image pullspec as the base bundle image")
+
 	return bundleBuildCmd
 }
 
@@ -89,5 +93,6 @@ func buildFunc(cmd *cobra.Command, _ []string) error {
 		channels,
 		defaultChannel,
 		overwrite,
+		baseImage,
 	)
 }

--- a/cmd/opm/alpha/bundle/generate.go
+++ b/cmd/opm/alpha/bundle/generate.go
@@ -45,6 +45,7 @@ Note:
 	bundleGenerateCmd.Flags().StringVarP(&outputDir, "output-dir", "u", "",
 		"Optional output directory for operator manifests")
 
+	bundleGenerateCmd.Flags().StringVar(&baseImage, "base-image", "scratch", "Use a custom image pullspec as the base bundle image")
 	return bundleGenerateCmd
 }
 
@@ -56,5 +57,6 @@ func generateFunc(cmd *cobra.Command, _ []string) error {
 		channels,
 		defaultChannel,
 		true,
+		baseImage,
 	)
 }

--- a/pkg/lib/bundle/build.go
+++ b/pkg/lib/bundle/build.go
@@ -51,14 +51,14 @@ func ExecuteCommand(cmd *exec.Cmd) error {
 // @channelDefault: The default channel for the bundle image
 // @overwrite: Boolean flag to enable overwriting annotations.yaml locally if existed
 func BuildFunc(directory, outputDir, imageTag, imageBuilder, packageName, channels, channelDefault string,
-	overwrite bool) error {
+	overwrite bool, baseImage string) error {
 	_, err := os.Stat(directory)
 	if os.IsNotExist(err) {
 		return err
 	}
 
 	// Generate annotations.yaml and Dockerfile
-	err = GenerateFunc(directory, outputDir, packageName, channels, channelDefault, overwrite)
+	err = GenerateFunc(directory, outputDir, packageName, channels, channelDefault, overwrite, baseImage)
 	if err != nil {
 		return err
 	}

--- a/pkg/lib/bundle/generate.go
+++ b/pkg/lib/bundle/generate.go
@@ -46,7 +46,7 @@ type AnnotationMetadata struct {
 // @channels: The list of channels that bundle image belongs to
 // @channelDefault: The default channel for the bundle image
 // @overwrite: Boolean flag to enable overwriting annotations.yaml locally if existed
-func GenerateFunc(directory, outputDir, packageName, channels, channelDefault string, overwrite bool) error {
+func GenerateFunc(directory, outputDir, packageName, channels, channelDefault string, overwrite bool, baseImage string) error {
 	// clean the input so that we know the absolute paths of input directories
 	directory, err := filepath.Abs(directory)
 	if err != nil {
@@ -132,7 +132,7 @@ func GenerateFunc(directory, outputDir, packageName, channels, channelDefault st
 	log.Info("Building Dockerfile")
 
 	// Generate Dockerfile
-	content, err = GenerateDockerfile(mediaType, ManifestsDir, MetadataDir, outManifestDir, outMetadataDir, workingDir, packageName, channels, channelDefault)
+	content, err = GenerateDockerfile(mediaType, ManifestsDir, MetadataDir, outManifestDir, outMetadataDir, workingDir, packageName, channels, channelDefault, baseImage)
 	if err != nil {
 		return err
 	}
@@ -319,7 +319,7 @@ func GenerateAnnotations(mediaType, manifests, metadata, packageName, channels, 
 // GenerateDockerfile builds Dockerfile with mediatype, manifests &
 // metadata directories in bundle image, package name, channels and default
 // channels information in LABEL section.
-func GenerateDockerfile(mediaType, manifests, metadata, copyManifestDir, copyMetadataDir, workingDir, packageName, channels, channelDefault string) ([]byte, error) {
+func GenerateDockerfile(mediaType, manifests, metadata, copyManifestDir, copyMetadataDir, workingDir, packageName, channels, channelDefault string, baseImage string) ([]byte, error) {
 	var fileContent string
 
 	relativeManifestDirectory, err := filepath.Rel(workingDir, copyManifestDir)
@@ -335,7 +335,7 @@ func GenerateDockerfile(mediaType, manifests, metadata, copyManifestDir, copyMet
 	relativeMetadataDirectory = filepath.ToSlash(relativeMetadataDirectory)
 
 	// FROM
-	fileContent += "FROM scratch\n\n"
+	fileContent += fmt.Sprintf("FROM %s\n\n", baseImage)
 
 	// LABEL
 	fileContent += fmt.Sprintf("LABEL %s=%s\n", MediatypeLabel, mediaType)

--- a/test/e2e/opm_test.go
+++ b/test/e2e/opm_test.go
@@ -284,7 +284,7 @@ var _ = Describe("opm", func() {
 			By("building bundle")
 			img := bundleImage + ":" + bundleTag3
 			err := inTemporaryBuildContext(func() error {
-				return bundle.BuildFunc(bundlePath3, "", img, containerTool, packageName, channels, defaultChannel, false)
+				return bundle.BuildFunc(bundlePath3, "", img, containerTool, packageName, channels, defaultChannel, false, "scratch")
 			}, "../../manifests", "manifests")
 			Expect(err).NotTo(HaveOccurred())
 
@@ -329,7 +329,7 @@ var _ = Describe("opm", func() {
 			var err error
 			for _, b := range bundles {
 				err = inTemporaryBuildContext(func() error {
-					return bundle.BuildFunc(b.path, "", b.image, containerTool, packageName, channels, defaultChannel, false)
+					return bundle.BuildFunc(b.path, "", b.image, containerTool, packageName, channels, defaultChannel, false, "scratch")
 				}, "../../manifests", "manifests")
 				Expect(err).NotTo(HaveOccurred())
 			}
@@ -423,7 +423,7 @@ var _ = Describe("opm", func() {
 				Expect(err).NotTo(HaveOccurred())
 				defer os.RemoveAll(td)
 
-				err = bundle.BuildFunc(b.path, td, b.image, containerTool, "", "", "", true)
+				err = bundle.BuildFunc(b.path, td, b.image, containerTool, "", "", "", true, "scratch")
 				Expect(err).NotTo(HaveOccurred())
 			}
 
@@ -459,7 +459,7 @@ var _ = Describe("opm", func() {
 				Expect(err).NotTo(HaveOccurred())
 				defer os.RemoveAll(td)
 
-				err = bundle.BuildFunc(b.path, td, b.image, containerTool, "", "", "", true)
+				err = bundle.BuildFunc(b.path, td, b.image, containerTool, "", "", "", true, "scratch")
 				Expect(err).NotTo(HaveOccurred())
 			}
 


### PR DESCRIPTION


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This PR adds an optional "base-image" flag to `opm alpha bundle generate`.  This results in some breaking changes for possible clients which now must pass a new parameter `"scratch"` to produce previous behavior. 

**Motivation for the change:**
Some clients prefer to use base images other than `scratch`.  This is the lightest-touch approach I could use to provide this. 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
