### PR TITLE
🐛  OCPBUGS-84642: remove substitutesFor interpretation from sqlite code

### DIFF
--- a/pkg/registry/parse.go
+++ b/pkg/registry/parse.go
@@ -209,13 +209,6 @@ func (b *bundleParser) derivedProperties(bundle *Bundle) ([]Property, error) {
 		if err != nil {
 			return nil, err
 		}
-		if release == "" && csv.GetSubstitutesFor() != "" {
-			version, release, err = extractReleaseVersionFromBuildMetadata(version)
-			if err != nil {
-				return nil, fmt.Errorf("bundle %q error: %v", bundle.Name, err)
-			}
-		}
-
 		value, err := json.Marshal(PackageProperty{
 			PackageName: pkg,
 			Version:     version,
@@ -265,22 +258,4 @@ func propertySet(properties []Property) []Property {
 	}
 
 	return set
-}
-
-func extractReleaseVersionFromBuildMetadata(substitutesFor string) (string, string, error) {
-	var version, release string
-	// if the bundle expresses no release version, but
-	// includes the substitutesFor annotation, then we
-	// interpret any build metadata in the version as
-	// the release version.
-	// failure to parse build metadata under these conditions is fatal,
-	// though validation is later
-	parts := strings.SplitN(substitutesFor, "+", 2)
-	if len(parts) == 2 {
-		version = parts[0]
-		release = parts[1]
-	} else {
-		return "", "", fmt.Errorf("no release version expressed as build metadata: %q", substitutesFor)
-	}
-	return version, release, nil
 }


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Removes bundle release inference from legacy build metadata / substitutesFor annotation approach for both SQLite and FBC processing paths. 

**Motivation for the change:**
SQLite `opm index add` and friends were adding multiple distinct bundle versions into catalogs: inferred release version, and without inferred release version.   This made the catalog invalid due to FBC constraints on only a single bundle version property.  It also failed `opm validate` of resulting FBC because bundles with explicit release versions must comply with bundle naming restrictions. 

The underlying problem is that while it is trivial to infer the release version from legacy approach data when the CSV is processed, the resulting FBC loses any identification that the release version was inferred vs explicit set in the catalog. 

Since there is no perceptible pattern in the resulting naming (and bundle names cannot be changed after they are published, as OLMv0 requires that the CSV metadata.name matches the olm.bundle FBC .name at all times, the distinction must be re-inferred from first principles.  

For example, given the original FBC
```yaml
name: cryostat-operator.v2.2.1-13
properties:
- type: olm.package
  value:
    packageName: cryostat-operator
    version: 2.2.1+13
- type: olm.csv.metadata
  value:
    annotations:
      olm.substitutesFor: cryostat-operator.v2.2.1-12
```

when processed with an inferred release version to become

```yaml
name: cryostat-operator.v2.2.1-13
properties:
- type: olm.package
  value:
    packageName: cryostat-operator
    version: 2.2.1
    release: 13
```

has no evidence of the inference, no discernable pattern in the remaining data, and is immediately in violation of the bundle naming conventions when a release version is set. 

To forgo the naming conventions, it is necessary to re-infer by evaluating:
- bundle.CSVJSON blob (only present for SQLite --> FBC conversions)
- bundle's `olm.bundle.object` property corresponding to the serialized CSV, if present
- bundle's `olm.csv.metadata` property corresponding to select data from the CSV, if present

It's far easier to remove the inference and fix the bug while we continue to debate the merits. 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
