### PR TITLE
set an exception for migrate file permissions

### DIFF
--- a/alpha/declcfg/write.go
+++ b/alpha/declcfg/write.go
@@ -608,7 +608,9 @@ func writeFile(cfg DeclarativeConfig, filename string, writeFunc WriteFunc) erro
 	if err := writeFunc(cfg, buf); err != nil {
 		return fmt.Errorf("write to buffer for %q: %v", filename, err)
 	}
-	if err := os.WriteFile(filename, buf.Bytes(), 0600); err != nil {
+	// we explicitly want to generate content from this function which is limited only by the user's umask (G306)
+	// nolint:gosec
+	if err := os.WriteFile(filename, buf.Bytes(), 0666); err != nil {
 		return fmt.Errorf("write file %q: %v", filename, err)
 	}
 	return nil


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Reverts #1524 changes to alpha/declcfg/write.go associated with FBC migration support.  

**Motivation for the change:**
Though this represents a legitimate ratcheting of security concerns, and we'd like to in general adhere to the security best practices of gosec linter, in this case we intend to rely on appropriate umask configuration of end users.
Not only were users of the binary impacted, but indirect clients who vendored the packages. 

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage 
- [x] Sufficient end-to-end test coverage
- [x] Docs updated or added to `/docs` 
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
