### PR TITLE
validate fail for stranded channel entries

### DIFF
--- a/alpha/model/model.go
+++ b/alpha/model/model.go
@@ -288,6 +288,10 @@ func (c *Channel) validateReplacesChain() error {
 		if _, ok := chainFrom[cur.Name]; !ok {
 			chainFrom[cur.Name] = []string{cur.Name}
 		}
+		// if the replaces edge is known to be skipped, disregard it
+		if skippedBundles.Has(cur.Replaces) {
+			break
+		}
 		for k := range chainFrom {
 			chainFrom[k] = append(chainFrom[k], cur.Replaces)
 		}

--- a/alpha/model/model_test.go
+++ b/alpha/model/model_test.go
@@ -164,7 +164,15 @@ func TestValidReplacesChain(t *testing.T) {
 			}},
 			assertion: hasError(`channel contains one or more stranded bundles: anakin.v0.0.1`),
 		},
-	}
+		{
+			name: "Error/SkippedReplacesStranded",
+			ch: Channel{Bundles: map[string]*Bundle{
+				"anakin.v0.0.1": {Name: "anakin.v0.0.1"},
+				"anakin.v0.0.2": {Name: "anakin.v0.0.2", Replaces: "anakin.v0.0.1"},
+				"anakin.v0.0.3": {Name: "anakin.v0.0.3", Replaces: "anakin.v0.0.2", Skips: []string{"anakin.v0.0.2"}},
+			}},
+			assertion: hasError(`channel contains one or more stranded bundles: anakin.v0.0.1`),
+		}}
 	for _, s := range specs {
 		t.Run(s.name, func(t *testing.T) {
 			err := s.ch.validateReplacesChain()


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
`opm validate` fails when an edge is stranded because the replaces chain from the head is broken by skipped edges.  

**Motivation for the change:**
Due to OLMv0 graph mechanics, any skips edge will cause OLMv0 to ignore the bundle version when considering upgrades (since v0 discards graph contribution from skipped bundle versions). 
Since the purpose of a replaces edge is to enable upgrade mobility across a graph, allowing the bundle version to be ignored (due to the skips entry) is an error, and potentially results in stranding. 

For example, take input `olm.channel`:
```yaml
schema: olm.channel
name: stable-v1
package: test-operator
entries:
  - name: test-operator-v1.0.0 # stranded due to skip of test-operator-v1.1.2
  - name: test-operator-v1.1.0 # stranded due to skip of test-operator-v1.1.2
    replaces: test-operator-v1.0.0
  - name: test-operator-v1.1.2
    replaces: test-operator-v1.1.0
  - name: test-operator-v1.1.4
    replaces: test-operator-v1.1.2
    skips:
      - test-operator-v1.1.2
  - name: test-operator-v1.2.0
  - name: test-operator-v1.2.1
    replaces: test-operator-v1.1.4
    skips:
      - test-operator-v1.1.4
      - test-operator-v1.2.0
  - name: test-operator-v1.3.0
    replaces: test-operator-v1.2.1
    skips:
      - test-operator-v1.2.1
  - name: test-operator-v1.4.0
    replaces: test-operator-v1.3.0
    skips:
      - test-operator-v1.3.0

```

Using a [new version of opm](https://github.com/operator-framework/operator-registry/pull/1744) which can optionally display OLMv0 graph semantics, skipped objects are limned in red and ignored edges are red dashed arrows to help visualize the stranded edges. 

<img width="1904" height="248" alt="image" src="https://github.com/user-attachments/assets/fd0d3d83-07a0-434a-a0f7-c8566a4496b1" />



**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
