### PR TITLE
🌱 remove bingo upgrade target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,13 +107,6 @@ lint: $(GOLANGCI_LINT)
 fix-lint: $(GOLANGCI_LINT)
 	$(GOLANGCI_LINT) run --fix $(GOLANGCI_LINT_ARGS)
 
-.PHONY: bingo-upgrade
-bingo-upgrade: $(BINGO) #EXHELP Upgrade tools
-	@for pkg in $$($(BINGO) list | awk '{ print $$3 }' | tail -n +3 | sed 's/@.*//'); do \
-		echo -e "Upgrading \033[35m$$pkg\033[0m to latest..."; \
-		$(BINGO) get "$$pkg@latest"; \
-	done
-
 .PHONY: codegen
 codegen: $(PROTOC) $(PROTOC_GEN_GO_GRPC)
 	$(PROTOC) --plugin=protoc-gen-go=$(PROTOC_GEN_GO_GRPC) -I pkg/api/ --go_out=pkg/api pkg/api/*.proto


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Removes the bingo-upgrade target

**Motivation for the change:**
This well-intentioned target is incapable of discerning infra tooling from public API tooling (which is similarly pinned, but has very different support expectations). 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
