### PR TITLE
initial working viz of ignored v0 edges

### DIFF
--- a/alpha/declcfg/write.go
+++ b/alpha/declcfg/write.go
@@ -253,19 +253,19 @@ func (writer *MermaidWriter) WriteChannels(cfg DeclarativeConfig, out io.Writer)
 		return pkgNames[i] < pkgNames[j]
 	})
 	for _, pkgName := range pkgNames {
-		_, _ = out.Write([]byte(fmt.Sprintf("  %%%% package %q\n", pkgName)))
-		_, _ = out.Write([]byte(fmt.Sprintf("  subgraph %q\n", pkgName)))
+		_, _ = fmt.Fprintf(out, "  %%%% package %q\n", pkgName)
+		_, _ = fmt.Fprintf(out, "  subgraph %q\n", pkgName)
 		_, _ = out.Write([]byte(pkgs[pkgName].String()))
 		_, _ = out.Write([]byte("  end\n"))
 	}
 
 	if deprecatedPackage != "" {
-		_, _ = out.Write([]byte(fmt.Sprintf("style %s fill:#989695\n", deprecatedPackage)))
+		_, _ = fmt.Fprintf(out, "style %s fill:#989695\n", deprecatedPackage)
 	}
 
 	if len(deprecatedChannelIDs) > 0 {
 		for _, deprecatedChannel := range deprecatedChannelIDs {
-			_, _ = out.Write([]byte(fmt.Sprintf("style %s fill:#DCD0FF\n", deprecatedChannel)))
+			_, _ = fmt.Fprintf(out, "style %s fill:#DCD0FF\n", deprecatedChannel)
 		}
 	}
 
@@ -274,12 +274,12 @@ func (writer *MermaidWriter) WriteChannels(cfg DeclarativeConfig, out io.Writer)
 		if len(decoratedBundleIDs[key]) > 0 {
 			b := slices.Clone(decoratedBundleIDs[key])
 			slices.Sort(b)
-			_, _ = out.Write([]byte(fmt.Sprintf("class %s %s\n", strings.Join(b, ","), key)))
+			_, _ = fmt.Fprintf(out, "class %s %s\n", strings.Join(b, ","), key)
 		}
 	}
 
 	if len(skippedLinkIDs) > 0 {
-		_, _ = out.Write([]byte("linkStyle " + strings.Join(skippedLinkIDs, ",") + " stroke:#FF0000,stroke-width:3px,stroke-dasharray:5;\n"))
+		_, _ = fmt.Fprintf(out, "linkStyle %s %s\n", strings.Join(skippedLinkIDs, ","), "stroke:#FF0000,stroke-width:3px,stroke-dasharray:5;")
 	}
 
 	return nil

