### PR TITLE
OCPBUGS-85775: validate skipRange with blang/semver ParseRange

### DIFF
--- a/alpha/model/model.go
+++ b/alpha/model/model.go
@@ -404,6 +404,11 @@ func (b *Bundle) Validate() error {
 			result.subErrors = append(result.subErrors, fmt.Errorf("skip[%d] is empty", i))
 		}
 	}
+	if b.SkipRange != "" {
+		if _, err := semver.ParseRange(b.SkipRange); err != nil {
+			result.subErrors = append(result.subErrors, fmt.Errorf("invalid skipRange %q: %v", b.SkipRange, err))
+		}
+	}
 	// TODO(joelanford): Validate related images? It looks like some
 	//   CSVs in production databases use incorrect fields ([name,value]
 	//   instead of [name,image]), which results in empty image values.

--- a/alpha/model/model_test.go
+++ b/alpha/model/model_test.go
@@ -618,6 +618,65 @@ func TestValidators(t *testing.T) {
 			assertion: hasError(`skip[0] is empty`),
 		},
 		{
+			name: "Bundle/Success/EmptySkipRange",
+			v: &Bundle{
+				Package:  pkg,
+				Channel:  ch,
+				Name:     "anakin.v0.1.0",
+				Image:    "registry.io/image",
+				Replaces: "anakin.v0.0.1",
+				Properties: []property.Property{
+					property.MustBuildPackage("anakin", "0.1.0"),
+				},
+			},
+			assertion: require.NoError,
+		},
+		{
+			name: "Bundle/Success/ValidSkipRange",
+			v: &Bundle{
+				Package:   pkg,
+				Channel:   ch,
+				Name:      "anakin.v0.1.0",
+				Image:     "registry.io/image",
+				Replaces:  "anakin.v0.0.1",
+				SkipRange: ">=1.0.0 <2.0.0",
+				Properties: []property.Property{
+					property.MustBuildPackage("anakin", "0.1.0"),
+				},
+			},
+			assertion: require.NoError,
+		},
+		{
+			name: "Bundle/Error/InvalidSkipRange/LeadingV",
+			v: &Bundle{
+				Package:   pkg,
+				Channel:   ch,
+				Name:      "anakin.v0.1.0",
+				Image:     "registry.io/image",
+				Replaces:  "anakin.v0.0.1",
+				SkipRange: ">v0.1.0",
+				Properties: []property.Property{
+					property.MustBuildPackage("anakin", "0.1.0"),
+				},
+			},
+			assertion: hasError(`invalid skipRange ">v0.1.0": Could not parse Range ">v0.1.0": Could not parse comparator ">v" in ">v0.1.0"`),
+		},
+		{
+			name: "Bundle/Error/InvalidSkipRange/LeadingZero",
+			v: &Bundle{
+				Package:   pkg,
+				Channel:   ch,
+				Name:      "anakin.v0.1.0",
+				Image:     "registry.io/image",
+				Replaces:  "anakin.v0.0.1",
+				SkipRange: ">1.00.1",
+				Properties: []property.Property{
+					property.MustBuildPackage("anakin", "0.1.0"),
+				},
+			},
+			assertion: hasError(`invalid skipRange ">1.00.1": Could not parse Range ">1.00.1": Could not parse version "1.00.1" in ">1.00.1": Minor number must not contain leading zeroes "00"`),
+		},
+		{
 			name: "Bundle/Error/MissingPackage",
 			v: &Bundle{
 				Package:    pkg,


### PR DESCRIPTION
**Description of the change:**

`opm validate` does not validate the `skipRange` field in operator bundle metadata. Invalid semver ranges (e.g. `>v0.1.0`, `>1.00.1`) are silently accepted, which can lead to broken upgrade graphs discovered only at runtime.

This PR adds validation of the `skipRange` field in `Bundle.Validate()` using `semver.ParseRange()` from the `blang/semver` library (already a dependency). Any parse error is surfaced in the validation error tree.

**Motivation for the change:**

Invalid `skipRange` values should be caught at build/validation time rather than at install time. This makes `opm validate` more reliable as a pre-publish check.

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs`
- [x] Commit messages sensible and descriptive

Jira: https://redhat.atlassian.net/browse/OCPBUGS-85775

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve OCPBUGS-85775`