### PR TITLE
:bug: Fixup go-verdiff job

### DIFF
--- a/.github/workflows/go-verdiff.yaml
+++ b/.github/workflows/go-verdiff.yaml
@@ -5,7 +5,7 @@ on:
       - '**.mod'
       - '.github/workflows/go-verdiff.yaml'
     branches:
-      - main
+      - master
 jobs:
   go-verdiff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Description of the change:**

Fixes go-verdiff action configuration to point to the master branch

