### PR TITLE
Add PodMonitor to supported resources

### DIFF
--- a/pkg/lib/bundle/supported_resources.go
+++ b/pkg/lib/bundle/supported_resources.go
@@ -22,6 +22,7 @@ const (
 	ConsoleLinkKind           = "ConsoleLink"
 	ConsolePlugin             = "ConsolePlugin"
 	NetworkPolicyKind         = "NetworkPolicy"
+	PodMonitorKind            = "PodMonitor"
 )
 
 // Namespaced indicates whether the resource is namespace scoped (true) or cluster-scoped (false).
@@ -51,6 +52,7 @@ var supportedResources = map[string]Namespaced{
 	ConsoleLinkKind:           false,
 	ConsolePlugin:             false,
 	NetworkPolicyKind:         true,
+	PodMonitorKind:            true,
 }
 
 // IsSupported checks if the object kind is OLM-supported and if it is namespaced


### PR DESCRIPTION
**Description of the change:**

Add PodMonitor to supported resources

**Motivation for the change:**

PodMonitor is a useful resource when monitoring a set of Pods that do not have a dedicated Service resource associated. This is helpful if the only reason to add them to a Service would be to configure monitoring.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive



Closes #1688