### PR TITLE
bump to go1.23.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/operator-framework/operator-registry
 
-go 1.23.0
-
-toolchain go1.23.4
+go 1.23.5
 
 require (
 	github.com/akrylysov/pogreb v0.10.2


### PR DESCRIPTION
**Description of the change:**

bump to go1.23.5 to address CVE-2024-45336

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
