### PR TITLE
containers/image: remove signatures when copying in to OCI layout

### DIFF
--- a/pkg/image/containersimageregistry/registry.go
+++ b/pkg/image/containersimageregistry/registry.go
@@ -161,6 +161,13 @@ func (r *Registry) Pull(ctx context.Context, ref orimage.Reference) error {
 		SourceCtx:                             sourceCtx,
 		DestinationCtx:                        r.cache.getSystemContext(),
 		OptimizeDestinationImageAlreadyExists: true,
+
+		// We use the OCI layout as a temporary storage and
+		// pushing signatures for OCI images is not supported
+		// so we remove the source signatures when copying.
+		// Signature validation will still be performed
+		// accordingly to a provided policy context.
+		RemoveSignatures: true,
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
This does not affect signature validation, and we do not need to preserve signatures _after_ validation because we will never need to propagate those signatures to another image transport/destination.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

When using the containers/image registry client implementation, remove signatures when copying in to OCI layout

**Motivation for the change:**

The OCI layout destination does not support copying signatures. This causes a bug (render/migrate fail) when using a policy that requires signature validation.

This change does not affect signature validation, and we do not need to preserve signatures _after_ validation because we will never need to propagate those signatures to another image transport/destination.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
