### PR TITLE
bump Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/operator-framework/operator-registry
 
-go 1.24.3
+go 1.24.4
 
 require (
 	github.com/akrylysov/pogreb v0.10.2


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Updated the `go` directive in `go.mod` from version 1.24.3 to 1.24.4 to resolve [GO-2025-3751](https://pkg.go.dev/vuln/GO-2025-3751), a vulnerability affecting crypto/tls certificate verification.

**Motivation for the change:**
This repository is being flagged by internal security scanners due to CVE-2025-24768, which is addressed in Go 1.24.4. Updating the Go version ensures compliance with security policies and mitigates the identified vulnerability.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
