### PR TITLE
:seedling: Group k8s and golang.org/x dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      k8s-dependencies:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      golang-x-deps:
+        patterns:
+          - "golang.org/x/*"
   - package-exosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
**Description of the change:**
Reduce number of dependabot PRs by grouping k8s and golang.org/x deps

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
