### PR TITLE
empty cred check failed to fall back

### DIFF
--- a/pkg/image/containersimageregistry/registry.go
+++ b/pkg/image/containersimageregistry/registry.go
@@ -160,14 +160,14 @@ func (r *Registry) Pull(ctx context.Context, ref orimage.Reference) error {
 		return err
 	}
 
-	sourceCtx := r.sourceCtx
-	authFile := getAuthFile(r.sourceCtx, namedRef.String())
+	sysCtx := *r.sourceCtx
+	authFile := getAuthFile(r.sourceCtx, namedRef.Name())
 	if authFile != "" {
-		sourceCtx.AuthFilePath = authFile
+		sysCtx.AuthFilePath = authFile
 	}
 
 	if _, err := copy.Image(ctx, policyContext, ociLayoutRef, dockerRef, &copy.Options{
-		SourceCtx:                             sourceCtx,
+		SourceCtx:                             &sysCtx,
 		DestinationCtx:                        r.cache.getSystemContext(),
 		OptimizeDestinationImageAlreadyExists: true,
 
@@ -290,7 +290,7 @@ func getAuthFile(sourceCtx *types.SystemContext, ref string) string {
 	// the auth config file we derived above, if it exists. If we find a matching credential
 	// in this file, we'll use this file.
 	if stat, statErr := os.Stat(authFile); statErr == nil && stat.Mode().IsRegular() {
-		if _, err := config.GetCredentials(&types.SystemContext{AuthFilePath: authFile}, ref); err == nil {
+		if cred, err := config.GetCredentials(&types.SystemContext{AuthFilePath: authFile}, ref); err == nil && cred != (types.DockerAuthConfig{}) {
 			return authFile
 		}
 	}

--- a/pkg/image/containersimageregistry/registry.go
+++ b/pkg/image/containersimageregistry/registry.go
@@ -290,7 +290,12 @@ func getAuthFile(sourceCtx *types.SystemContext, ref string) string {
 	// the auth config file we derived above, if it exists. If we find a matching credential
 	// in this file, we'll use this file.
 	if stat, statErr := os.Stat(authFile); statErr == nil && stat.Mode().IsRegular() {
-		if cred, err := config.GetCredentials(&types.SystemContext{AuthFilePath: authFile}, ref); err == nil && cred != (types.DockerAuthConfig{}) {
+		credCtx := &types.SystemContext{AuthFilePath: authFile}
+		if sourceCtx != nil {
+			credCtx.SystemRegistriesConfPath = sourceCtx.SystemRegistriesConfPath
+			credCtx.SystemRegistriesConfDirPath = sourceCtx.SystemRegistriesConfDirPath
+		}
+		if cred, err := config.GetCredentials(credCtx, ref); err == nil && cred != (types.DockerAuthConfig{}) {
 			return authFile
 		}
 	}

--- a/pkg/image/containersimageregistry/registry_test.go
+++ b/pkg/image/containersimageregistry/registry_test.go
@@ -1,0 +1,99 @@
+package containersimageregistry
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.podman.io/image/v5/types"
+)
+
+func writeAuthFile(t *testing.T, dir, filename string, auths map[string]interface{}) string {
+	t.Helper()
+	data, err := json.Marshal(map[string]interface{}{"auths": auths})
+	require.NoError(t, err)
+	path := filepath.Join(dir, filename)
+	require.NoError(t, os.WriteFile(path, data, 0600))
+	return path
+}
+
+func authEntry(user, pass string) map[string]string {
+	return map[string]string{
+		"auth": base64.StdEncoding.EncodeToString([]byte(user + ":" + pass)),
+	}
+}
+
+func TestGetAuthFile(t *testing.T) {
+	const ref = "registry.example.com/ns/image"
+
+	t.Run("REGISTRY_AUTH_FILE with matching creds", func(t *testing.T) {
+		dir := t.TempDir()
+		authPath := writeAuthFile(t, dir, "auth.json", map[string]interface{}{
+			"registry.example.com": authEntry("user", "pass"),
+		})
+		t.Setenv("REGISTRY_AUTH_FILE", authPath)
+		t.Setenv("DOCKER_CONFIG", t.TempDir()) // avoid default docker config
+
+		got := getAuthFile(nil, ref)
+		require.Equal(t, authPath, got)
+	})
+
+	t.Run("REGISTRY_AUTH_FILE without matching creds returns empty for fallback", func(t *testing.T) {
+		dir := t.TempDir()
+		authPath := writeAuthFile(t, dir, "auth.json", map[string]interface{}{
+			"other.registry.io": authEntry("user", "pass"),
+		})
+		t.Setenv("REGISTRY_AUTH_FILE", authPath)
+		t.Setenv("DOCKER_CONFIG", t.TempDir())
+
+		got := getAuthFile(nil, ref)
+		require.Empty(t, got)
+	})
+
+	t.Run("REGISTRY_AUTH_FILE empty file returns empty for fallback", func(t *testing.T) {
+		dir := t.TempDir()
+		authPath := writeAuthFile(t, dir, "auth.json", map[string]interface{}{})
+		t.Setenv("REGISTRY_AUTH_FILE", authPath)
+		t.Setenv("DOCKER_CONFIG", t.TempDir())
+
+		got := getAuthFile(nil, ref)
+		require.Empty(t, got)
+	})
+
+	t.Run("no env vars and no auth file returns empty", func(t *testing.T) {
+		t.Setenv("REGISTRY_AUTH_FILE", "")
+		t.Setenv("DOCKER_CONFIG", t.TempDir()) // point to empty dir
+
+		got := getAuthFile(nil, ref)
+		require.Empty(t, got)
+	})
+
+	t.Run("falls back to sourceCtx.AuthFilePath", func(t *testing.T) {
+		dir := t.TempDir()
+		authPath := writeAuthFile(t, dir, "auth.json", map[string]interface{}{
+			"registry.example.com": authEntry("user", "pass"),
+		})
+		t.Setenv("REGISTRY_AUTH_FILE", "")
+		t.Setenv("DOCKER_CONFIG", t.TempDir())
+
+		sysCtx := &types.SystemContext{AuthFilePath: authPath}
+		got := getAuthFile(sysCtx, ref)
+		require.Equal(t, authPath, got)
+	})
+
+	t.Run("REGISTRY_AUTH_FILE nonexistent file falls back to sourceCtx", func(t *testing.T) {
+		dir := t.TempDir()
+		authPath := writeAuthFile(t, dir, "auth.json", map[string]interface{}{
+			"registry.example.com": authEntry("user", "pass"),
+		})
+		t.Setenv("REGISTRY_AUTH_FILE", "/nonexistent/auth.json")
+		t.Setenv("DOCKER_CONFIG", t.TempDir())
+
+		sysCtx := &types.SystemContext{AuthFilePath: authPath}
+		got := getAuthFile(sysCtx, ref)
+		require.Equal(t, authPath, got)
+	})
+}

--- a/pkg/image/containersimageregistry/registry_test.go
+++ b/pkg/image/containersimageregistry/registry_test.go
@@ -11,7 +11,7 @@ import (
 	"go.podman.io/image/v5/types"
 )
 
-func writeAuthFile(t *testing.T, dir, filename string, auths map[string]interface{}) string {
+func writeAuthFile(t *testing.T, dir, filename string, auths map[string]interface{}) string { //nolint:unparam
 	t.Helper()
 	data, err := json.Marshal(map[string]interface{}{"auths": auths})
 	require.NoError(t, err)
@@ -20,9 +20,22 @@ func writeAuthFile(t *testing.T, dir, filename string, auths map[string]interfac
 	return path
 }
 
-func authEntry(user, pass string) map[string]string {
+func authEntry(user, pass string) map[string]string { //nolint:unparam
 	return map[string]string{
 		"auth": base64.StdEncoding.EncodeToString([]byte(user + ":" + pass)),
+	}
+}
+
+// hermeticCtx returns a SystemContext that isolates credential lookups
+// from the host's /etc/containers/registries.conf.
+func hermeticCtx(t *testing.T) *types.SystemContext {
+	t.Helper()
+	emptyDir := t.TempDir()
+	regConf := filepath.Join(emptyDir, "registries.conf")
+	require.NoError(t, os.WriteFile(regConf, []byte{}, 0600))
+	return &types.SystemContext{
+		SystemRegistriesConfPath:    regConf,
+		SystemRegistriesConfDirPath: emptyDir,
 	}
 }
 
@@ -35,9 +48,9 @@ func TestGetAuthFile(t *testing.T) {
 			"registry.example.com": authEntry("user", "pass"),
 		})
 		t.Setenv("REGISTRY_AUTH_FILE", authPath)
-		t.Setenv("DOCKER_CONFIG", t.TempDir()) // avoid default docker config
+		t.Setenv("DOCKER_CONFIG", t.TempDir())
 
-		got := getAuthFile(nil, ref)
+		got := getAuthFile(hermeticCtx(t), ref)
 		require.Equal(t, authPath, got)
 	})
 
@@ -49,7 +62,7 @@ func TestGetAuthFile(t *testing.T) {
 		t.Setenv("REGISTRY_AUTH_FILE", authPath)
 		t.Setenv("DOCKER_CONFIG", t.TempDir())
 
-		got := getAuthFile(nil, ref)
+		got := getAuthFile(hermeticCtx(t), ref)
 		require.Empty(t, got)
 	})
 
@@ -59,15 +72,15 @@ func TestGetAuthFile(t *testing.T) {
 		t.Setenv("REGISTRY_AUTH_FILE", authPath)
 		t.Setenv("DOCKER_CONFIG", t.TempDir())
 
-		got := getAuthFile(nil, ref)
+		got := getAuthFile(hermeticCtx(t), ref)
 		require.Empty(t, got)
 	})
 
 	t.Run("no env vars and no auth file returns empty", func(t *testing.T) {
 		t.Setenv("REGISTRY_AUTH_FILE", "")
-		t.Setenv("DOCKER_CONFIG", t.TempDir()) // point to empty dir
+		t.Setenv("DOCKER_CONFIG", t.TempDir())
 
-		got := getAuthFile(nil, ref)
+		got := getAuthFile(hermeticCtx(t), ref)
 		require.Empty(t, got)
 	})
 
@@ -79,7 +92,8 @@ func TestGetAuthFile(t *testing.T) {
 		t.Setenv("REGISTRY_AUTH_FILE", "")
 		t.Setenv("DOCKER_CONFIG", t.TempDir())
 
-		sysCtx := &types.SystemContext{AuthFilePath: authPath}
+		sysCtx := hermeticCtx(t)
+		sysCtx.AuthFilePath = authPath
 		got := getAuthFile(sysCtx, ref)
 		require.Equal(t, authPath, got)
 	})
@@ -92,7 +106,8 @@ func TestGetAuthFile(t *testing.T) {
 		t.Setenv("REGISTRY_AUTH_FILE", "/nonexistent/auth.json")
 		t.Setenv("DOCKER_CONFIG", t.TempDir())
 
-		sysCtx := &types.SystemContext{AuthFilePath: authPath}
+		sysCtx := hermeticCtx(t)
+		sysCtx.AuthFilePath = authPath
 		got := getAuthFile(sysCtx, ref)
 		require.Equal(t, authPath, got)
 	})


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md
Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
`getAuthFile` evaluates only if the credentials file can be parsed, which leads to concurrence between 'no creds found' and 'creds found' paths, so this PR introduces a new "empty creds" check which allows fallback to system default creds if empty.  Adds unit tests to prove the change. 

**Motivation for the change:**
Resolves #1826 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
