### PR TITLE
:bug: Add key ordering for mermaid graph output

### DIFF
--- a/alpha/declcfg/write.go
+++ b/alpha/declcfg/write.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -270,7 +271,8 @@ func (writer *MermaidWriter) WriteChannels(cfg DeclarativeConfig, out io.Writer)
 	}
 
 	// express the decoration classes
-	for key := range decoratedBundleIDs {
+	sortedKeys := slices.Sorted(maps.Keys(decoratedBundleIDs))
+	for _, key := range sortedKeys {
 		if len(decoratedBundleIDs[key]) > 0 {
 			b := slices.Clone(decoratedBundleIDs[key])
 			slices.Sort(b)


### PR DESCRIPTION
**Description of the change:**

The decorated bundle section of the mermaid graph being written out was using map key ordering causing one of the unit tests to flake.


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
