### PR TITLE
Store custom schema metas as proto binary in pogreb cache

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -49,7 +49,7 @@ type backend interface {
 	PutBundle(context.Context, bundleKey, *api.Bundle) error
 
 	PutMeta(context.Context, metaKey, []byte) error
-	SendMetas(context.Context, metaKey, func([]byte) error) error
+	SendMetas(context.Context, metaKey, func(*structpb.Struct) error) error
 
 	GetDigest(context.Context) (string, error)
 	ComputeDigest(context.Context, fs.FS) (string, error)
@@ -248,13 +248,7 @@ func (c *cache) ListPackageCustomSchemas(ctx context.Context, schema, packageNam
 	if err != nil {
 		return fmt.Errorf("invalid custom schema query: %w", err)
 	}
-	return c.backend.SendMetas(ctx, mk, func(blob []byte) error {
-		st := &structpb.Struct{}
-		if err := st.UnmarshalJSON(blob); err != nil {
-			return fmt.Errorf("convert custom schema blob to struct: %w", err)
-		}
-		return sender(st)
-	})
+	return c.backend.SendMetas(ctx, mk, sender)
 }
 
 func (c *cache) CheckIntegrity(ctx context.Context, fbc fs.FS) error {

--- a/pkg/cache/json.go
+++ b/pkg/cache/json.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/operator-framework/operator-registry/pkg/api"
 	"github.com/operator-framework/operator-registry/pkg/registry"
@@ -156,7 +157,7 @@ func (q *jsonBackend) PutMeta(_ context.Context, key metaKey, blob []byte) error
 	return os.WriteFile(filepath.Join(dir, fmt.Sprintf("%x.json", h.Sum64())), blob, jsonCacheModeFile)
 }
 
-func (q *jsonBackend) SendMetas(ctx context.Context, key metaKey, sender func([]byte) error) error {
+func (q *jsonBackend) SendMetas(ctx context.Context, key metaKey, sender func(*structpb.Struct) error) error {
 	dir := q.metaDir(key)
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -178,7 +179,11 @@ func (q *jsonBackend) SendMetas(ctx context.Context, key metaKey, sender func([]
 		if err != nil {
 			return err
 		}
-		if err := sender(data); err != nil {
+		st := &structpb.Struct{}
+		if err := st.UnmarshalJSON(data); err != nil {
+			return fmt.Errorf("unmarshal meta JSON: %w", err)
+		}
+		if err := sender(st); err != nil {
 			return err
 		}
 	}

--- a/pkg/cache/pogrebv1.go
+++ b/pkg/cache/pogrebv1.go
@@ -17,6 +17,7 @@ import (
 	"github.com/akrylysov/pogreb"
 	pogrebfs "github.com/akrylysov/pogreb/fs"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/pkg/api"
@@ -172,8 +173,16 @@ func (q *pogrebV1Backend) metaDBKey(in metaKey) []byte {
 }
 
 func (q *pogrebV1Backend) PutMeta(_ context.Context, key metaKey, blob []byte) error {
-	if len(blob) > math.MaxUint32 {
-		return fmt.Errorf("meta blob too large: %d bytes exceeds uint32 max", len(blob))
+	st := &structpb.Struct{}
+	if err := st.UnmarshalJSON(blob); err != nil {
+		return fmt.Errorf("parse meta JSON: %w", err)
+	}
+	protoBytes, err := proto.MarshalOptions{Deterministic: true}.Marshal(st)
+	if err != nil {
+		return fmt.Errorf("marshal meta to proto: %w", err)
+	}
+	if len(protoBytes) > math.MaxUint32 {
+		return fmt.Errorf("meta blob too large: %d bytes exceeds uint32 max", len(protoBytes))
 	}
 	dbKey := q.metaDBKey(key)
 	existing, err := q.db.Get(dbKey)
@@ -181,11 +190,11 @@ func (q *pogrebV1Backend) PutMeta(_ context.Context, key metaKey, blob []byte) e
 		return fmt.Errorf("read existing meta blobs: %w", err)
 	}
 	header := make([]byte, 4)
-	binary.BigEndian.PutUint32(header, uint32(len(blob))) //#nosec G115 -- bounds checked above
-	return q.db.Put(dbKey, append(existing, append(header, blob...)...))
+	binary.BigEndian.PutUint32(header, uint32(len(protoBytes))) //#nosec G115 -- bounds checked above
+	return q.db.Put(dbKey, append(existing, append(header, protoBytes...)...))
 }
 
-func (q *pogrebV1Backend) SendMetas(ctx context.Context, key metaKey, sender func([]byte) error) error {
+func (q *pogrebV1Backend) SendMetas(ctx context.Context, key metaKey, sender func(*structpb.Struct) error) error {
 	data, err := q.db.Get(q.metaDBKey(key))
 	if err != nil {
 		return fmt.Errorf("read meta blobs: %w", err)
@@ -204,7 +213,11 @@ func (q *pogrebV1Backend) SendMetas(ctx context.Context, key metaKey, sender fun
 		if len(data) < int(blobLen) {
 			return fmt.Errorf("truncated meta blob in pogreb value")
 		}
-		if err := sender(data[:blobLen]); err != nil {
+		st := &structpb.Struct{}
+		if err := proto.Unmarshal(data[:blobLen], st); err != nil {
+			return fmt.Errorf("unmarshal meta proto: %w", err)
+		}
+		if err := sender(st); err != nil {
 			return err
 		}
 		data = data[blobLen:]


### PR DESCRIPTION
**Description of the change:**

Changes the `SendMetas` backend method to send `*structpb.Struct` instead of raw `[]byte`,
pushing deserialization responsibility into each backend implementation.

The pogreb backend now converts incoming JSON to protobuf binary wire format at write time
(`PutMeta`) and uses `proto.Unmarshal` at read time (`SendMetas`), which is significantly
cheaper than JSON parsing. The JSON backend continues to store JSON on disk and unmarshals
at read time.

This eliminates the JSON→structpb.Struct conversion that previously happened in the shared
`ListPackageCustomSchemas` method, since each backend now owns the full round-trip.

**Motivation for the change:**

Proto binary deserialization is 2-5x faster than JSON for structpb.Struct. Since the pogreb
cache is built infrequently but read on every query, shifting the JSON parse cost to build
time reduces per-request latency.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive