### PR TITLE
:seedling: add structured output from validation with 'output' option

### DIFF
--- a/cmd/opm/validate/validate.go
+++ b/cmd/opm/validate/validate.go
@@ -1,17 +1,51 @@
 package validate
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 
 	"github.com/operator-framework/operator-registry/pkg/lib/config"
 )
 
+const (
+	outputJSON = "json"
+	outputYAML = "yaml"
+)
+
+// ValidationResult represents the structured output of validation
+type ValidationResult struct {
+	Passed bool             `json:"passed" yaml:"passed"`
+	Error  *ValidationError `json:"error,omitempty" yaml:"error,omitempty"`
+}
+
+// ValidationError represents a structured validation error that can be nested
+type ValidationError struct {
+	Message string            `json:"message" yaml:"message"`
+	Errors  []ValidationError `json:"errors,omitempty" yaml:"errors,omitempty"`
+}
+
+// errorToValidationError converts a Go error into a structured ValidationError
+func errorToValidationError(err error) *ValidationError {
+	if err == nil {
+		return nil
+	}
+
+	// For now, handle the error as a simple string message
+	// The error tree structure is already formatted in the Error() output
+	return &ValidationError{
+		Message: err.Error(),
+	}
+}
+
 func NewCmd() *cobra.Command {
 	logger := logrus.New()
+	var output string
+
 	validate := &cobra.Command{
 		Use:   "validate <directory>",
 		Short: "Validate the declarative index config",
@@ -27,12 +61,50 @@ func NewCmd() *cobra.Command {
 				return fmt.Errorf("%q is not a directory", directory)
 			}
 
-			if err := config.Validate(c.Context(), os.DirFS(directory)); err != nil {
-				logger.Fatal(err)
+			// Perform validation
+			validationErr := config.Validate(c.Context(), os.DirFS(directory))
+
+			// Handle structured output
+			if output != "" {
+				result := ValidationResult{
+					Passed: validationErr == nil,
+					Error:  errorToValidationError(validationErr),
+				}
+
+				var data []byte
+				var marshalErr error
+
+				switch output {
+				case outputJSON:
+					data, marshalErr = json.MarshalIndent(result, "", "  ")
+				case outputYAML:
+					data, marshalErr = yaml.Marshal(result)
+				default:
+					return fmt.Errorf("invalid --output value %q, expected (json|yaml)", output)
+				}
+
+				if marshalErr != nil {
+					return fmt.Errorf("failed to marshal output: %w", marshalErr)
+				}
+
+				fmt.Fprintln(os.Stdout, string(data))
+
+				// Exit directly with appropriate code to avoid cobra printing error
+				if validationErr != nil {
+					os.Exit(1)
+				}
+				return nil
+			}
+
+			// Default behavior: use logger.Fatal on error
+			if validationErr != nil {
+				logger.Fatal(validationErr)
 			}
 			return nil
 		},
 	}
+
+	validate.Flags().StringVarP(&output, "output", "o", "", "Output format for validation results (json|yaml)")
 
 	return validate
 }

--- a/cmd/opm/validate/validate.go
+++ b/cmd/opm/validate/validate.go
@@ -23,10 +23,9 @@ type ValidationResult struct {
 	Error  *ValidationError `json:"error,omitempty" yaml:"error,omitempty"`
 }
 
-// ValidationError represents a structured validation error that can be nested
+// ValidationError represents a structured validation error
 type ValidationError struct {
-	Message string            `json:"message" yaml:"message"`
-	Errors  []ValidationError `json:"errors,omitempty" yaml:"errors,omitempty"`
+	Message string `json:"message" yaml:"message"`
 }
 
 // errorToValidationError converts a Go error into a structured ValidationError
@@ -87,13 +86,18 @@ func NewCmd() *cobra.Command {
 					return fmt.Errorf("failed to marshal output: %w", marshalErr)
 				}
 
-				fmt.Fprintln(os.Stdout, string(data))
-
-				// Exit directly with appropriate code to avoid cobra printing error
-				if validationErr != nil {
-					os.Exit(1)
+				if _, err := fmt.Fprintln(os.Stdout, string(data)); err != nil {
+					return fmt.Errorf("failed to write output: %w", err)
 				}
-				return nil
+
+				// Silence cobra error output only for validation errors
+				// This prevents mixing structured output with error messages,
+				// while still showing errors for flag/marshal/write failures
+				if validationErr != nil {
+					c.SilenceErrors = true
+					c.SilenceUsage = true
+				}
+				return validationErr
 			}
 
 			// Default behavior: use logger.Fatal on error


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Provides JSON/YAML structured output option from `opm validate`, in case callers need more info than an exit status. Documentation for this fucntionality is in [this PR](https://github.com/operator-framework/olm-docs/pull/347).

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