--- a/alpha/declcfg/write_test.go
+++ b/alpha/declcfg/write_test.go
@@ -527,35 +527,40 @@ func TestWriteMermaidChannels(t *testing.T) {
 			packageFilter: "",
 			expected: `graph LR
   classDef deprecated fill:#E8960F
+  classDef skipped stroke:#FF0000,stroke-width:4px
+  classDef deprecatedskipped fill:#E8960F,stroke:#FF0000,stroke-width:4px
   %% package "anakin"
   subgraph "anakin"
     %% channel "dark"
     subgraph anakin-dark["dark"]
-      anakin-dark-anakin.v0.0.1["anakin.v0.0.1"]:::deprecated
+      anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]
+      anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]-- skip --> anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]
+      anakin-dark-anakin.v0.0.1["anakin.v0.0.1"]-- replace --> anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]
       anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]
       anakin-dark-anakin.v0.0.1["anakin.v0.0.1"]-- replace --> anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]
-      anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]
-      anakin-dark-anakin.v0.0.1["anakin.v0.0.1"]-- replace --> anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]
-      anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]-- skip --> anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]
+      anakin-dark-anakin.v0.0.1["anakin.v0.0.1"]
     end
     %% channel "light"
     subgraph anakin-light["light"]
-      anakin-light-anakin.v0.0.1["anakin.v0.0.1"]:::deprecated
       anakin-light-anakin.v0.1.0["anakin.v0.1.0"]
       anakin-light-anakin.v0.0.1["anakin.v0.0.1"]-- replace --> anakin-light-anakin.v0.1.0["anakin.v0.1.0"]
+      anakin-light-anakin.v0.0.1["anakin.v0.0.1"]
     end
   end
   %% package "boba-fett"
   subgraph "boba-fett"
     %% channel "mando"
     subgraph boba-fett-mando["mando"]
-      boba-fett-mando-boba-fett.v1.0.0["boba-fett.v1.0.0"]
       boba-fett-mando-boba-fett.v2.0.0["boba-fett.v2.0.0"]
       boba-fett-mando-boba-fett.v1.0.0["boba-fett.v1.0.0"]-- replace --> boba-fett-mando-boba-fett.v2.0.0["boba-fett.v2.0.0"]
+      boba-fett-mando-boba-fett.v1.0.0["boba-fett.v1.0.0"]
     end
   end
 style anakin fill:#989695
 style anakin-light fill:#DCD0FF
+class anakin-dark-anakin.v0.0.1,anakin-light-anakin.v0.0.1 deprecated
+class anakin-dark-anakin.v0.1.0 skipped
+linkStyle 2 stroke:#FF0000,stroke-width:3px,stroke-dasharray:5;
 `,
 		},
 		{
@@ -565,13 +570,15 @@ style anakin-light fill:#DCD0FF
 			packageFilter: "",
 			expected: `graph LR
   classDef deprecated fill:#E8960F
+  classDef skipped stroke:#FF0000,stroke-width:4px
+  classDef deprecatedskipped fill:#E8960F,stroke:#FF0000,stroke-width:4px
   %% package "anakin"
   subgraph "anakin"
     %% channel "dark"
     subgraph anakin-dark["dark"]
-      anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]
       anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]
       anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]-- skip --> anakin-dark-anakin.v0.1.1["anakin.v0.1.1"]
+      anakin-dark-anakin.v0.1.0["anakin.v0.1.0"]
     end
     %% channel "light"
     subgraph anakin-light["light"]
@@ -580,6 +587,7 @@ style anakin-light fill:#DCD0FF
   end
 style anakin fill:#989695
 style anakin-light fill:#DCD0FF
+class anakin-dark-anakin.v0.1.0 skipped
 `,
 		},
 		{
@@ -589,13 +597,15 @@ style anakin-light fill:#DCD0FF
 			packageFilter: "boba-fett",
 			expected: `graph LR
   classDef deprecated fill:#E8960F
+  classDef skipped stroke:#FF0000,stroke-width:4px
+  classDef deprecatedskipped fill:#E8960F,stroke:#FF0000,stroke-width:4px
   %% package "boba-fett"
   subgraph "boba-fett"
     %% channel "mando"
     subgraph boba-fett-mando["mando"]
-      boba-fett-mando-boba-fett.v1.0.0["boba-fett.v1.0.0"]
       boba-fett-mando-boba-fett.v2.0.0["boba-fett.v2.0.0"]
       boba-fett-mando-boba-fett.v1.0.0["boba-fett.v1.0.0"]-- replace --> boba-fett-mando-boba-fett.v2.0.0["boba-fett.v2.0.0"]
+      boba-fett-mando-boba-fett.v1.0.0["boba-fett.v1.0.0"]
     end
   end
 `,

--- a/cmd/opm/alpha/render-graph/cmd.go
+++ b/cmd/opm/alpha/render-graph/cmd.go
@@ -18,7 +18,7 @@ func NewCmd() *cobra.Command {
 		render               action.Render
 		minEdge              string
 		specifiedPackageName string
-		drawV0Semantics   bool
+		drawV0Semantics      bool
 	)
 	cmd := &cobra.Command{
 		Use:   "render-graph [index-image | fbc-dir]",

--- a/cmd/opm/alpha/render-graph/cmd.go
+++ b/cmd/opm/alpha/render-graph/cmd.go
@@ -18,6 +18,7 @@ func NewCmd() *cobra.Command {
 		render               action.Render
 		minEdge              string
 		specifiedPackageName string
+		drawV0Semantics   bool
 	)
 	cmd := &cobra.Command{
 		Use:   "render-graph [index-image | fbc-dir]",
@@ -67,7 +68,10 @@ $ opm alpha render-graph quay.io/operatorhubio/catalog:latest | \
 				log.Fatal(err)
 			}
 
-			writer := declcfg.NewMermaidWriter(declcfg.WithMinEdgeName(minEdge), declcfg.WithSpecifiedPackageName(specifiedPackageName))
+			writer := declcfg.NewMermaidWriter(
+				declcfg.WithMinEdgeName(minEdge),
+				declcfg.WithSpecifiedPackageName(specifiedPackageName),
+				declcfg.WithV0Semantics(drawV0Semantics))
 			if err := writer.WriteChannels(*cfg, os.Stdout); err != nil {
 				log.Fatal(err)
 			}
@@ -75,5 +79,6 @@ $ opm alpha render-graph quay.io/operatorhubio/catalog:latest | \
 	}
 	cmd.Flags().StringVar(&minEdge, "minimum-edge", "", "the channel edge to be used as the lower bound of the set of edges composing the upgrade graph; default is to include all edges")
 	cmd.Flags().StringVarP(&specifiedPackageName, "package-name", "p", "", "a specific package name to filter output; default is to include all packages in reference")
+	cmd.Flags().BoolVar(&drawV0Semantics, "draw-v0-semantics", false, "whether to indicate OLMv0 semantics in the output; default is to simply represent the upgrade graph")
 	return cmd
 }


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

This is a first pass in making OLMv0 upgrade graph mechanics visible in rendered graphs, adding to existing `olm.deprecations` indication rendering.

Bundle versions which are skipped in a graph are outlined in red and have all their contributory edges changed to red, dashed arrows to indicate that they are ignored when calculating upgrades, for e.g. 
<img width="1198" height="217" alt="Screenshot 2025-08-18 at 9 58 21 AM" src="https://github.com/user-attachments/assets/2593c43b-c862-4d75-8db8-ebe55bcc6265" />

in this graph, cert-manager-operator.v1.15.1 is skipped, so any graph updates by this version are similarly ignored.  This means that users cannot upgrade from v1.15.0 to v1.15.1. 

These features are controlled by a new `draw-v0-semantics` flag (defaults off).  
By default, render-graph displays simple upgrade graph mechanics, which aligns to OLMv1 functionality.

**Motivation for the change:**

Answering user questions recently, it became apparent that OLMv0 interpretation of an upgrade graph includes some interpretation mechanics which aren't well-communicated.  These mechanics can result in some user stranding on operator versions because of ignored graph contributions. 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
