### PR TITLE
Fix invalid ConfigMap key translation

### DIFF
--- a/pkg/configmap/configmap_writer.go
+++ b/pkg/configmap/configmap_writer.go
@@ -67,7 +67,7 @@ func NewConfigMapLoaderWithClient(configMapName, namespace, manifestsDir string,
 }
 
 func TranslateInvalidChars(input string) string {
-	validConfigMapKey := unallowedKeyChars.ReplaceAllString(input, "~")
+	validConfigMapKey := unallowedKeyChars.ReplaceAllString(input, "-")
 	return validConfigMapKey
 }
 

--- a/pkg/configmap/configmap_writer_test.go
+++ b/pkg/configmap/configmap_writer_test.go
@@ -1,0 +1,41 @@
+package configmap
+
+import (
+	"testing"
+)
+
+func TestTranslateInvalidChars(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name           string
+		input          string
+		expectedOutput string
+	}{
+		{
+			name:           "identity when there're no invalid characters",
+			input:          "foo-bar.yaml",
+			expectedOutput: "foo-bar.yaml",
+		},
+		{
+			name:           "input having invalid character",
+			input:          "foo:bar.yaml",
+			expectedOutput: "foo-bar.yaml",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := TranslateInvalidChars(tc.input)
+			if tc.expectedOutput != got {
+				t.Errorf("expected %s, got %s", tc.expectedOutput, got)
+			}
+
+			if unallowedKeyChars.MatchString(got) {
+				t.Errorf("translated output %q contains invalid characters", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION

**Description of the change:**

When generating ConfigMap keys from OLM bundle filenames, colons (`:`) were being replaced with tildes (`~`). However, `~` is not a valid character for ConfigMap keys, leading to errors like:
```
binaryData[scylladb~controller~aggregate-to-operator_rbac.authorization.k8s.io_v1_clusterrole.yaml]: Invalid value: "...": a valid config key must consist of alphanumeric characters, '-', '_' or '.' (regex: '[-._a-zA-Z0-9]+')
```

This commit fixes the issue by replacing `:` with hyphens (`-`) instead, which are allowed in ConfigMap keys. For example:

* Before: `scylladb:controller:aggregate-to-operator...` →  `scylladb~controller~aggregate-to-operator...` (invalid)
* After:  `scylladb:controller:aggregate-to-operator...` →  `scylladb-controller-aggregate-to-operator...` (valid)

**Motivation for the change:**

This ensures all generated ConfigMap keys conform to Kubernetes naming requirements.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


Closes #1741
