### PR TITLE
release/goreleaser.opm.Dockerfile: parameterize grpc-health-probe version

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -61,7 +61,7 @@ jobs:
         run: make release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_ARGS: release --skip=validate --clean -f release/goreleaser.windows.yaml ${{ github.event_name == 'pull_request' && '--snapshot' || '' }}
+          RELEASE_ARGS: release --verbose --skip=validate --clean -f release/goreleaser.windows.yaml ${{ github.event_name == 'pull_request' && '--snapshot' || '' }}
 
       - run: tar -cvf dist-windows.tar dist
       - uses: actions/upload-artifact@v4
@@ -85,7 +85,7 @@ jobs:
         run: make release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_ARGS: release --rm-dist -f release/goreleaser.darwin.yaml --skip=validate ${{ github.event_name == 'pull_request' && '--snapshot' || '' }}
+          RELEASE_ARGS: release --verbose --clean -f release/goreleaser.darwin.yaml --skip=validate ${{ github.event_name == 'pull_request' && '--snapshot' || '' }}
 
       - run: gtar -cvf dist-darwin.tar dist
       - uses: actions/upload-artifact@v4
@@ -140,7 +140,7 @@ jobs:
         run: make release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_ARGS: release --rm-dist -f release/goreleaser.linux.yaml --skip=validate ${{ github.event_name == 'pull_request' && '--snapshot' || '' }}
+          RELEASE_ARGS: release --verbose --clean -f release/goreleaser.linux.yaml --skip=validate ${{ github.event_name == 'pull_request' && '--snapshot' || '' }}
 
       - run: tar -cvf dist-linux.tar dist
       - uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ export PKG := github.com/operator-framework/operator-registry
 export GIT_COMMIT := $(or $(SOURCE_GIT_COMMIT),$(shell git rev-parse --short HEAD))
 export OPM_VERSION := $(or $(SOURCE_GIT_TAG),$(shell git describe --always --tags HEAD))
 export BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+export GRPC_HEALTH_PROBE_VERSION := $(shell $(GO) list -m github.com/grpc-ecosystem/grpc-health-probe | awk '{print $$2}')
 
 .DEFAULT_GOAL := all
 
@@ -143,7 +144,7 @@ export LATEST_IMAGE_OR_EMPTY := $(shell \
 	&& [ "$(shell echo -e "$(OPM_VERSION)\n$(LATEST_TAG)" | sort -rV | head -n1)" == "$(OPM_VERSION)" ] \
 	&& echo "$(OPM_IMAGE_REPO):latest" || echo "")
 RELEASE_GOOS := $(shell go env GOOS)
-RELEASE_ARGS ?= release --clean --snapshot -f release/goreleaser.$(RELEASE_GOOS).yaml
+RELEASE_ARGS ?= release --verbose --clean --snapshot -f release/goreleaser.$(RELEASE_GOOS).yaml
 
 # Note: bingo does not yet support windows (https://github.com/bwplotka/bingo/issues/26)
 # so GOOS=windows gets its own way to install goreleaser

--- a/release/goreleaser.linux.yaml
+++ b/release/goreleaser.linux.yaml
@@ -87,6 +87,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - --platform=linux/amd64
+      - --build-arg=GRPC_HEALTH_PROBE_VERSION={{ .Env.GRPC_HEALTH_PROBE_VERSION }}
   - image_templates:
       - "{{ .Env.OPM_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-arm64"
     ids: ["linux-arm64"]
@@ -97,6 +98,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - --platform=linux/arm64
+      - --build-arg=GRPC_HEALTH_PROBE_VERSION={{ .Env.GRPC_HEALTH_PROBE_VERSION }}
   - image_templates:
       - "{{ .Env.OPM_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-ppc64le"
     ids: ["linux-ppc64le"]
@@ -107,6 +109,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - --platform=linux/ppc64le
+      - --build-arg=GRPC_HEALTH_PROBE_VERSION={{ .Env.GRPC_HEALTH_PROBE_VERSION }}
   - image_templates:
       - "{{ .Env.OPM_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-s390x"
     ids: ["linux-s390x"]
@@ -117,6 +120,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - --platform=linux/s390x
+      - --build-arg=GRPC_HEALTH_PROBE_VERSION={{ .Env.GRPC_HEALTH_PROBE_VERSION }}
 docker_manifests:
   # IMAGE_TAG is either set by the Makefile or the goreleaser action workflow,
   # This image is intended to be tagged/pushed on all trunk (master, release branch) commits and tags.

--- a/release/goreleaser.opm.Dockerfile
+++ b/release/goreleaser.opm.Dockerfile
@@ -1,8 +1,13 @@
 # NOTE: This Dockerfile is used in conjuction with GoReleaser to
 #   build opm images. See the configurations in .goreleaser.yaml
 #   and .github/workflows/release.yaml.
+#
+# The GRPC_HEALTH_PROBE_VERSION is automatically passed as a build arg
+# by GoReleaser from the GRPC_HEALTH_PROBE_VERSION environment variable,
+# which is set in the Makefile from go.mod.
 
-FROM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.37 AS grpc_health_probe
+ARG GRPC_HEALTH_PROBE_VERSION
+FROM ghcr.io/grpc-ecosystem/grpc-health-probe:${GRPC_HEALTH_PROBE_VERSION} AS grpc_health_probe
 FROM gcr.io/distroless/static:debug
 COPY --from=grpc_health_probe /ko-app/grpc-health-probe /bin/grpc_health_probe
 COPY ["nsswitch.conf", "/etc/nsswitch.conf"]


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Parameterize and use the go.mod `grpc-health-probe` version in the goreleaser-built `quay.io/operator-framework/opm`.

**Motivation for the change:**

This will help us keep the grpc-health-probe version up-to-date in the `opm` image. Dependabot is already helping us keep the `grpc-health-probe` go dependency up-to-date, so this PR means that that automation will now automatically propagate to the version used in the image.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
