### PR TITLE
WIP: FBC data model migrations

### DIFF
--- a/alpha/action/init.go
+++ b/alpha/action/init.go
@@ -43,7 +43,7 @@ func (i Init) Run() (*declcfg.Package, error) {
 		if iconType.MIME.Type != "image" {
 			return nil, fmt.Errorf("detected invalid type %q: not an image", iconType.MIME.Value)
 		}
-		pkg.Icon = &declcfg.Icon{
+		pkg.Icon = &declcfg.PackageIcon{
 			Data:      iconData,
 			MediaType: iconType.MIME.Value,
 		}

--- a/alpha/action/migrations/001_split_icon.go
+++ b/alpha/action/migrations/001_split_icon.go
@@ -1,0 +1,29 @@
+package migrations
+
+import (
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+)
+
+func splitIcon(cfg *declcfg.DeclarativeConfig) error {
+	splitIconFromPackage := func(p *declcfg.Package) error {
+		if p.Icon == nil {
+			return nil
+		}
+
+		cfg.Icons = append(cfg.Icons, declcfg.Icon{
+			Schema:    declcfg.SchemaIcon,
+			Package:   p.Name,
+			MediaType: p.Icon.MediaType,
+			Data:      p.Icon.Data,
+		})
+		p.Icon = nil
+		return nil
+	}
+
+	for i := range cfg.Packages {
+		if err := splitIconFromPackage(&cfg.Packages[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/alpha/action/migrations/002_promote_bundle_version.go
+++ b/alpha/action/migrations/002_promote_bundle_version.go
@@ -1,0 +1,44 @@
+package migrations
+
+import (
+	"encoding/json"
+	"slices"
+
+	"github.com/Masterminds/semver/v3"
+
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+	"github.com/operator-framework/operator-registry/alpha/property"
+)
+
+func promoteBundleVersion(cfg *declcfg.DeclarativeConfig) error {
+	promoteVersion := func(b *declcfg.Bundle) error {
+		// Promote the version from the olm.package property to the bundle field.
+		for _, p := range b.Properties {
+			if p.Type != property.TypePackage {
+				continue
+			}
+			var pkg property.Package
+			if err := json.Unmarshal(p.Value, &pkg); err != nil {
+				return err
+			}
+			version, err := semver.StrictNewVersion(pkg.Version)
+			if err != nil {
+				return err
+			}
+			b.Version = version
+		}
+
+		// Delete the olm.package properties
+		b.Properties = slices.DeleteFunc(b.Properties, func(p property.Property) bool {
+			return p.Type == property.TypePackage
+		})
+		return nil
+	}
+
+	for i := range cfg.Bundles {
+		if err := promoteVersion(&cfg.Bundles[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/alpha/action/migrations/003_promote_package_metadata.go
+++ b/alpha/action/migrations/003_promote_package_metadata.go
@@ -1,0 +1,109 @@
+package migrations
+
+import (
+	"encoding/json"
+
+	"github.com/Masterminds/semver/v3"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+	"github.com/operator-framework/operator-registry/alpha/property"
+)
+
+func promotePackageMetadata(cfg *declcfg.DeclarativeConfig) error {
+	metadataByPackage := map[string]promotedMetadata{}
+	for i := range cfg.Bundles {
+		b := &cfg.Bundles[i]
+
+		csvMetadata, csvMetadataIdx, err := getCsvMetadata(b)
+		if err != nil {
+			return err
+		}
+		if csvMetadata == nil {
+			continue
+		}
+
+		cur, ok := metadataByPackage[b.Package]
+		if !ok || compareRegistryV1Semver(cur.version, b.Version) < 0 {
+			metadataByPackage[b.Package] = promotedCSVMetadata(b.Version, csvMetadata)
+		}
+
+		csvMetadata.DisplayName = ""
+		delete(csvMetadata.Annotations, "description")
+		csvMetadata.Provider = v1alpha1.AppLink{}
+		csvMetadata.Maintainers = nil
+		csvMetadata.Links = nil
+		csvMetadata.Keywords = nil
+
+		newCSVMetadata, err := json.Marshal(csvMetadata)
+		if err != nil {
+			return err
+		}
+		b.Properties[csvMetadataIdx] = property.Property{
+			Type:  property.TypeCSVMetadata,
+			Value: newCSVMetadata,
+		}
+	}
+
+	for i := range cfg.Packages {
+		pkg := &cfg.Packages[i]
+		metadata, ok := metadataByPackage[pkg.Name]
+		if !ok {
+			continue
+		}
+		pkg.DisplayName = metadata.displayName
+		pkg.ShortDescription = metadata.shortDescription
+		pkg.Provider = metadata.provider
+		pkg.Maintainers = metadata.maintainers
+		pkg.Links = metadata.links
+		pkg.Keywords = metadata.keywords
+	}
+	return nil
+}
+
+func getCsvMetadata(b *declcfg.Bundle) (*property.CSVMetadata, int, error) {
+	for i, p := range b.Properties {
+		if p.Type != property.TypeCSVMetadata {
+			continue
+		}
+		var csvMetadata property.CSVMetadata
+		if err := json.Unmarshal(p.Value, &csvMetadata); err != nil {
+			return nil, -1, err
+		}
+		return &csvMetadata, i, nil
+	}
+	return nil, -1, nil
+}
+
+func compareRegistryV1Semver(a, b *semver.Version) int {
+	if v := a.Compare(b); v != 0 {
+		return v
+	}
+	aPre := semver.New(0, 0, 0, a.Metadata(), "")
+	bPre := semver.New(0, 0, 0, b.Metadata(), "")
+	return aPre.Compare(bPre)
+}
+
+type promotedMetadata struct {
+	version *semver.Version
+
+	displayName      string
+	shortDescription string
+	provider         v1alpha1.AppLink
+	maintainers      []v1alpha1.Maintainer
+	links            []v1alpha1.AppLink
+	keywords         []string
+}
+
+func promotedCSVMetadata(version *semver.Version, metadata *property.CSVMetadata) promotedMetadata {
+	return promotedMetadata{
+		version:          version,
+		displayName:      metadata.DisplayName,
+		shortDescription: metadata.Annotations["description"],
+		provider:         metadata.Provider,
+		maintainers:      metadata.Maintainers,
+		links:            metadata.Links,
+		keywords:         metadata.Keywords,
+	}
+}

--- a/alpha/action/migrations/migrations.go
+++ b/alpha/action/migrations/migrations.go
@@ -54,6 +54,7 @@ type Migrations struct {
 var allMigrations = []Migration{
 	newMigration(NoMigrations, "do nothing", func(_ *declcfg.DeclarativeConfig) error { return nil }),
 	newMigration("bundle-object-to-csv-metadata", `migrates bundles' "olm.bundle.object" to "olm.csv.metadata"`, bundleObjectToCSVMetadata),
+	newMigration("split-icon", `split package icon out into separate "olm.icon" blob`, splitIcon),
 }
 
 func NewMigrations(name string) (*Migrations, error) {

--- a/alpha/action/migrations/migrations.go
+++ b/alpha/action/migrations/migrations.go
@@ -56,6 +56,7 @@ var allMigrations = []Migration{
 	newMigration("bundle-object-to-csv-metadata", `migrates bundles' "olm.bundle.object" to "olm.csv.metadata"`, bundleObjectToCSVMetadata),
 	newMigration("split-icon", `split package icon out into separate "olm.icon" blob`, splitIcon),
 	newMigration("promote-bundle-version", `promote bundle version into first-class bundle field, remove olm.package properties`, promoteBundleVersion),
+	newMigration("promote-package-metadata", `promote package metadata from "olm.csv.metadata" properties to "olm.package" blob`, promotePackageMetadata),
 }
 
 func NewMigrations(name string) (*Migrations, error) {

--- a/alpha/action/migrations/migrations.go
+++ b/alpha/action/migrations/migrations.go
@@ -55,6 +55,7 @@ var allMigrations = []Migration{
 	newMigration(NoMigrations, "do nothing", func(_ *declcfg.DeclarativeConfig) error { return nil }),
 	newMigration("bundle-object-to-csv-metadata", `migrates bundles' "olm.bundle.object" to "olm.csv.metadata"`, bundleObjectToCSVMetadata),
 	newMigration("split-icon", `split package icon out into separate "olm.icon" blob`, splitIcon),
+	newMigration("promote-bundle-version", `promote bundle version into first-class bundle field, remove olm.package properties`, promoteBundleVersion),
 }
 
 func NewMigrations(name string) (*Migrations, error) {

--- a/alpha/declcfg/declcfg.go
+++ b/alpha/declcfg/declcfg.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/Masterminds/semver/v3"
 	"golang.org/x/text/cases"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -90,8 +91,9 @@ type ChannelEntry struct {
 //     evaluation in bundlesEqual().
 type Bundle struct {
 	Schema        string              `json:"schema"`
-	Name          string              `json:"name,omitempty"`
-	Package       string              `json:"package,omitempty"`
+	Name          string              `json:"name"`
+	Package       string              `json:"package"`
+	Version       *semver.Version     `json:"version,omitempty"`
 	Image         string              `json:"image"`
 	Properties    []property.Property `json:"properties,omitempty" hash:"set"`
 	RelatedImages []RelatedImage      `json:"relatedImages,omitempty" hash:"set"`

--- a/alpha/declcfg/declcfg.go
+++ b/alpha/declcfg/declcfg.go
@@ -11,6 +11,8 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+
 	"github.com/operator-framework/operator-registry/alpha/property"
 	prettyunmarshaler "github.com/operator-framework/operator-registry/pkg/prettyunmarshaler"
 )
@@ -36,12 +38,12 @@ type Package struct {
 	Schema string `json:"schema"`
 	Name   string `json:"name"`
 
-	//DisplayName      string                `json:"displayName,omitempty"`
-	//ShortDescription string                `json:"shortDescription,omitempty"`
-	//Provider         v1alpha1.AppLink      `json:"provider,omitempty"`
-	//Maintainers      []v1alpha1.Maintainer `json:"maintainers,omitempty"`
-	//Links            []v1alpha1.AppLink    `json:"links,omitempty"`
-	//Keywords         []string              `json:"keywords,omitempty"`
+	DisplayName      string                `json:"displayName,omitempty"`
+	ShortDescription string                `json:"shortDescription,omitempty"`
+	Provider         v1alpha1.AppLink      `json:"provider,omitempty"`
+	Maintainers      []v1alpha1.Maintainer `json:"maintainers,omitempty"`
+	Links            []v1alpha1.AppLink    `json:"links,omitempty"`
+	Keywords         []string              `json:"keywords,omitempty"`
 
 	DefaultChannel string              `json:"defaultChannel"`
 	Description    string              `json:"description,omitempty"`

--- a/alpha/declcfg/declcfg.go
+++ b/alpha/declcfg/declcfg.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	SchemaPackage     = "olm.package"
+	SchemaIcon        = "olm.icon"
 	SchemaChannel     = "olm.channel"
 	SchemaBundle      = "olm.bundle"
 	SchemaDeprecation = "olm.deprecations"
@@ -23,6 +24,7 @@ const (
 
 type DeclarativeConfig struct {
 	Packages     []Package
+	Icons        []Icon
 	Channels     []Channel
 	Bundles      []Bundle
 	Deprecations []Deprecation
@@ -30,15 +32,34 @@ type DeclarativeConfig struct {
 }
 
 type Package struct {
-	Schema         string              `json:"schema"`
-	Name           string              `json:"name"`
+	Schema string `json:"schema"`
+	Name   string `json:"name"`
+
+	//DisplayName      string                `json:"displayName,omitempty"`
+	//ShortDescription string                `json:"shortDescription,omitempty"`
+	//Provider         v1alpha1.AppLink      `json:"provider,omitempty"`
+	//Maintainers      []v1alpha1.Maintainer `json:"maintainers,omitempty"`
+	//Links            []v1alpha1.AppLink    `json:"links,omitempty"`
+	//Keywords         []string              `json:"keywords,omitempty"`
+
 	DefaultChannel string              `json:"defaultChannel"`
-	Icon           *Icon               `json:"icon,omitempty"`
 	Description    string              `json:"description,omitempty"`
 	Properties     []property.Property `json:"properties,omitempty" hash:"set"`
+
+	// Deprecated: It is no longer recommended to embed an icon in the package.
+	//   Instead, use separate a Icon item alongside the Package.
+	Icon *PackageIcon `json:"icon,omitempty"`
 }
 
 type Icon struct {
+	Schema  string `json:"schema"`
+	Package string `json:"package"`
+
+	MediaType string `json:"mediaType"`
+	Data      []byte `json:"data"`
+}
+
+type PackageIcon struct {
 	Data      []byte `json:"base64data"`
 	MediaType string `json:"mediatype"`
 }
@@ -201,6 +222,7 @@ func extractUniqueMetaKeys(blobMap map[string]any, m *Meta) error {
 
 func (destination *DeclarativeConfig) Merge(src *DeclarativeConfig) {
 	destination.Packages = append(destination.Packages, src.Packages...)
+	destination.Icons = append(destination.Icons, src.Icons...)
 	destination.Channels = append(destination.Channels, src.Channels...)
 	destination.Bundles = append(destination.Bundles, src.Bundles...)
 	destination.Others = append(destination.Others, src.Others...)

--- a/alpha/declcfg/declcfg_to_model.go
+++ b/alpha/declcfg/declcfg_to_model.go
@@ -32,12 +32,12 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 			Description: p.Description,
 			Channels:    map[string]*model.Channel{},
 
-			//DisplayName:      p.DisplayName,
-			//ShortDescription: p.ShortDescription,
-			//Provider:         p.Provider,
-			//Maintainers:      p.Maintainers,
-			//Links:            p.Links,
-			//Keywords:         p.Keywords,
+			DisplayName:      p.DisplayName,
+			ShortDescription: p.ShortDescription,
+			Provider:         p.Provider,
+			Maintainers:      p.Maintainers,
+			Links:            p.Links,
+			Keywords:         p.Keywords,
 		}
 		if p.Icon != nil {
 			mpkg.Icon = &model.Icon{

--- a/alpha/declcfg/declcfg_to_model.go
+++ b/alpha/declcfg/declcfg_to_model.go
@@ -31,6 +31,13 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 			Name:        p.Name,
 			Description: p.Description,
 			Channels:    map[string]*model.Channel{},
+
+			//DisplayName:      p.DisplayName,
+			//ShortDescription: p.ShortDescription,
+			//Provider:         p.Provider,
+			//Maintainers:      p.Maintainers,
+			//Links:            p.Links,
+			//Keywords:         p.Keywords,
 		}
 		if p.Icon != nil {
 			mpkg.Icon = &model.Icon{
@@ -40,6 +47,19 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 		}
 		defaultChannels[p.Name] = p.DefaultChannel
 		mpkgs[p.Name] = mpkg
+	}
+	for _, i := range cfg.Icons {
+		mpkg, ok := mpkgs[i.Package]
+		if !ok {
+			return nil, fmt.Errorf("unknown package %q found in olm.icon", i.Package)
+		}
+		if mpkg.Icon != nil {
+			return nil, fmt.Errorf("duplicate icon found for package %q; expecting no more than one icon per package", i.Package)
+		}
+		mpkg.Icon = &model.Icon{
+			MediaType: i.MediaType,
+			Data:      i.Data,
+		}
 	}
 
 	channelDefinedEntries := map[string]sets.Set[string]{}

--- a/alpha/declcfg/declcfg_to_model.go
+++ b/alpha/declcfg/declcfg_to_model.go
@@ -140,19 +140,22 @@ func ConvertToModel(cfg DeclarativeConfig) (model.Model, error) {
 			return nil, fmt.Errorf("parse properties for bundle %q: %v", b.Name, err)
 		}
 
-		if len(props.Packages) != 1 {
-			return nil, fmt.Errorf("package %q bundle %q must have exactly 1 %q property, found %d", b.Package, b.Name, property.TypePackage, len(props.Packages))
-		}
+		var ver semver.Version
+		if b.Version != nil {
+			ver = semver.MustParse(b.Version.String())
+		} else if len(props.Packages) == 1 {
+			if b.Package != props.Packages[0].PackageName {
+				return nil, fmt.Errorf("package %q does not match %q property %q", b.Package, property.TypePackage, props.Packages[0].PackageName)
+			}
 
-		if b.Package != props.Packages[0].PackageName {
-			return nil, fmt.Errorf("package %q does not match %q property %q", b.Package, property.TypePackage, props.Packages[0].PackageName)
-		}
-
-		// Parse version from the package property.
-		rawVersion := props.Packages[0].Version
-		ver, err := semver.Parse(rawVersion)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing bundle %q version %q: %v", b.Name, rawVersion, err)
+			// Parse version from the package property.
+			rawVersion := props.Packages[0].Version
+			ver, err = semver.Parse(rawVersion)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing bundle %q version %q: %v", b.Name, rawVersion, err)
+			}
+		} else {
+			return nil, fmt.Errorf("package %q bundle %q requires either version being set or exactly one property with type %q", b.Package, b.Name, props.Packages[0].PackageName)
 		}
 
 		channelDefinedEntries[b.Package] = channelDefinedEntries[b.Package].Delete(b.Name)

--- a/alpha/declcfg/load.go
+++ b/alpha/declcfg/load.go
@@ -279,6 +279,7 @@ type fbcBuilder struct {
 	cfg DeclarativeConfig
 
 	packagesMu     sync.Mutex
+	iconsMu        sync.Mutex
 	channelsMu     sync.Mutex
 	bundlesMu      sync.Mutex
 	deprecationsMu sync.Mutex
@@ -295,6 +296,14 @@ func (c *fbcBuilder) addMeta(in *Meta) error {
 		c.packagesMu.Lock()
 		c.cfg.Packages = append(c.cfg.Packages, p)
 		c.packagesMu.Unlock()
+	case SchemaIcon:
+		var i Icon
+		if err := json.Unmarshal(in.Blob, &i); err != nil {
+			return fmt.Errorf("parse icon: %v", err)
+		}
+		c.iconsMu.Lock()
+		c.cfg.Icons = append(c.cfg.Icons, i)
+		c.iconsMu.Unlock()
 	case SchemaChannel:
 		var ch Channel
 		if err := json.Unmarshal(in.Blob, &ch); err != nil {

--- a/alpha/declcfg/model_to_declcfg.go
+++ b/alpha/declcfg/model_to_declcfg.go
@@ -12,9 +12,9 @@ func ConvertFromModel(mpkgs model.Model) DeclarativeConfig {
 	for _, mpkg := range mpkgs {
 		channels, bundles := traverseModelChannels(*mpkg)
 
-		var i *Icon
+		var i *PackageIcon
 		if mpkg.Icon != nil {
-			i = &Icon{
+			i = &PackageIcon{
 				Data:      mpkg.Icon.Data,
 				MediaType: mpkg.Icon.MediaType,
 			}

--- a/alpha/model/model.go
+++ b/alpha/model/model.go
@@ -3,6 +3,7 @@ package model
 import (
 	"errors"
 	"fmt"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"sort"
 	"strings"
 
@@ -52,12 +53,12 @@ type Package struct {
 	Channels       map[string]*Channel
 	Deprecation    *Deprecation
 
-	//DisplayName      string
-	//ShortDescription string
-	//Provider         v1alpha1.AppLink
-	//Maintainers      []v1alpha1.Maintainer
-	//Links            []v1alpha1.AppLink
-	//Keywords         []string
+	DisplayName      string
+	ShortDescription string
+	Provider         v1alpha1.AppLink
+	Maintainers      []v1alpha1.Maintainer
+	Links            []v1alpha1.AppLink
+	Keywords         []string
 }
 
 func (m *Package) Validate() error {

--- a/alpha/model/model.go
+++ b/alpha/model/model.go
@@ -44,12 +44,20 @@ func (m Model) Validate() error {
 }
 
 type Package struct {
-	Name           string
+	Name string
+
 	Description    string
 	Icon           *Icon
 	DefaultChannel *Channel
 	Channels       map[string]*Channel
 	Deprecation    *Deprecation
+
+	//DisplayName      string
+	//ShortDescription string
+	//Provider         v1alpha1.AppLink
+	//Maintainers      []v1alpha1.Maintainer
+	//Links            []v1alpha1.AppLink
+	//Keywords         []string
 }
 
 func (m *Package) Validate() error {
@@ -58,6 +66,26 @@ func (m *Package) Validate() error {
 	if m.Name == "" {
 		result.subErrors = append(result.subErrors, errors.New("package name must not be empty"))
 	}
+
+	//if len(m.ShortDescription) > 128 {
+	//	result.subErrors = append(result.subErrors, errors.New("short description must not be more than 128 characters"))
+	//}
+	//
+	//for i, maintainer := range m.Maintainers {
+	//	if maintainer.Name == "" && maintainer.Email == "" {
+	//		result.subErrors = append(result.subErrors, fmt.Errorf("maintainer at index %d must not be empty", i))
+	//	}
+	//}
+	//for i, link := range m.Links {
+	//	if link.Name == "" && link.URL == "" {
+	//		result.subErrors = append(result.subErrors, fmt.Errorf("link at index %d must not be empty", i))
+	//	}
+	//}
+	//for i, keyword := range m.Keywords {
+	//	if keyword == "" {
+	//		result.subErrors = append(result.subErrors, fmt.Errorf("keyword at index %d must not be empty", i))
+	//	}
+	//}
 
 	if err := m.Icon.Validate(); err != nil {
 		result.subErrors = append(result.subErrors, err)
@@ -133,8 +161,8 @@ func (m *Package) validateUniqueBundleVersions() error {
 }
 
 type Icon struct {
-	Data      []byte `json:"base64data"`
-	MediaType string `json:"mediatype"`
+	Data      []byte
+	MediaType string
 }
 
 func (i *Icon) Validate() error {

--- a/alpha/model/model.go
+++ b/alpha/model/model.go
@@ -391,7 +391,7 @@ func (b *Bundle) Validate() error {
 	//	}
 	//}
 
-	if props != nil && len(props.Packages) != 1 {
+	if b.Version.String() == "0.0.0" && props != nil && len(props.Packages) != 1 {
 		result.subErrors = append(result.subErrors, fmt.Errorf("must be exactly one property with type %q", property.TypePackage))
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.3
 toolchain go1.23.6
 
 require (
+	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/akrylysov/pogreb v0.10.2
 	github.com/blang/semver/v4 v4.0.0
 	github.com/containerd/containerd v1.7.27

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
+github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
+github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.12.9 h1:2zJy5KA+l0loz1HzEGqyNnjd3fyZA31ZBCGKacp6lLg=

--- a/pkg/api/model_to_api.go
+++ b/pkg/api/model_to_api.go
@@ -30,7 +30,7 @@ func ConvertModelBundleToAPIBundle(b model.Bundle) (*Bundle, error) {
 				MediaType: b.Package.Icon.MediaType,
 			}}
 		}
-		csv := csvMetadataToCsv(props.CSVMetadatas[0])
+		csv := bundleToCSV(b)
 		csv.Name = b.Name
 		csv.Spec.Icon = icons
 		csv.Spec.InstallStrategy = v1alpha1.NamedInstallStrategy{
@@ -101,7 +101,28 @@ func parseProperties(in []property.Property) (*property.Properties, error) {
 	return props, nil
 }
 
-func csvMetadataToCsv(m property.CSVMetadata) v1alpha1.ClusterServiceVersion {
+func bundleToCSV(b model.Bundle) v1alpha1.ClusterServiceVersion {
+	p := b.Package
+	m := b.PropertiesP.CSVMetadatas[0]
+
+	if m.DisplayName == "" {
+		m.DisplayName = p.DisplayName
+	}
+	if _, ok := m.Annotations["description"]; !ok {
+		m.Annotations["description"] = p.ShortDescription
+	}
+	if m.Provider.Name == "" && m.Provider.URL == "" {
+		m.Provider = p.Provider
+	}
+	if m.Maintainers == nil {
+		m.Maintainers = p.Maintainers
+	}
+	if m.Links == nil {
+		m.Links = p.Links
+	}
+	if m.Keywords == nil {
+		m.Keywords = p.Keywords
+	}
 	return v1alpha1.ClusterServiceVersion{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       operators.ClusterServiceVersionKind,


### PR DESCRIPTION
Signed-off-by: Joe Lanford <joe.lanford@gmail.com><!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

WIP: This is an implementation with no tests. Before merge, we need to add some tests to ensure migrations work as expected and GRPC compatibility is maintained.

**Description of the change:**
1. [add olm.icon blob and migration](https://github.com/operator-framework/operator-registry/commit/24e924066f8b00c6477725c27ff1b43235b4fb0d)
2. [fbc: promote bundle version from property to first-class field](https://github.com/operator-framework/operator-registry/commit/9ac8e60786fa9669dc003d08c98835ef57108c4e)
3. [fbc: promote package-level metdata from olm.csv.metadata to olm.package blob](https://github.com/operator-framework/operator-registry/commit/8840220b2bd4e806b419782638734a056a9541d5) 

For all of these, the `opm serve` implementation is updated to correctly plumb the new fields into the GRPC API.

**Motivation for the change:**
1. With the work in catalogd to allow querying a catalog by schema, package, and/or name, we can give catalogd clients more granular access to package metadata without the icon, which is beneficial for clients that want to list packages without also having to download all of the icons, which they may not care about (e.g. CLI clients or catalog resolvers like operator-controller)
2. The current data model requires an `olm.package` property, where both the package name and version are required. The bundle schema already has the package name, and the bundle version is a key piece of information when dealing with bundles. Promoting the bundle version to a first class field and eliminating the `olm.package` property from FBCs reduces duplication of package name and improves performance and ergonomics for clients that need to know the bundle version (which is virtually all clients).
3. Often, clients want to know package-level metadata like display name, a short description, its provider and maintainers, and lists of links and keywords. This metadata is essentially duplicated in all bundles unnecessarily and it is more useful when coloated with the package. Otherwise, clients need to also download all bundles and process them to find the "best" bundle from which to derive this metadata, this is wasteful of CPU and disk space.

**Open questions:**
1.  Is it okay to remove the `olm.package`'s `.icon` field when we migrate to `olm.icon`? Clients that don't know about the new `olm.icon` will think there is no icon. If we don't remove the `.icon` field. The benefit of separating it out is completely eliminated and we might as well not separate it because then we'd just duplicate the icon unecessarily.
2. Is it okay to remove the `olm.bundle`'s `olm.package` property when we promote the version to a first-class field? Same sort of problem as above, In this case, we could probably keep both the property and the version field, but then we would need extra validation to ensure they match and we'd be using slightly more space per bundle.
3. Do we agree that the following make sense as package-level fields?
- Short Description
- Display Name
- Provider
- Maintainers
- Links
- Keywords
5. For all of the fields in (3) can we safely extract those from the bundle with the highest semver version in the package? Of those, I wonder most about links, which bundle authors _may_ be setting to version-specific release notes or documentation.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
