### PR TITLE
fix: update opm build toolchain and fulcio

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/operator-framework/operator-registry
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/akrylysov/pogreb v0.10.2

--- a/upstream-builder.Dockerfile
+++ b/upstream-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 RUN apk update && apk add build-base git mercurial bash linux-headers
 WORKDIR /build


### PR DESCRIPTION
## Summary
- update the module Go version from 1.26.3 to 1.26.5 so GitHub Actions and GoReleaser build opm with a patched Go stdlib
- pin upstream-builder.Dockerfile to golang:1.26.5-alpine for the direct upstream builder path
- bump github.com/sigstore/fulcio from v1.8.5 to v1.8.6 and keep the minimal go mod tidy result required by that bump

## Trivy evidence
Before, quay.io/operator-framework/opm:master at sha256:a9f84574354fb46686fd0958b0ab5f6f49d6b2736c5c99f10e05d6d92cca10ea failed Trivy 0.70.0 with HIGH findings in usr/bin/opm:
- github.com/sigstore/fulcio CVE-2026-49478, fixed in v1.8.6
- Go stdlib CVE-2026-27145, fixed in Go 1.26.4 / 1.25.11
- Go stdlib CVE-2026-39822, fixed in Go 1.26.5 / 1.25.12 / 1.27.0-rc.2
- Go stdlib CVE-2026-42504, fixed in Go 1.26.4 / 1.25.11

After, I built a local linux/arm64 release-shaped image using Go 1.26.5, distroless static, /bin/opm, /bin/grpc_health_probe, nsswitch.conf, user 1001, and the opm entrypoint. The image ID was sha256:7a7598e588808493efb14e9b9398939e6d836509983b9cca4cfcc1197dc10a37.

Trivy command run locally, adapted only for the OrbStack Docker socket path:
```sh
docker run --rm -v /Users/russell/.orbstack/run/docker.sock:/var/run/docker.sock aquasec/trivy:0.70.0 image --ignore-unfixed --severity CRITICAL,HIGH --exit-code 1 opm-trivy-test:go1.26.5-fulcio1.8.6
```

Result:
```text
Report Summary

Target                                                Type      Vulnerabilities
opm-trivy-test:go1.26.5-fulcio1.8.6 (debian 13.6)  debian    0
usr/bin/grpc_health_probe                             gobinary  0
usr/bin/opm                                           gobinary  0
```

## Verification
- GOCACHE=/tmp/opreg-go-build-cache GOMODCACHE=/tmp/opreg-go-mod-cache GOTOOLCHAIN=auto go mod tidy
- GOCACHE=/tmp/opreg-go-build-cache GOMODCACHE=/tmp/opreg-go-mod-cache GOTOOLCHAIN=auto go mod verify
- GOCACHE=/tmp/opreg-go-build-cache GOMODCACHE=/tmp/opreg-go-mod-cache GOTOOLCHAIN=auto make bin/opm
- GOMODCACHE=/tmp/opreg-go-mod-cache GOTOOLCHAIN=auto go version -m bin/opm
  - reported go1.26.5
  - included github.com/sigstore/fulcio v1.8.6
- GOCACHE=/tmp/opreg-go-build-cache GOMODCACHE=/tmp/opreg-go-mod-cache GOTOOLCHAIN=auto make unit
  - first sandboxed run failed only because localhost binds were denied
  - rerun with local socket permissions passed
- docker buildx build --platform linux/arm64 -f /private/tmp/opm-release-trivy.Dockerfile -t opm-trivy-test:go1.26.5-fulcio1.8.6 --load .
- Trivy command above

No vulnerability suppressions, ignores, or scan weakening were added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s Go version to 1.26.5.
  * Updated the build environment to use Go 1.26.5 for consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->