### PR TITLE
Install linux-headers in upstream-opm-builder

### DIFF
--- a/upstream-opm-builder.Dockerfile
+++ b/upstream-opm-builder.Dockerfile
@@ -7,7 +7,7 @@ FROM golang:1.23-alpine AS builder
 
 RUN apk update && apk add ca-certificates
 COPY ["nsswitch.conf", "/etc/nsswitch.conf"]
-RUN apk update && apk add sqlite build-base git mercurial bash
+RUN apk update && apk add sqlite build-base git mercurial bash linux-headers
 RUN set -eux;     apk add --no-cache --virtual .build-deps         bash         gcc
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR /build


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Install linux-headers package in `upstream-opm-builder` to get required linux/limits.h header file.

**Motivation for the change:**
Closes #1689 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
